### PR TITLE
SJRA-442 fix nav bar to allow link anchor and button

### DIFF
--- a/frontend/components/base/buttons/ActionButton.tsx
+++ b/frontend/components/base/buttons/ActionButton.tsx
@@ -27,7 +27,7 @@ function ActionButton({
   variant,
   ...btnProps
 }: ActionButtonProps) {
-  const style = actionButtonVariants({ size, variant });
+  const style = actionButtonVariants({ size, variant, disabled: btnProps.disabled });
 
   return (
     <div className={cn('flex items-center', className)}>

--- a/frontend/components/base/buttons/button.variants.ts
+++ b/frontend/components/base/buttons/button.variants.ts
@@ -7,22 +7,27 @@ export const baseButtonVariants = tv({
   variants: {
     variant: {
       default: {
-        base: 'bg-primary text-primary-foreground shadow-sm enabled:hover:bg-primary/90',
+        base: 'bg-primary text-primary-foreground shadow-sm hover:bg-primary/90',
       },
       destructive: {
-        base: 'bg-destructive text-destructive-foreground shadow-xs enabled:hover:bg-destructive/90',
+        base: 'bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90',
       },
       outline: {
-        base: 'border border-input bg-background text-foreground shadow-xs enabled:hover:bg-accent enabled:hover:text-accent-foreground',
+        base: 'border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground',
       },
       secondary: {
-        base: 'bg-secondary text-secondary-foreground shadow-xs enabled:hover:bg-secondary/80',
+        base: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
       },
       ghost: {
-        base: 'enabled:hover:bg-accent enabled:hover:text-accent-foreground',
+        base: 'hover:bg-accent hover:text-accent-foreground',
       },
       link: {
-        base: 'text-primary underline-offset-4 enabled:hover:underline',
+        base: 'text-primary underline-offset-4 hover:underline',
+      },
+    },
+    disabled: {
+      true: {
+        base: 'disabled:pointer-events-none',
       },
     },
     size: {
@@ -118,8 +123,8 @@ export const actionButtonVariants = tv({
     },
     variant: {
       outline: {
-        base: 'enabled:hover:z-2',
-        actionsButton: '-ml-px enabled:hover:z-2',
+        base: 'hover:z-2',
+        actionsButton: '-ml-px hover:z-2',
       },
     },
   },

--- a/frontend/components/base/ui/alert-dialog.tsx
+++ b/frontend/components/base/ui/alert-dialog.tsx
@@ -64,7 +64,7 @@ export type AlertDialogActionProps = React.ComponentPropsWithoutRef<typeof Alert
   VariantProps<typeof buttonVariants>;
 
 function AlertDialogAction({ className, variant = 'default', size, ...props }: AlertDialogActionProps) {
-  const style = buttonVariants({ variant, size });
+  const style = buttonVariants({ variant, size, disabled: props.disabled });
   return <AlertDialogPrimitive.Action className={style.base({ className })} {...props} />;
 }
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
@@ -73,7 +73,7 @@ export type AlertDialogCancelProps = React.ComponentPropsWithoutRef<typeof Alert
   VariantProps<typeof buttonVariants>;
 
 function AlertDialogCancel({ className, variant = 'outline', size, ...props }: AlertDialogCancelProps) {
-  const style = buttonVariants({ variant, size });
+  const style = buttonVariants({ variant, size, disabled: props.disabled });
   return <AlertDialogPrimitive.Cancel className={cn(style.base(), 'mt-2 sm:mt-0', className)} {...props} />;
 }
 AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;

--- a/frontend/components/base/ui/button.tsx
+++ b/frontend/components/base/ui/button.tsx
@@ -21,7 +21,7 @@ const Button = function ({
   ...props
 }: ButtonProps) {
   const Comp = asChild ? Slot : 'button';
-  const style = buttonVariants({ variant, size, iconOnly });
+  const style = buttonVariants({ variant, size, iconOnly, disabled: disabled });
 
   return (
     <Comp className={style.base({ className })} disabled={disabled || loading} {...props}>

--- a/frontend/components/feature/navbar/main-navbar-button.tsx
+++ b/frontend/components/feature/navbar/main-navbar-button.tsx
@@ -1,29 +1,77 @@
 import * as React from 'react';
-import { Button, ButtonProps } from '@/components/base/ui/button';
+import { buttonVariants } from '@/components/base/ui/button';
 import { cn } from '@/components/lib/utils';
+import { VariantProps } from 'tailwind-variants';
+import { Link } from 'react-router';
 
-export interface MainNavbarButtonProps extends ButtonProps {
+type MainNavbarAnchorProps = {
+  as: 'a';
+  href: string;
+  to?: never;
+};
+
+type MainNavbarButtonProps = {
+  as: 'button';
+  href?: never;
+  to?: never;
+};
+
+type MainNavbarRouterLinkProps = {
+  as: typeof Link;
+  to: string;
+  href?: never;
+};
+
+export type MainNavbarLinkProps = VariantProps<typeof buttonVariants> & {
+  className?: string;
   title?: string;
   icon?: React.ReactNode;
   rightIcon?: React.ReactNode;
   active?: boolean;
-}
+  onClick?: () => void;
+} & (MainNavbarAnchorProps | MainNavbarButtonProps | MainNavbarRouterLinkProps);
 
-function MainNavbarButton({ icon, rightIcon, title, iconOnly, active, className, ...props }: MainNavbarButtonProps) {
+function MainNavbarLink({
+  icon,
+  rightIcon,
+  title,
+  iconOnly,
+  active,
+  className,
+  variant = 'ghost',
+  size,
+  disabled,
+  as,
+  ...rest
+}: MainNavbarLinkProps) {
+  const styles = buttonVariants({ variant, iconOnly, size, disabled });
+
+  let Component: React.ElementType;
+  if (as === Link) {
+    Component = Link;
+  } else if (as === 'button') {
+    Component = 'button';
+  } else {
+    Component = 'a';
+  }
+
+  const otherProps =
+    as === Link ? { to: rest.to } : as === 'button' ? { type: 'button', onClick: rest.onClick } : { href: rest.href };
+
   return (
-    <Button
-      variant="ghost"
+    <Component
       className={cn(
-        'text-muted-foreground text-base md:text-sm',
+        styles.base(),
+        'enabled text-muted-foreground text-base md:text-sm',
         {
-          'h-10 py-2.5 px-2 md:px-3': !iconOnly,
-          '[&_svg]:size-5': iconOnly,
+          'h-10 md:h-7 py-2.5 md:py-1 px-2': !iconOnly,
+          'md:size-7 [&_svg]:size-5': iconOnly,
           'text-primary': active,
         },
         className,
       )}
-      iconOnly={iconOnly}
-      {...props}
+      {...otherProps}
+      {...rest}
     >
       <span
         className={cn('flex flex-1 gap-2 items-center', {
@@ -34,8 +82,8 @@ function MainNavbarButton({ icon, rightIcon, title, iconOnly, active, className,
         {icon} {iconOnly ? '' : title}
       </span>
       {rightIcon && <span className="[&_svg]:size-5">{rightIcon}</span>}
-    </Button>
+    </Component>
   );
 }
 
-export default MainNavbarButton;
+export default MainNavbarLink;

--- a/frontend/components/feature/navbar/main-navbar-item.tsx
+++ b/frontend/components/feature/navbar/main-navbar-item.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import useIsMobile from '@/components/hooks/use-is-mobile';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/base/ui/collapsible';
 import { ChevronRight } from 'lucide-react';
+import { Link } from 'react-router';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,16 +11,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/base/ui/dropdown-menu';
-import MainNavbarButton, { MainNavbarButtonProps } from './main-navbar-button';
-import { ButtonProps } from '@/components/base/ui/button';
+import MainNavbarLink, { MainNavbarLinkProps } from './main-navbar-button';
 import { cn } from '@/components/lib/utils';
 
-export interface MainNavbarItemProps extends Omit<ButtonProps, 'children'> {
+export interface MainNavbarItemProps extends Omit<MainNavbarLinkProps, 'children'> {
   title: string;
   icon: React.ReactNode;
   active?: boolean;
-  subItems?: ((MainNavbarButtonProps & { separator?: never }) | { separator: true })[];
+  subItems?: ((MainNavbarLinkProps & { separator?: never }) | { separator: true })[];
   responsive?: boolean;
+  onClick?: () => void;
 }
 
 function MainNavbarItem({ responsive = true, icon, title, subItems, ...props }: MainNavbarItemProps) {
@@ -30,12 +31,12 @@ function MainNavbarItem({ responsive = true, icon, title, subItems, ...props }: 
     return subItems?.length ? (
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <CollapsibleTrigger asChild>
-          <MainNavbarButton
+          <MainNavbarLink
             title={title}
             icon={icon}
             data-state={isOpen ? 'open' : 'closed'}
             rightIcon={<ChevronRight className="transition-transform duration-200 group-data-[state=open]:rotate-90" />}
-            {...props}
+            {...(props as any)}
             className={cn('group', props.className)}
           />
         </CollapsibleTrigger>
@@ -43,16 +44,16 @@ function MainNavbarItem({ responsive = true, icon, title, subItems, ...props }: 
           {subItems
             .filter(item => !item.separator)
             .map(item => (
-              <MainNavbarButton key={item.title} {...item} />
+              <MainNavbarLink key={item.title} {...item} />
             ))}
         </CollapsibleContent>
       </Collapsible>
     ) : (
-      <MainNavbarButton title={title} icon={icon} {...props} />
+      <MainNavbarLink title={title} icon={icon} {...(props as any)} />
     );
   }
 
-  const navbarButton = <MainNavbarButton icon={icon} title={title} {...props} />;
+  const navbarButton = <MainNavbarLink icon={icon} title={title} {...(props as any)} />;
 
   if (subItems?.length) {
     return (
@@ -61,17 +62,7 @@ function MainNavbarItem({ responsive = true, icon, title, subItems, ...props }: 
           {navbarButton}
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuGroup>
-            {subItems.map(item =>
-              item.separator ? (
-                <DropdownMenuSeparator key="separator" />
-              ) : (
-                <DropdownMenuItem key={item.title}>
-                  {item.icon} {item.title}
-                </DropdownMenuItem>
-              ),
-            )}
-          </DropdownMenuGroup>
+          <DropdownMenuGroup>{subItems.map(renderDropdownItem)}</DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenu>
     );
@@ -79,5 +70,43 @@ function MainNavbarItem({ responsive = true, icon, title, subItems, ...props }: 
 
   return navbarButton;
 }
+
+const renderDropdownItem = (item: NonNullable<MainNavbarItemProps['subItems']>[0]) => {
+  if (item.separator) {
+    return <DropdownMenuSeparator key="separator" />;
+  }
+
+  const menuItem = (
+    <DropdownMenuItem key={item.title}>
+      {item.icon} {item.title}
+    </DropdownMenuItem>
+  );
+
+  if (item.as === 'a') {
+    return (
+      <a key={item.title} href={item.href} target="_blank" rel="noopener noreferrer">
+        {menuItem}
+      </a>
+    );
+  }
+
+  if (item.as === 'button') {
+    return (
+      <DropdownMenuItem key={item.title} {...item}>
+        {item.icon} {item.title}
+      </DropdownMenuItem>
+    );
+  }
+
+  if (item.as === Link) {
+    return (
+      <Link key={item.title} to={item.to}>
+        {menuItem}
+      </Link>
+    );
+  }
+
+  return menuItem;
+};
 
 export default MainNavbarItem;

--- a/frontend/components/feature/navbar/main-navbar-user-avatar.tsx
+++ b/frontend/components/feature/navbar/main-navbar-user-avatar.tsx
@@ -18,23 +18,24 @@ interface NavbarUserAvatarProps {
     name: string;
     email: string;
   };
+  avatarClassName?: string;
   onLogoutClick: () => void;
 }
 
-function NavbarUserAvatar({ userDetails: { name, email }, onLogoutClick }: NavbarUserAvatarProps) {
+function NavbarUserAvatar({ userDetails: { name, email }, onLogoutClick, avatarClassName }: NavbarUserAvatarProps) {
   const { t } = useI18n();
 
   return (
     <>
       <div className="block md:hidden">
-        <AvatarUserDetails name={name} email={email} />
-        <MainNavbarItem title="Profile" icon={<UserIcon />} className="w-full" />
-        <MainNavbarItem title="Sign out" icon={<LogOutIcon />} className="w-full" onClick={onLogoutClick} />
+        <AvatarUserDetails name={name} email={email} avatarClassName={avatarClassName} />
+        <MainNavbarItem title="Profile" as="button" icon={<UserIcon />} className="w-full" onClick={() => {}} />
+        <MainNavbarItem title="Sign out" as="button" icon={<LogOutIcon />} className="w-full" onClick={onLogoutClick} />
       </div>
       <div className="hidden md:flex">
         <DropdownMenu>
           <DropdownMenuTrigger className="outline-none">
-            <UserAvatar name={name} />
+            <UserAvatar name={name} className={avatarClassName} />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-56">
             <div className="py-1.5 px-2">

--- a/frontend/components/feature/navbar/main-navbar.tsx
+++ b/frontend/components/feature/navbar/main-navbar.tsx
@@ -14,7 +14,7 @@ import { useSidebar } from '@/components/base/ui/sidebar';
 
 const navbarVariant = tv({
   slots: {
-    base: 'flex items-center py-3 border-b bg-background shadow-xs w-full',
+    base: 'flex items-center h-[44px] px-6 hidden md:flex py-2 border-b bg-background shadow-xs w-full',
   },
 });
 
@@ -37,6 +37,7 @@ function MainNavbar({ placement, logo, links, actions, userDetails, onLogoutClic
         icon={<CircleAlert />}
         variant="destructive"
         className="text-destructive-foreground"
+        as="button"
         onClick={() => setBetaSheetOpen(true)}
       />
     ) : null;
@@ -85,9 +86,9 @@ function MainNavbar({ placement, logo, links, actions, userDetails, onLogoutClic
             </div>
           )}
           {/* Desktop NavBar */}
-          <div className={navbarStyles.base({ className: 'h-16 px-6 hidden md:flex' })}>
+          <div className={navbarStyles.base()}>
             <div
-              className="flex mr-6 h-9 text-primary"
+              className="flex mr-6 h-7 text-primary [&_svg]:h-full [&_img]:h-full"
               onClick={e => {
                 if (e.metaKey && e.altKey) {
                   setBetaSuperMode(!betaSuperMode);
@@ -102,13 +103,13 @@ function MainNavbar({ placement, logo, links, actions, userDetails, onLogoutClic
               ))}
               {betaSuperModeItem}
             </div>
-            <div className="flex gap-4">
+            <div className="flex items-center gap-4">
               {actions.map(action => (
                 <MainNavbarItem iconOnly key={action.title} {...action} />
               ))}
-              <MainNavbarUserAvatar userDetails={userDetails} onLogoutClick={onLogoutClick} />
-              <MainNavbarLangSwitcher />
-              <ThemeToggle className="text-muted-foreground [&_svg]:size-5" />
+              <MainNavbarUserAvatar avatarClassName="size-7" userDetails={userDetails} onLogoutClick={onLogoutClick} />
+              <MainNavbarLangSwitcher className="size-7" />
+              <ThemeToggle className="text-muted-foreground size-7 [&_svg]:size-5" />
             </div>
           </div>
         </>
@@ -136,6 +137,7 @@ function MobileNavbar({
         iconOnly
         icon={isOpen ? <XIcon /> : <MenuIcon />}
         onClick={onBurgerClick}
+        as="button"
         responsive={false}
       />
       <div className="flex flex-1 h-8 justify-center text-primary">{logo}</div>

--- a/frontend/components/stories/feature/navbar.stories.tsx
+++ b/frontend/components/stories/feature/navbar.stories.tsx
@@ -44,40 +44,55 @@ export const Default: Story = {
       {
         title: 'Dashboard',
         icon: <LayoutDashboardIcon />,
+        as: 'button',
       },
       {
         title: 'Studies',
         icon: <BookOpenTextIcon />,
+        as: 'a',
+        href: 'https://google.com',
       },
       {
         title: 'Data Exploration',
         icon: <TelescopeIcon />,
+        as: 'a',
+        href: 'https://google.com',
       },
       {
         title: 'Variants',
         icon: <AudioWaveformIcon />,
+        as: 'a',
+        href: 'https://google.com',
       },
       {
         title: 'Analysis',
         icon: <BlendIcon />,
+        as: 'a',
+        href: 'https://google.com',
       },
     ],
     actions: [
       {
         title: 'Community',
         icon: <UsersIcon />,
+        as: 'button',
       },
       {
         title: 'Resources',
         icon: <LightbulbIcon />,
+        as: 'button',
         subItems: [
           {
             title: 'Website',
             icon: <ExternalLink />,
+            as: 'a',
+            href: 'https://google.com',
           },
           {
             title: 'Documentation',
             icon: <ExternalLink />,
+            as: 'a',
+            href: 'https://google.com',
           },
           {
             separator: true,
@@ -85,6 +100,7 @@ export const Default: Story = {
           {
             title: 'Contact',
             icon: <MailIcon />,
+            as: 'button',
           },
         ],
       },

--- a/frontend/portals/radiant/app/layout/protected-layout.tsx
+++ b/frontend/portals/radiant/app/layout/protected-layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useLoaderData, useLocation, useNavigate } from 'react-router';
+import { Link, Outlet, useLoaderData, useLocation, useNavigate } from 'react-router';
 import { authenticateRequest, getSessionUser, requireAuth } from '~/utils/auth.server';
 import type { Route } from '../+types/root';
 import type { IAuthUser } from '~/utils/auth.types';
@@ -59,30 +59,37 @@ const _ProtectedLayout = () => {
             {
               title: t('mainNavbar.links.dashboard'),
               icon: <LayoutDashboardIcon />,
+              as: 'button',
             },
             {
               title: t('mainNavbar.links.cases'),
               icon: <FolderIcon />,
-              onClick: () => navigate('/case-exploration'),
-              active: pathname === '/case-exploration'
+              to: '/case-exploration',
+              as: Link,
+              active: pathname === '/case-exploration',
             },
           ]}
           actions={[
             {
               title: t('mainNavbar.actions.community'),
               icon: <UsersIcon />,
+              as: 'button',
             },
             {
               title: t('mainNavbar.actions.resources'),
               icon: <LightbulbIcon />,
+              as: 'button',
               subItems: [
                 {
                   title: t('mainNavbar.actions.website'),
                   icon: <ExternalLink />,
+                  as: 'a',
+                  href: 'https://www.radiant-genomics.com',
                 },
                 {
                   title: t('mainNavbar.actions.documentation'),
                   icon: <ExternalLink />,
+                  as: 'button',
                 },
                 {
                   separator: true,
@@ -90,6 +97,7 @@ const _ProtectedLayout = () => {
                 {
                   title: t('mainNavbar.actions.contact'),
                   icon: <MailIcon />,
+                  as: 'button',
                 },
               ],
             },


### PR DESCRIPTION
We can now have different type of "link" in the `navbar` component, for example:

```typescript
{
    links: [
      {
        title: 'Dashboard',
        icon: <LayoutDashboardIcon />,
        as: 'button',
        onClick: () => navigate("/")
      },
      {
        title: 'Studies',
        icon: <BookOpenTextIcon />,
        as: 'a',
        href: 'https://google.com',
      },
      {
        title: 'Data Exploration',
        icon: <TelescopeIcon />,
        as: Link,
        to: '/case-exploration',
      },
    ],
}
```

Also updated the navbar sizing for desktop:

<img width="980" height="61" alt="Screenshot 2025-07-16 at 9 50 59 PM" src="https://github.com/user-attachments/assets/fe73afe5-8459-4384-8d59-220e083c82a7" />
