### PR TITLE
:bug: fix: SJRA-593 Refactor Occurrence to use GermlineSNV prefix in artifacts

### DIFF
--- a/frontend/apps/case-entity/src/components/variants/hook.tsx
+++ b/frontend/apps/case-entity/src/components/variants/hook.tsx
@@ -15,7 +15,7 @@ export type OccurrenceCountInput = {
 
 export function useOccurencesListHelper(input: OccurrencesListInput) {
   const fetch = useCallback(async () => {
-    return occurrencesApi.listGermlineOccurrences(input.seqId, input.listBody)
+    return occurrencesApi.listGermlineSNVOccurrences(input.seqId, input.listBody)
       .then(response => response.data);
   }, [input]);
 
@@ -27,7 +27,7 @@ export function useOccurencesListHelper(input: OccurrencesListInput) {
 
 export function useOccurencesCountHelper(input: OccurrenceCountInput) {
   const fetch = useCallback(async () => {
-    return occurrencesApi.countGermlineOccurrences(input.seqId, input.countBody)
+    return occurrencesApi.countGermlineSNVOccurrences(input.seqId, input.countBody)
       .then(response => response.data);
   }, [input]);
 

--- a/frontend/apps/case-entity/src/components/variants/interpretation/header.tsx
+++ b/frontend/apps/case-entity/src/components/variants/interpretation/header.tsx
@@ -1,4 +1,4 @@
-import { Occurrence } from '@/api/api';
+import { GermlineSNVOccurrence } from '@/api/api';
 import AnchorLink from '@/components/base/navigation/anchor-link';
 import { Badge } from '@/components/base/ui/badge';
 import { Separator } from '@/components/base/ui/separator';
@@ -9,7 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/ui/to
 import { SeqIDContext } from '../variants-tab';
 
 type InterpretationVariantHeaderProps = {
-  occurrence?: Occurrence;
+  occurrence?: GermlineSNVOccurrence;
 };
 
 function InterpretationVariantHeader({ occurrence }: InterpretationVariantHeaderProps) {

--- a/frontend/apps/case-entity/src/components/variants/interpretation/hook.ts
+++ b/frontend/apps/case-entity/src/components/variants/interpretation/hook.ts
@@ -1,10 +1,10 @@
-import { InterpretationGermline, InterpretationSomatic, Occurrence } from '@/api/api';
+import { InterpretationGermline, InterpretationSomatic, GermlineSNVOccurrence } from '@/api/api';
 import { interpretationApi, occurrencesApi } from '@/utils/api';
 import { useCallback } from 'react';
 import { MutationFetcher } from 'swr/mutation';
 import { Interpretation } from './types';
 
-export function useInterpretationHelper(occurrence: Occurrence, isSomatic: boolean) {
+export function useInterpretationHelper(occurrence: GermlineSNVOccurrence, isSomatic: boolean) {
   const fetch = useCallback(async () => {
     if (isSomatic) {
       return interpretationApi
@@ -63,9 +63,9 @@ export function useInterpretationHelper(occurrence: Occurrence, isSomatic: boole
 }
 
 
-export function useOccurenceExpandHelper(occurrence: Occurrence) {
+export function useOccurenceExpandHelper(occurrence: GermlineSNVOccurrence) {
   const fetch = useCallback(async () => {
-    return occurrencesApi.getExpandedGermlineOccurrence(
+    return occurrencesApi.getExpandedGermlineSNVOccurrence(
       occurrence.seq_id!.toString(),
       occurrence.locus_id!.toString(),
     )

--- a/frontend/apps/case-entity/src/components/variants/interpretation/interpretation-dialog.tsx
+++ b/frontend/apps/case-entity/src/components/variants/interpretation/interpretation-dialog.tsx
@@ -11,7 +11,7 @@ import { toast } from "sonner";
 import { Separator } from '@/components/base/ui/separator';
 import InterpretationFormGermline from './interpretation-form-germline';
 import { ReactNode, useCallback, useContext, useRef, useState } from 'react';
-import { ExpandedOccurrence, Occurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence, GermlineSNVOccurrence } from '@/api/api';
 import InterpretationFormSomatic from './interpretation-form-somatic';
 import InterpretationLastUpdatedBanner from './last-updated-banner';
 import InterpretationVariantHeader from './header';
@@ -25,7 +25,7 @@ import OccurrenceDetails from './occurence-details';
 import { useI18n } from '@/components/hooks/i18n';
 
 type InterpretationDialogButtonProps = {
-  occurrence: Occurrence;
+  occurrence: GermlineSNVOccurrence;
   handleSaveCallback?: () => void;
   renderTrigger: (handleOpen: () => void) => ReactNode;
 };
@@ -49,7 +49,7 @@ function InterpretationDialog({ occurrence, handleSaveCallback, renderTrigger }:
   const interpretationUniqueKey = `interpretation-${occurrence.seq_id}-${occurrence.locus_id}-${occurrence.transcript_id}`;
   const occurrenceUniqueKey = `occurrence-${occurrence.seq_id}-${occurrence.locus_id}`;
 
-  const fetchOccurrenceExpand = useSWR<ExpandedOccurrence>(occurrenceUniqueKey, fetchOccurrenceExpandHelper, {
+  const fetchOccurrenceExpand = useSWR<ExpandedGermlineSNVOccurrence>(occurrenceUniqueKey, fetchOccurrenceExpandHelper, {
     revalidateOnFocus: false,
     revalidateOnMount: false,
     shouldRetryOnError: false,

--- a/frontend/apps/case-entity/src/components/variants/interpretation/occurence-details.tsx
+++ b/frontend/apps/case-entity/src/components/variants/interpretation/occurence-details.tsx
@@ -1,4 +1,4 @@
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 import ClassificationSection from '../occurrence-table/classification-section';
 import PredictionSection from '../occurrence-table/prediction-section';
 import FrequencySection from '../occurrence-table/frequency-section';
@@ -7,7 +7,7 @@ import GeneSection from '../occurrence-table/gene-section';
 import ClinicalAssociationSection from '../occurrence-table/clinical-association-section';
 
 interface OccurrenceDetailsProps {
-  occurrence?: ExpandedOccurrence;
+  occurrence?: ExpandedGermlineSNVOccurrence;
 }
 
 function OccurrenceDetails({ occurrence }: OccurrenceDetailsProps) {

--- a/frontend/apps/case-entity/src/components/variants/interpretation/transcript.tsx
+++ b/frontend/apps/case-entity/src/components/variants/interpretation/transcript.tsx
@@ -3,11 +3,11 @@ import ConsequenceLabel from '@/components/feature/variant/consequence-label';
 import { getDbSnpUrl, getOmimOrgUrl } from '@/components/feature/variant/utils';
 import { useI18n } from '@/components/hooks/i18n';
 import TranscriptIdLink from '@/components/feature/variant/transcript-id-link';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 import AnchorLink from '@/components/base/navigation/anchor-link';
 
 type InterpretationTranscriptProps = {
-  occurrence?: ExpandedOccurrence;
+  occurrence?: ExpandedGermlineSNVOccurrence;
 };
 
 function InterpretationTranscript({ occurrence }: InterpretationTranscriptProps) {

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/cells/interpretation-cell.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/cells/interpretation-cell.tsx
@@ -1,4 +1,4 @@
-import { Occurrence } from '@/api/api';
+import { GermlineSNVOccurrence } from '@/api/api';
 import { Button } from '@/components/base/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/ui/tooltip';
 import { useI18n } from '@/components/hooks/i18n';
@@ -8,7 +8,7 @@ import InterpretationDialog from '../../interpretation/interpretation-dialog';
 import { useState } from 'react';
 
 type InterpretationCellProps = {
-  occurrence: Occurrence;
+  occurrence: GermlineSNVOccurrence;
 };
 
 

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/classification-section.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/classification-section.tsx
@@ -1,10 +1,10 @@
 import { useI18n } from '@/components/hooks/i18n';
 import DetailSection, { DetailItem } from './detail-section';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 import ClinVarBadge from '@/components/feature/variant/clinvar-badge';
 
 type ClassificationSectionProps = {
-  data: ExpandedOccurrence;
+  data: ExpandedGermlineSNVOccurrence;
 };
 
 export default function ClassificationSection({ data }: ClassificationSectionProps) {

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/clinical-association-section.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/clinical-association-section.tsx
@@ -1,14 +1,14 @@
 import { ReactElement } from 'react';
 import { useI18n } from '@/components/hooks/i18n';
 import DetailSection, { DetailItem } from './detail-section';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 import { Badge } from '@/components/base/ui/badge';
 import { useCallback } from 'react';
 import { Link } from 'react-router';
 import AnchorLink from '@/components/base/navigation/anchor-link';
 
 type ClinicalAssociationSectionProps = {
-  data: ExpandedOccurrence;
+  data: ExpandedGermlineSNVOccurrence;
 };
 
 const MAX_CLINICAL_ASSOCIATION = 3; // Maximum number of clinical associations to display before showing "see more"

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/family-section.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/family-section.tsx
@@ -1,12 +1,12 @@
 import { useI18n } from '@/components/hooks/i18n';
 import DetailSection, { DetailItem } from './detail-section';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/ui/tooltip';
 import PedigreeMaleNotAffectedIcon from '@/components/base/icons/pedigree-male-not-affected-icon';
 import PedigreeFemaleNotAffectedIcon from '@/components/base/icons/pedigree-female-not-affected-icon';
 
 type FamilySectionProps = {
-  data: ExpandedOccurrence;
+  data: ExpandedGermlineSNVOccurrence;
 };
 
 export default function FamilySection({ data }: FamilySectionProps) {

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/frequency-section.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/frequency-section.tsx
@@ -1,6 +1,6 @@
 import { useI18n } from '@/components/hooks/i18n';
 import DetailSection, { DetailItem } from './detail-section';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 import { Diamond } from 'lucide-react';
 import ShapeDiamondIcon from '@/components/base/icons/shape-diamond-icon';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/ui/tooltip';
@@ -8,7 +8,7 @@ import AnchorLink from '@/components/base/navigation/anchor-link';
 import { toExponentialNotationAtThreshold } from '@/components/lib/number-format';
 
 type FrequencySectionProps = {
-  data: ExpandedOccurrence;
+  data: ExpandedGermlineSNVOccurrence;
 };
 
 export default function FrequencySection({ data }: FrequencySectionProps) {

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/functional-score-section.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/functional-score-section.tsx
@@ -1,9 +1,9 @@
 import { useI18n } from '@/components/hooks/i18n';
 import DetailSection, { DetailItem } from './detail-section';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 
 interface FunctionalScoreSectionProps {
-  data: ExpandedOccurrence;
+  data: ExpandedGermlineSNVOccurrence;
 }
 
 export default function FunctionalScoreSection({ data }: FunctionalScoreSectionProps) {

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/gene-section.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/gene-section.tsx
@@ -1,12 +1,12 @@
 import { useI18n } from '@/components/hooks/i18n';
 import DetailSection, { DetailItem } from './detail-section';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 import { Badge } from '@/components/base/ui/badge';
 import AnchorLink from '@/components/base/navigation/anchor-link';
 import { toExponentialNotationAtThreshold } from '@/components/lib/number-format';
 
 interface GeneSectionProps {
-  data: ExpandedOccurrence;
+  data: ExpandedGermlineSNVOccurrence;
 }
 
 

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/metric-section.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/metric-section.tsx
@@ -1,11 +1,11 @@
 import { useI18n } from '@/components/hooks/i18n';
 import DetailSection, { DetailItem } from './detail-section';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 import { Triangle } from 'lucide-react';
 import ShapeTriangleUpIcon from '@/components/base/icons/shape-triangle-up-icon';
 
 type MetricSectionProps = {
-  data: ExpandedOccurrence;
+  data: ExpandedGermlineSNVOccurrence;
 };
 
 export default function MetricSection({ data }: MetricSectionProps) {

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/occurrence-expand-details.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/occurrence-expand-details.tsx
@@ -7,10 +7,10 @@ import ZygositySection from './zygosity-section';
 import FamilySection from './family-section';
 import ClinicalAssociationSection from './clinical-association-section';
 import MetricSection from './metric-section';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 
 type ExpandedOccurrenceDetailsProps = {
-  data: ExpandedOccurrence;
+  data: ExpandedGermlineSNVOccurrence;
 };
 
 export default function OccurrenceExpandDetails({ data }: ExpandedOccurrenceDetailsProps) {

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/occurrence-expand-header.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/occurrence-expand-header.tsx
@@ -1,14 +1,14 @@
 import { Button } from '@/components/base/ui/button';
 import { Edit2Icon } from 'lucide-react';
 import InterpretationDialog from '../interpretation/interpretation-dialog';
-import { Occurrence } from '@/api/api';
+import { GermlineSNVOccurrence } from '@/api/api';
 import { useI18n } from '@/components/hooks/i18n';
 import { Separator } from '@/components/base/ui/separator';
 import { Link } from 'react-router';
 import AnchorLink from '@/components/base/navigation/anchor-link';
 
 type OccurrenceExpandHeaderProps = {
-  occurrence: Occurrence;
+  occurrence: GermlineSNVOccurrence;
 };
 
 export default function OccurrenceExpandHeader({ occurrence }: OccurrenceExpandHeaderProps) {

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/occurrence-expand-transcript.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/occurrence-expand-transcript.tsx
@@ -1,4 +1,4 @@
-import { ExpandedOccurrence, Occurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence, GermlineSNVOccurrence } from '@/api/api';
 import { Separator } from '@/components/base/ui/separator';
 import ConsequenceLabel from '@/components/feature/variant/consequence-label';
 import AnchorLink from '@/components/base/navigation/anchor-link';
@@ -11,8 +11,8 @@ import TranscriptIdLink from '@/components/feature/variant/transcript-id-link';
 import {cn} from "@/lib/utils";
 
 type OccurrenceExpandTranscriptProps = {
-  occurrence: Occurrence;
-  expandedOccurrence: ExpandedOccurrence;
+  occurrence: GermlineSNVOccurrence;
+  expandedOccurrence: ExpandedGermlineSNVOccurrence;
 };
 
 export default function OccurrenceExpandTranscript({

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/occurrence-expand.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/occurrence-expand.tsx
@@ -1,4 +1,4 @@
-import { ExpandedOccurrence, Occurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence, GermlineSNVOccurrence } from '@/api/api';
 import { Card, CardContent, CardHeader } from '@/components/base/ui/card';
 import { Separator } from '@/components/base/ui/separator';
 import useSWR from 'swr';
@@ -9,7 +9,7 @@ import OccurrenceExpandHeader from './occurrence-expand-header';
 import OccurrenceExpandTranscript from './occurrence-expand-transcript';
 
 type GermlineVariantPreviewProps = {
-  occurrence: Occurrence;
+  occurrence: GermlineSNVOccurrence;
 };
 
 type OccurrenceExpandInput = {
@@ -18,12 +18,12 @@ type OccurrenceExpandInput = {
 };
 
 async function fetchOccurrenceExpand(input: OccurrenceExpandInput) {
-  const response = await occurrencesApi.getExpandedGermlineOccurrence(input.seqId, input.locusId);
+  const response = await occurrencesApi.getExpandedGermlineSNVOccurrence(input.seqId, input.locusId);
   return response.data;
 }
 
 export default function OccurrenceExpand({ occurrence }: GermlineVariantPreviewProps) {
-  const { data, isLoading } = useSWR<ExpandedOccurrence, any, OccurrenceExpandInput>(
+  const { data, isLoading } = useSWR<ExpandedGermlineSNVOccurrence, any, OccurrenceExpandInput>(
     {
       locusId: occurrence.locus_id.toString(),
       seqId: occurrence.seq_id.toString(),

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/prediction-section.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/prediction-section.tsx
@@ -1,12 +1,12 @@
 import { useI18n } from '@/components/hooks/i18n';
 import DetailSection, { DetailItem } from './detail-section';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 import ClinVarBadge from '@/components/feature/variant/clinvar-badge';
 import { Badge } from '@/components/base/ui/badge';
 import { getClassificationCriteriaColor } from '../interpretation/data';
 
 type PredictionSectionProps = {
-  data: ExpandedOccurrence;
+  data: ExpandedGermlineSNVOccurrence;
 };
 
 export default function PredictionSection({ data }: PredictionSectionProps) {

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/table-settings.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/table-settings.tsx
@@ -13,12 +13,12 @@ import ClinvarCell from '@/components/base/data-table/cells/clinvar-cell';
 import GnomadCell from '@/components/base/data-table/cells/gnomad-cell';
 import ParticipantFrequencyCell from '@/components/base/data-table/cells/participant-frequency-cell';
 import ZygosityCell from '@/components/base/data-table/cells/zygosity-cell';
-import { Occurrence } from '@/api/api';
+import { GermlineSNVOccurrence } from '@/api/api';
 import { TFunction } from 'i18next';
 import { ZapIcon } from 'lucide-react';
 import InterpretationCell from './cells/interpretation-cell';
 
-const columnHelper = createColumnHelper<Occurrence>();
+const columnHelper = createColumnHelper<GermlineSNVOccurrence>();
 
 function getVariantColumns(t: TFunction<string, undefined>) {
   return [
@@ -232,7 +232,7 @@ function getVariantColumns(t: TFunction<string, undefined>) {
       header: t('variant.headers.ad_ratio'),
       minSize: 120,
     }),
-  ] as TableColumnDef<Occurrence, any>[];
+  ] as TableColumnDef<GermlineSNVOccurrence, any>[];
 }
 
 const defaultSettings = createColumnSettings([

--- a/frontend/apps/case-entity/src/components/variants/occurrence-table/zygosity-section.tsx
+++ b/frontend/apps/case-entity/src/components/variants/occurrence-table/zygosity-section.tsx
@@ -1,11 +1,11 @@
 import { useI18n } from '@/components/hooks/i18n';
 import DetailSection, { DetailItem } from './detail-section';
-import { ExpandedOccurrence } from '@/api/api';
+import { ExpandedGermlineSNVOccurrence } from '@/api/api';
 import { titleCase, replaceUnderscore } from '@/components/lib/string-format';
 
 
 type ZygositySectionProps = {
-  data: ExpandedOccurrence;
+  data: ExpandedGermlineSNVOccurrence;
 };
 
 export default function ZygositySection({ data }: ZygositySectionProps) {

--- a/frontend/apps/case-entity/src/components/variants/variants-tab.tsx
+++ b/frontend/apps/case-entity/src/components/variants/variants-tab.tsx
@@ -1,4 +1,4 @@
-import { CaseEntity, Count, Occurrence, SortBody, SortBodyOrderEnum, Sqon } from '@/api/api';
+import { CaseEntity, Count, GermlineSNVOccurrence, SortBody, SortBodyOrderEnum, Sqon } from '@/api/api';
 import DataTable from '@/components/base/data-table/data-table';
 import { PaginationState } from '@tanstack/react-table';
 import useSWR from 'swr';
@@ -47,7 +47,7 @@ type VariantTabProps = {
 }
 
 async function fetchQueryCount(input: OccurrenceCountInput) {
-  const response = await occurrencesApi.countGermlineOccurrences(input.seqId, input.countBody);
+  const response = await occurrencesApi.countGermlineSNVOccurrences(input.seqId, input.countBody);
   return response.data;
 }
 
@@ -112,7 +112,7 @@ function VariantTab({ caseEntity, isLoading }: VariantTabProps) {
     countBody: { sqon: activeSqon }
   });
 
-  const fetchOccurrencesList = useSWR<Occurrence[]>('fetch-occurences-list', fetchOccurrencesListHelper, {
+  const fetchOccurrencesList = useSWR<GermlineSNVOccurrence[]>('fetch-occurences-list', fetchOccurrencesListHelper, {
     revalidateOnFocus: false,
     revalidateOnMount: false,
     shouldRetryOnError: false,

--- a/frontend/components/feature/query-filters/numerical-filter.tsx
+++ b/frontend/components/feature/query-filters/numerical-filter.tsx
@@ -29,7 +29,7 @@ type OccurrenceStatisticsInput = {
 
 const statisticsFetcher = (input: OccurrenceStatisticsInput): Promise<Statistics> => {
   return occurrencesApi
-    .statisticsGermlineOccurrences(input.seqId, input.statisticsBody)
+    .statisticsGermlineSNVOccurrences(input.seqId, input.statisticsBody)
     .then(response => response.data);
 };
 

--- a/frontend/components/feature/query-filters/use-aggregation-builder.ts
+++ b/frontend/components/feature/query-filters/use-aggregation-builder.ts
@@ -18,7 +18,7 @@ type OccurrenceAggregationInput = {
 
 const fetcher = (input: OccurrenceAggregationInput): Promise<Aggregation[]> => {
   return occurrencesApi
-    .aggregateGermlineOccurrences(input.seqId, input.aggregationBody)
+    .aggregateGermlineSNVOccurrences(input.seqId, input.aggregationBody)
     .then(response => response.data);
 };
 


### PR DESCRIPTION
## Context

In https://github.com/radiant-network/radiant-portal/pull/577, we refactored some components in preparation of adding the CNV data into Radiant. 

Endpoint routes and component names were updated to reflect the germline namespace to which they correspond (SNV or CNV). 

However, the UI components were not updated to properly reflect those changes.

## Contribution

This PR fixes the calls and usage of the auto-generated `openapi` classes to include the germline namespace as well. 