### PR TITLE
:sparkles: feat: SJRA-468 Always lower case facets value before add a Maj

### DIFF
--- a/frontend/components/feature/query-builder/query-pill/query-pill-values.tsx
+++ b/frontend/components/feature/query-builder/query-pill/query-pill-values.tsx
@@ -34,7 +34,7 @@ function QueryPillValues({ valueFilter, ...props }: QueryPillValuesProps) {
               {
                 t(
                   `common.filters.labels.${valueFilter.content.field}_value.${val}`,
-                  { defaultValue: replaceUnderscore(String(val)).replace(/^\w/, c => c.toUpperCase()) }
+                  { defaultValue: replaceUnderscore(String(val)).toLowerCase().replace(/^\w/, c => c.toUpperCase()) }
                 )
               }
             </span>

--- a/frontend/components/feature/query-filters/multiselect-filter.tsx
+++ b/frontend/components/feature/query-filters/multiselect-filter.tsx
@@ -74,7 +74,7 @@ export function MultiSelectFilter({ field, maxVisibleItems = 5, searchVisible = 
     });
 
     aggregationData?.forEach(item => {
-      item.label = item.key ? replaceUnderscore(item.key).replace(/^\w/, c => c.toUpperCase()) : item.key
+      item.label = item.key ? replaceUnderscore(item.key).toLowerCase().replace(/^\w/, c => c.toUpperCase()) : item.key
     });
 
     setItems(aggregationData || []);

--- a/frontend/docs/query-builder.md
+++ b/frontend/docs/query-builder.md
@@ -10,7 +10,7 @@ If a translation doesn't exist, a simple default value is displayed. This defaul
 // query-pill-values.tsx
 t(
   `common.filters.labels.${valueFilter.content.field}_value.${val}`,
-  { defaultValue: replaceUnderscore(String(val)).replace(/^\w/, c => c.toUpperCase()) }
+  { defaultValue: replaceUnderscore(String(val)).toLowerCase().replace(/^\w/, c => c.toUpperCase()) }
 )
 ```
 


### PR DESCRIPTION
Example for Exomiser:

Before : 
<img width="273" height="148" alt="Screenshot 2025-07-17 at 2 49 56 PM" src="https://github.com/user-attachments/assets/2a3a1809-ae07-47bc-bff4-f8e6da703820" />

After : 
<img width="271" height="149" alt="Screenshot 2025-07-17 at 2 50 34 PM" src="https://github.com/user-attachments/assets/f7b3bda5-9d08-4a5a-b081-060e61562741" />

Note : for exomiser classifications we will also lower case values in another ticket