### PR TITLE
SJRA-621 fix data-table sub component

### DIFF
--- a/frontend/components/base/data-table/data-table.tsx
+++ b/frontend/components/base/data-table/data-table.tsx
@@ -773,7 +773,7 @@ function TranstackTable<T>({
               </TableFooter>
             )}
           </Table>
-        )}{' '}
+        )}
       </div>
       {!shouldHidePagination && (
         <div className={'flex items-center justify-between py-3 '}>


### PR DESCRIPTION
@francisl @lflangis Fixed that twice already. We need to make sure to keep `containerRef` always rendered.
<img width="1655" height="683" alt="Screenshot 2025-08-17 at 12 27 55 PM" src="https://github.com/user-attachments/assets/81a51fe1-e549-481e-bf19-fa6cc4762589" />
