### PR TITLE
:bug: fix: SJRA-579 Apply role-based middleware to private routes and upgrade dependencies

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"gorm.io/gorm"
 	"log"
 	"os"
 	"strings"
@@ -20,19 +21,121 @@ import (
 	"github.com/tbaehler/gin-keycloak/pkg/ginkeycloak"
 )
 
-var corsAllowedOrigins = strings.Split(os.Getenv("CORS_ALLOWED_ORIGINS"), ",")
-
-var keycloakConfig = ginkeycloak.BuilderConfig{
-	Service: os.Getenv("KEYCLOAK_CLIENT"),
-	Url:     os.Getenv("KEYCLOAK_HOST"),
-	Realm:   os.Getenv("KEYCLOAK_REALM"),
-}
-
 func init() {
 	err := flag.Set("logtostderr", "true")
 	if err != nil {
 		log.Fatalf("Failed to set logtostderr flag: %v", err)
 	} // Log to standard error
+}
+
+func setupRouter(dbStarrocks *gorm.DB, dbPostgres *gorm.DB) *gin.Engine {
+
+	// Create repository
+	repoStarrocks := repository.NewStarrocksRepository(dbStarrocks)
+	repoSeqExp := repository.NewSequencingRepository(dbStarrocks)
+	repoVariants := repository.NewVariantsRepository(dbStarrocks)
+	repoExomiser := repository.NewExomiserRepository(dbStarrocks)
+	repoOccurrences := repository.NewOccurrencesRepository(dbStarrocks)
+	repoTerms := repository.NewTermsRepository(dbStarrocks)
+	repoCases := repository.NewCasesRepository(dbStarrocks)
+	repoAssays := repository.NewAssaysRepository(dbStarrocks)
+	repoGenePanels := repository.NewGenePanelsRepository(dbStarrocks)
+	pubmedClient := client.NewPubmedClient()
+	repoPostgres := repository.NewPostgresRepository(dbPostgres, pubmedClient)
+	repoClinvarRCV := repository.NewClinvarRCVRepository(dbStarrocks)
+
+	r := gin.Default()
+	r.Use(gzip.Gzip(gzip.DefaultCompression))
+
+	r.Use(ginglog.Logger(3 * time.Second))
+	r.Use(ginkeycloak.RequestLogger([]string{"uid"}, "data"))
+
+	var corsAllowedOrigins = strings.Split(os.Getenv("CORS_ALLOWED_ORIGINS"), ",")
+
+	var keycloakConfig = ginkeycloak.BuilderConfig{
+		Service: os.Getenv("KEYCLOAK_CLIENT"),
+		Url:     os.Getenv("KEYCLOAK_HOST"),
+		Realm:   os.Getenv("KEYCLOAK_REALM"),
+	}
+
+	r.Use(cors.New(cors.Config{
+		AllowOrigins:     corsAllowedOrigins,
+		AllowMethods:     []string{"GET", "POST", "OPTIONS"},
+		AllowHeaders:     []string{"Accept", "Authorization", "Content-Type"},
+		AllowCredentials: true, // Enable cookies/auth
+	}))
+
+	role := os.Getenv("KEYCLOAK_CLIENT_ROLE")
+	// check if role belongs of either ResourceAccess or RealmAccess
+	roleAccessMiddleware := ginkeycloak.NewAccessBuilder(keycloakConfig).
+		RestrictButForRole(role).
+		RestrictButForRealm(role).
+		Build()
+
+	// Initialize public routes explicitly
+	r.GET("/status", server.StatusHandler(repoStarrocks, repoPostgres))
+
+	// Private routes, alphabetically ordered
+	// Use privateRoutes instead of `r` for all private routes to automatically apply the role access middleware
+	privateRoutes := r.Group("/")
+	privateRoutes.Use(roleAccessMiddleware)
+
+	assaysGroup := privateRoutes.Group("/assays")
+	assaysGroup.GET("/:seq_id", server.GetAssayBySeqIdHandler(repoAssays))
+
+	casesGroup := privateRoutes.Group("/cases")
+	casesGroup.POST("/search", server.SearchCasesHandler(repoCases))
+	casesGroup.GET("/autocomplete", server.CasesAutocompleteHandler(repoCases))
+	casesGroup.POST("/filters", server.CasesFiltersHandler(repoCases))
+	casesGroup.GET("/:case_id", server.CaseEntityHandler(repoCases))
+
+	hpoGroup := privateRoutes.Group("/hpo")
+	hpoGroup.GET("/autocomplete", server.GetHPOTermAutoComplete(repoTerms))
+
+	interpretationsGroup := privateRoutes.Group("/interpretations")
+	interpretationsGroup.GET("/pubmed/:citation_id", server.GetPubmedCitation(pubmedClient))
+	interpretationsGroup.GET("/germline", server.SearchInterpretationGermline(repoPostgres.Interpretations))
+	interpretationsGroup.GET("/somatic", server.SearchInterpretationSomatic(repoPostgres.Interpretations))
+
+	interpretationsGermlineGroup := interpretationsGroup.Group("/germline/:sequencing_id/:locus_id/:transcript_id")
+	interpretationsGermlineGroup.GET("", server.GetInterpretationGermline(repoPostgres.Interpretations))
+	interpretationsGermlineGroup.POST("", server.PostInterpretationGermline(repoPostgres.Interpretations))
+	interpretationsSomaticGroup := interpretationsGroup.Group("/somatic/:sequencing_id/:locus_id/:transcript_id")
+	interpretationsSomaticGroup.GET("", server.GetInterpretationSomatic(repoPostgres.Interpretations))
+	interpretationsSomaticGroup.POST("", server.PostInterpretationSomatic(repoPostgres.Interpretations))
+
+	mondoGroup := privateRoutes.Group("/mondo")
+	mondoGroup.GET("/autocomplete", server.GetMondoTermAutoComplete(repoTerms))
+
+	occurrencesGroup := privateRoutes.Group("/occurrences")
+	occurrencesGermlineGroup := occurrencesGroup.Group("/germline")
+	occurrencesGermlineGroup.POST("/:seq_id/count", server.OccurrencesGermlineCountHandler(repoOccurrences))
+	occurrencesGermlineGroup.POST("/:seq_id/list", server.OccurrencesGermlineListHandler(repoOccurrences))
+	occurrencesGermlineGroup.POST("/:seq_id/aggregate", server.OccurrencesGermlineAggregateHandler(repoOccurrences))
+	occurrencesGermlineGroup.POST("/:seq_id/statistics", server.OccurrencesGermlineStatisticsHandler(repoOccurrences))
+	occurrencesGermlineGroup.GET("/:seq_id/:locus_id/expanded", server.GetExpandedGermlineOccurrence(repoOccurrences))
+
+	sequencingGroup := privateRoutes.Group("/sequencing")
+	sequencingGroup.GET("/:seq_id", server.GetSequencing(repoSeqExp))
+
+	usersGroup := privateRoutes.Group("/users")
+	usersGroup.GET("/sets/:user_set_id", server.GetUserSet(repoPostgres.UserSets))
+
+	variantsGroup := privateRoutes.Group("/variants")
+	variantsGermlineGroup := variantsGroup.Group("/germline")
+	variantsGermlineGroup.GET("/:locus_id/header", server.GetGermlineVariantHeader(repoVariants))
+	variantsGermlineGroup.GET("/:locus_id/overview", server.GetGermlineVariantOverview(repoVariants, repoExomiser))
+	variantsGermlineGroup.GET("/:locus_id/consequences", server.GetGermlineVariantConsequences(repoVariants))
+	variantsGermlineGroup.POST("/:locus_id/cases/interpreted", server.GetGermlineVariantInterpretedCases(repoVariants))
+	variantsGermlineGroup.POST("/:locus_id/cases/uninterpreted", server.GetGermlineVariantUninterpretedCases(repoVariants))
+	variantsGermlineGroup.GET("/:locus_id/cases/interpreted/:seq_id/:transcript_id", server.GetExpandedGermlineVariantInterpretedCase(repoVariants))
+	variantsGermlineGroup.GET("/:locus_id/cases/count", server.GetGermlineVariantCasesCount(repoVariants))
+	variantsGermlineGroup.GET("/cases/filters", server.GetGermlineVariantCasesFilters(repoVariants))
+	variantsGermlineGroup.GET("/:locus_id/conditions/:panel_type", server.GetGermlineVariantConditions(repoGenePanels))
+	variantsGermlineGroup.GET("/:locus_id/conditions/clinvar", server.GetGermlineVariantConditionsClinvar(repoClinvarRCV))
+
+	r.Use(gin.Recovery())
+	return r
 }
 
 // @version 1.0
@@ -60,101 +163,9 @@ func main() {
 		log.Fatal("Failed to initialize postgres database: ", err)
 	}
 
-	// Create repository
-	repoStarrocks := repository.NewStarrocksRepository(dbStarrocks)
-	repoSeqExp := repository.NewSequencingRepository(dbStarrocks)
-	repoVariants := repository.NewVariantsRepository(dbStarrocks)
-	repoExomiser := repository.NewExomiserRepository(dbStarrocks)
-	repoOccurrences := repository.NewOccurrencesRepository(dbStarrocks)
-	repoTerms := repository.NewTermsRepository(dbStarrocks)
-	repoCases := repository.NewCasesRepository(dbStarrocks)
-	repoAssays := repository.NewAssaysRepository(dbStarrocks)
-	repoGenePanels := repository.NewGenePanelsRepository(dbStarrocks)
-	pubmedClient := client.NewPubmedClient()
-	repoPostgres := repository.NewPostgresRepository(dbPostgres, pubmedClient)
-	repoClinvarRCV := repository.NewClinvarRCVRepository(dbStarrocks)
-
-	r := gin.Default()
-	r.Use(gzip.Gzip(gzip.DefaultCompression))
-
-	r.Use(ginglog.Logger(3 * time.Second))
-	r.Use(ginkeycloak.RequestLogger([]string{"uid"}, "data"))
-
-	r.Use(cors.New(cors.Config{
-		AllowOrigins:     corsAllowedOrigins,
-		AllowMethods:     []string{"GET", "POST", "OPTIONS"},
-		AllowHeaders:     []string{"Accept", "Authorization", "Content-Type"},
-		AllowCredentials: true, // Enable cookies/auth
-	}))
-
-	occurrencesGroup := r.Group("/occurrences")
-	occurrencesGermlineGroup := occurrencesGroup.Group("/germline")
-
-	role := os.Getenv("KEYCLOAK_CLIENT_ROLE")
-	// check if role belongs of either ResourceAccess or RealmAccess
-	roleAccessMiddleware := ginkeycloak.NewAccessBuilder(keycloakConfig).
-		RestrictButForRole(role).
-		RestrictButForRealm(role).
-		Build()
-
-	occurrencesGroup.Use(roleAccessMiddleware)
-
-	r.GET("/status", server.StatusHandler(repoStarrocks, repoPostgres))
-	occurrencesGermlineGroup.POST("/:seq_id/count", server.OccurrencesGermlineCountHandler(repoOccurrences))
-	occurrencesGermlineGroup.POST("/:seq_id/list", server.OccurrencesGermlineListHandler(repoOccurrences))
-	occurrencesGermlineGroup.POST("/:seq_id/aggregate", server.OccurrencesGermlineAggregateHandler(repoOccurrences))
-	occurrencesGermlineGroup.POST("/:seq_id/statistics", server.OccurrencesGermlineStatisticsHandler(repoOccurrences))
-	occurrencesGermlineGroup.GET("/:seq_id/:locus_id/expanded", server.GetExpandedGermlineOccurrence(repoOccurrences))
-
-	interpretationsGroup := r.Group("/interpretations")
-	interpretationsGroup.Use(roleAccessMiddleware)
-	interpretationsGroup.GET("/pubmed/:citation_id", server.GetPubmedCitation(pubmedClient))
-	interpretationsGermlineGroup := interpretationsGroup.Group("/germline/:sequencing_id/:locus_id/:transcript_id")
-	interpretationsGermlineGroup.GET("", server.GetInterpretationGermline(repoPostgres.Interpretations))
-	interpretationsGermlineGroup.POST("", server.PostInterpretationGermline(repoPostgres.Interpretations))
-	interpretationsSomaticGroup := interpretationsGroup.Group("/somatic/:sequencing_id/:locus_id/:transcript_id")
-	interpretationsSomaticGroup.GET("", server.GetInterpretationSomatic(repoPostgres.Interpretations))
-	interpretationsSomaticGroup.POST("", server.PostInterpretationSomatic(repoPostgres.Interpretations))
-
-	// search endpoints
-	interpretationsGroup.GET("/germline", server.SearchInterpretationGermline(repoPostgres.Interpretations))
-	interpretationsGroup.GET("/somatic", server.SearchInterpretationSomatic(repoPostgres.Interpretations))
-
-	usersGroup := r.Group("/users")
-	usersGroup.GET("/sets/:user_set_id", server.GetUserSet(repoPostgres.UserSets))
-
-	sequencingGroup := r.Group("/sequencing")
-	sequencingGroup.Use(roleAccessMiddleware)
-	sequencingGroup.GET("/:seq_id", server.GetSequencing(repoSeqExp))
-
-	mondoGroup := r.Group("/mondo")
-	mondoGroup.GET("/autocomplete", server.GetMondoTermAutoComplete(repoTerms))
-
-	hpoGroup := r.Group("/hpo")
-	hpoGroup.GET("/autocomplete", server.GetHPOTermAutoComplete(repoTerms))
-
-	variantsGroup := r.Group("/variants")
-	variantsGermlineGroup := variantsGroup.Group("/germline")
-	variantsGermlineGroup.GET("/:locus_id/header", server.GetGermlineVariantHeader(repoVariants))
-	variantsGermlineGroup.GET("/:locus_id/overview", server.GetGermlineVariantOverview(repoVariants, repoExomiser))
-	variantsGermlineGroup.GET("/:locus_id/consequences", server.GetGermlineVariantConsequences(repoVariants))
-	variantsGermlineGroup.POST("/:locus_id/cases/interpreted", server.GetGermlineVariantInterpretedCases(repoVariants))
-	variantsGermlineGroup.POST("/:locus_id/cases/uninterpreted", server.GetGermlineVariantUninterpretedCases(repoVariants))
-	variantsGermlineGroup.GET("/:locus_id/cases/interpreted/:seq_id/:transcript_id", server.GetExpandedGermlineVariantInterpretedCase(repoVariants))
-	variantsGermlineGroup.GET("/:locus_id/cases/count", server.GetGermlineVariantCasesCount(repoVariants))
-	variantsGermlineGroup.GET("/cases/filters", server.GetGermlineVariantCasesFilters(repoVariants))
-	variantsGermlineGroup.GET("/:locus_id/conditions/:panel_type", server.GetGermlineVariantConditions(repoGenePanels))
-	variantsGermlineGroup.GET("/:locus_id/conditions/clinvar", server.GetGermlineVariantConditionsClinvar(repoClinvarRCV))
-
-	casesGroup := r.Group("/cases")
-	casesGroup.POST("/search", server.SearchCasesHandler(repoCases))
-	casesGroup.GET("/autocomplete", server.CasesAutocompleteHandler(repoCases))
-	casesGroup.POST("/filters", server.CasesFiltersHandler(repoCases))
-	casesGroup.GET("/:case_id", server.CaseEntityHandler(repoCases))
-
-	assaysGroup := r.Group("/assays")
-	assaysGroup.GET("/:seq_id", server.GetAssayBySeqIdHandler(repoAssays))
-
-	r.Use(gin.Recovery())
-	r.Run(":8090")
+	r := setupRouter(dbStarrocks, dbPostgres)
+	err = r.Run(":8090")
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -113,7 +113,7 @@ require (
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/oauth2 v0.19.0 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/tools v0.28.0 // indirect

--- a/backend/test/testutils/setup_starrocks.go
+++ b/backend/test/testutils/setup_starrocks.go
@@ -34,6 +34,25 @@ func ParallelTestWithDb(t *testing.T, dbName string, testFunc func(t *testing.T,
 	db.Exec(fmt.Sprintf("DROP DATABASE %s;", dbName))
 
 }
+
+func ParallelTestWithPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB)) {
+	t.Parallel()
+	starrocks, dbName, err := initDb(dbName)
+	if err != nil {
+		log.Fatal("Failed to init db connection:", err)
+
+	}
+	postgres, err := initPostgresDb()
+	if err != nil {
+		log.Fatal("Failed to init PostgreSQL db connection:", err)
+
+	}
+	testFunc(t, starrocks, postgres)
+	//Drop database
+	starrocks.Exec(fmt.Sprintf("DROP DATABASE %s;", dbName))
+
+}
+
 func initDb(folderName string) (*gorm.DB, string, error) {
 	ctx := context.Background()
 	host, err := StarrocksContainerSetup.Container.Host(ctx)


### PR DESCRIPTION
## Context

This PR adjust some security settings, namely:

- Some routes were not properly covered by the KeyCloak access role middleware. 
- Some dependencies needed to be updated. 

## Contribution

This PR does the following things:

- Create a private endpoint group named `privateRoutes` which should be used to initialize private routers instead of the global Gin router. 
- Moves the router setup into a separate function outside of main. This allows the Gin router to be testable in integration tests. 
- Add an integration test to validate secure route return `401` when missing the proper authorization. 