### PR TITLE
:sparkles: feat: SJRA-531 add panels filter to CNV

### DIFF
--- a/backend/internal/repository/germline_cnv_occurrences.go
+++ b/backend/internal/repository/germline_cnv_occurrences.go
@@ -31,20 +31,38 @@ func NewGermlineCNVOccurrencesRepository(db *gorm.DB) *GermlineCNVOccurrencesRep
 
 func (r *GermlineCNVOccurrencesRepository) GetOccurrences(seqId int, userQuery types.ListQuery) ([]GermlineCNVOccurrence, error) {
 	var occurrences []GermlineCNVOccurrence
-	tx, err := r.prepareListOrCountQuery(seqId)
+	tx, err := r.prepareListOrCountQuery(seqId, userQuery)
 	if err != nil {
 		return nil, fmt.Errorf("error during query preparation %w", err)
 	}
+	if userQuery != nil && userQuery.Filters() != nil && userQuery.HasFieldFromTables(types.GenePanelsTables...) {
+		// We group by name to avoid duplicates when joining with gene panels tables
+		// and use any_value for other fields to satisfy sql requirements
+		// Example of query :
+		// SELECT cnvo.name as name,any_value(cnvo.seq_id) as seq_id,any_value(cnvo.aliquot) as aliquot,any_value(cnvo.chromosome) as chromosome,...
+		// LEFT JOIN omim_gene_panel om ON array_contains(cnvo.symbol, om.symbol)
+		// WHERE (seq_id = 1 and part=1) AND om.panel IN ('panel1', 'panel2') GROUP BY `name`
+		// ORDER BY cnvo.name asc LIMIT 10
+		tx = tx.Group("name")
+		var columns = sliceutils.Map(userQuery.SelectedFields(), func(field types.Field, index int, slice []types.Field) string {
+			if field.Name == "name" {
+				return fmt.Sprintf("%s.%s as %s", field.Table.Alias, field.Name, field.GetAlias())
+			}
 
-	var columns = sliceutils.Map(userQuery.SelectedFields(), func(field types.Field, index int, slice []types.Field) string {
-		return fmt.Sprintf("%s.%s as %s", field.Table.Alias, field.Name, field.GetAlias())
-	})
+			return fmt.Sprintf("any_value(%s.%s) as %s", field.Table.Alias, field.Name, field.GetAlias())
+		})
+
+		tx = tx.Select(columns)
+	} else {
+		var columns = sliceutils.Map(userQuery.SelectedFields(), func(field types.Field, index int, slice []types.Field) string {
+			return fmt.Sprintf("%s.%s as %s", field.Table.Alias, field.Name, field.GetAlias())
+		})
+		tx = tx.Select(columns)
+	}
 
 	utils.AddLimit(tx, userQuery)
 	utils.AddSort(tx, userQuery)
-	utils.AddWhere(userQuery, tx)
 
-	tx = tx.Select(columns)
 	if err = tx.Find(&occurrences).Error; err != nil {
 		return nil, fmt.Errorf("error fetching CNV occurrences: %w", err)
 	}
@@ -53,13 +71,14 @@ func (r *GermlineCNVOccurrencesRepository) GetOccurrences(seqId int, userQuery t
 }
 
 func (r *GermlineCNVOccurrencesRepository) CountOccurrences(seqId int, userQuery types.CountQuery) (int64, error) {
-	tx, err := r.prepareListOrCountQuery(seqId)
+	tx, err := r.prepareListOrCountQuery(seqId, userQuery)
 	if err != nil {
 		return 0, fmt.Errorf("error during query preparation %w", err)
 	}
 
-	utils.AddWhere(userQuery, tx)
-
+	if userQuery != nil && userQuery.Filters() != nil && userQuery.HasFieldFromTables(types.GenePanelsTables...) {
+		tx = tx.Distinct(fmt.Sprintf("%s.name", types.GermlineCNVOccurrenceTable.Alias))
+	}
 	var count int64
 	if err = tx.Count(&count).Error; err != nil {
 		return 0, fmt.Errorf("error fetching occurrences: %w", err)
@@ -67,7 +86,7 @@ func (r *GermlineCNVOccurrencesRepository) CountOccurrences(seqId int, userQuery
 	return count, nil
 }
 
-func (r *GermlineCNVOccurrencesRepository) prepareListOrCountQuery(seqId int) (*gorm.DB, error) {
+func (r *GermlineCNVOccurrencesRepository) prepareListOrCountQuery(seqId int, userQuery types.Query) (*gorm.DB, error) {
 	part, err := utils.GetSequencingPart(seqId, r.db)
 	if err != nil {
 		return nil, fmt.Errorf("error during partition fetch %w", err)
@@ -77,5 +96,14 @@ func (r *GermlineCNVOccurrencesRepository) prepareListOrCountQuery(seqId int) (*
 		fmt.Sprintf("%s %s", types.GermlineCNVOccurrenceTable.Name, types.GermlineCNVOccurrenceTable.Alias),
 	).Where("seq_id = ? and part=?", seqId, part)
 
+	if userQuery != nil && userQuery.Filters() != nil && userQuery.HasFieldFromTables(types.GenePanelsTables...) {
+		selectedPanelsField := userQuery.GetFieldsFromTables(types.GenePanelsTables...)
+		selectedPanelsTables := utils.GetDistinctTablesFromFields(selectedPanelsField)
+		for _, panelsTable := range selectedPanelsTables {
+			tx = tx.
+				Joins(fmt.Sprintf("LEFT JOIN %s %s ON array_contains(%s.symbol, %s.symbol)", panelsTable.Name, panelsTable.Alias, types.GermlineCNVOccurrenceTable.Alias, panelsTable.Alias))
+		}
+	}
+	utils.AddWhere(userQuery, tx)
 	return tx, nil
 }

--- a/backend/internal/types/germline_cnv_occurrence.go
+++ b/backend/internal/types/germline_cnv_occurrence.go
@@ -287,6 +287,12 @@ var GermlineCNVOccurrencesFields = []Field{
 	GermlineCNVGnomadSF,
 	GermlineCNVCytobandField,
 	GermlineCNVSymbolField,
+	OmimGenePanelField,
+	HpoGenePanelField,
+	DddGenePanelField,
+	CosmicGenePanelField,
+	OmimInheritanceField,
+	OrphanetGenePanelField,
 }
 
 var GermlineCNVOccurrencesDefaultFields = []Field{

--- a/backend/test/data/gene_panels/germline__cnv__occurrence.tsv
+++ b/backend/test/data/gene_panels/germline__cnv__occurrence.tsv
@@ -1,0 +1,4 @@
+part	seq_id	aliquot	chromosome	start	end	type	length	name	quality	calls	filter	bc	cn	pe	sm	svtype	svlen	reflen	ciend	cipos	symbol
+1	1	AQ001	1	10000	10500	DEL	500	CNV1	0.995	[1,0,1]	PASS	10	2	[5,3]	0.95	DEL	500	500	[100,200]	[50,60]	[BRAF, AA2]
+1	1	AQ002	2	20000	20500	DUP	500	CNV2	0.887	[0,1,1]	PASS	12	3	[2,4]	0.85	DUP	500	500	[150,250]	[70,80]	[TML1]
+1	2	AQ003	X	30000	30500	INS	500	CNV3	0.772	[1,1,0]	FAIL	8	1	[1,2]	0.65	INS	500	500	[120,220]	[55,65]	[BRAF]


### PR DESCRIPTION
This pull request enhances the handling of gene panel filters in the `GermlineCNVOccurrencesRepository` by improving how queries involving gene panel-related fields are constructed and executed. It also adds new fields related to gene panels and expands test coverage to ensure correct filtering and counting by gene panels.

**Gene panel filtering improvements:**

* Refactored the `prepareListOrCountQuery` method in `germline_cnv_occurrences.go` to dynamically join gene panel tables when any gene panel fields are present in the query, enabling accurate filtering based on gene panel membership.
* Updated the `GetOccurrences` and `CountOccurrences` methods to use the new query preparation logic and to group/select or count distinctly by panel name when gene panel fields are included in the query. [[1]](diffhunk://#diff-a26b21db76fd097b2638195e0cda0baba144c0149b78be9735b2f47c35006cebL34-L47) [[2]](diffhunk://#diff-a26b21db76fd097b2638195e0cda0baba144c0149b78be9735b2f47c35006cebL56-R82)

**Field and schema updates:**

* Added new fields for various gene panels (`OmimGenePanelField`, `HpoGenePanelField`, `DddGenePanelField`, `CosmicGenePanelField`, `OmimInheritanceField`, `OrphanetGenePanelField`) to `GermlineCNVOccurrencesFields` in `germline_cnv_occurrence.go`, making them available for querying and filtering.
* Added gene panel-related test data to `germline__cnv__occurrence.tsv` for use in integration tests.

**Testing improvements:**

* Added integration tests to verify correct filtering and counting of CNV occurrences by gene panel filters in `germline_cnv_occurrences_test.go`. [[1]](diffhunk://#diff-a0465356ec0da358cd154de651bb2cab84ea2e6cd630d8f3b84237013db25b02R64-R85) [[2]](diffhunk://#diff-a0465356ec0da358cd154de651bb2cab84ea2e6cd630d8f3b84237013db25b02R156-R174)