### PR TITLE
fix(table): SJRA-611 settings should always be at the right of the table

### DIFF
--- a/frontend/components/base/data-table/data-table.tsx
+++ b/frontend/components/base/data-table/data-table.tsx
@@ -610,16 +610,16 @@ function TranstackTable<T>({
       <div className={cn('w-full flex text-left justify-between items-end', { 'mb-4': hasUpperSettings })}>
         {/* Total */}
 
-        {tableIndexResultPosition === 'top' && !shouldHidePagination && (
-          <div className="flex">
+        <div className="flex-1">
+          {tableIndexResultPosition === 'top' && !shouldHidePagination && (
             <TableIndexResult
               loading={loadingStates?.total}
               pageIndex={(table.getState().pagination?.pageIndex ?? 0) + 1}
               pageSize={table.getState().pagination?.pageSize ?? 20}
               total={total}
             />
-          </div>
-        )}
+          )}
+        </div>
 
         {/* FiltersGroup */}
         {FiltersGroupForm && FiltersGroupForm({ loading: loadingStates?.list ?? true })}
@@ -778,7 +778,7 @@ function TranstackTable<T>({
       {!shouldHidePagination && (
         <div className={'flex items-center justify-between py-3 '}>
           <div>
-            {tableIndexResultPosition === 'bottom' && !shouldHidePagination && (
+            {tableIndexResultPosition === 'bottom' && (
               <TableIndexResult
                 loading={loadingStates?.total}
                 pageIndex={(table.getState().pagination?.pageIndex ?? 0) + 1}

--- a/frontend/components/stories/table/data-table.stories.tsx
+++ b/frontend/components/stories/table/data-table.stories.tsx
@@ -1,22 +1,24 @@
-import type { Meta, StoryObj } from '@storybook/react';
+// @ts-nocheck
 import { BrowserRouter } from 'react-router-dom';
-import DataTable, { createColumnSettings, TableColumnDef } from '@/components/base/data-table/data-table';
-import { SortBodyOrderEnum } from '@/api/api';
-import { ConfigProvider, PortalConfig } from '@/components/model/applications-config';
-import TableFilters from '@/apps/case-exploration/src/components/table-filters/table-filters';
+import type { Meta, StoryObj } from '@storybook/react';
 import { createColumnHelper } from '@tanstack/react-table';
+
+import { SortBodyOrderEnum } from '@/api/api';
+import TableFilters from '@/apps/case-exploration/src/components/table-filters/table-filters';
+import DataTable, { createColumnSettings, TableColumnDef } from '@/components/base/data-table/data-table';
+import { ConfigProvider, PortalConfig } from '@/components/model/applications-config';
+
 import {
+  applicationFirstSetCellColumns,
   defaultColumnSettings,
-  thirdSetCellColumns,
   firstSetCellColumns,
+  firstSetCellData,
   secondSetCellColumns,
   secondSetCellData,
-  firstSetCellData,
+  thirdSetCellColumns,
   thirdSetCellData,
-  applicationFirstSetCellColumns,
 } from './cells-mock';
 import { data, MockData } from './table-mock';
-
 
 const columnHelper = createColumnHelper<MockData>();
 
@@ -114,8 +116,8 @@ const meta = {
       pageIndex: 0,
       pageSize: 10,
     },
-    onPaginationChange: () => { },
-    onServerSortingChange: sorting => { },
+    onPaginationChange: () => {},
+    onServerSortingChange: sorting => {},
     total: 10,
   },
   decorators: [
@@ -175,6 +177,15 @@ export const Default: Story = {
   render: args => <DataTable {...args} />,
 };
 
+export const WithOneResult: Story = {
+  args: {
+    data: data.slice(0, 1),
+    total: 1,
+    enableFullscreen: true,
+    enableColumnOrdering: true,
+  },
+  render: args => <DataTable {...args} />,
+};
 
 // @TODO:  not functional at the moment
 // export const WithHeaderGroups: Story = {
@@ -258,7 +269,7 @@ export const WithTableFilters: Story = {
     enableColumnOrdering: false,
     enableFullscreen: true,
     tableIndexResultPosition: 'hidden',
-    TableFilters: () => <TableFilters loading={false} setSearchCriteria={() => { }} />,
+    TableFilters: () => <TableFilters loading={false} setSearchCriteria={() => {}} />,
   },
   render: args => <DataTable {...args} />,
 };


### PR DESCRIPTION
<img width="2417" height="782" alt="image" src="https://github.com/user-attachments/assets/a707dc4b-c827-435b-8896-9f87b8cc768d" />
<img width="2260" height="211" alt="image" src="https://github.com/user-attachments/assets/4039134c-c504-4769-901a-d252c759bc39" />
