### PR TITLE
:sparkles: feat: SJRA-732 Aggregate CNV

### DIFF
--- a/backend/internal/types/germline_cnv_occurrence.go
+++ b/backend/internal/types/germline_cnv_occurrence.go
@@ -245,11 +245,12 @@ var GermlineCNVGnomadSF = Field{
 }
 
 var GermlineCNVCytobandField = Field{
-	Name:          "cytoband",
-	CanBeSelected: true,
-	CanBeFiltered: true,
-	Type:          ArrayType,
-	Table:         GermlineCNVOccurrenceTable,
+	Name:            "cytoband",
+	CanBeSelected:   true,
+	CanBeFiltered:   true,
+	CanBeAggregated: true,
+	Type:            ArrayType,
+	Table:           GermlineCNVOccurrenceTable,
 }
 
 var GermlineCNVSymbolField = Field{

--- a/backend/test/data/gene_panels/germline__cnv__occurrence.tsv
+++ b/backend/test/data/gene_panels/germline__cnv__occurrence.tsv
@@ -1,4 +1,6 @@
-part	seq_id	aliquot	chromosome	start	end	type	length	name	quality	calls	filter	bc	cn	pe	sm	svtype	svlen	reflen	ciend	cipos	symbol
-1	1	AQ001	1	10000	10500	DEL	500	CNV1	0.995	[1,0,1]	PASS	10	2	[5,3]	0.95	DEL	500	500	[100,200]	[50,60]	[BRAF, AA2]
-1	1	AQ002	2	20000	20500	DUP	500	CNV2	0.887	[0,1,1]	PASS	12	3	[2,4]	0.85	DUP	500	500	[150,250]	[70,80]	[TML1]
-1	2	AQ003	X	30000	30500	INS	500	CNV3	0.772	[1,1,0]	FAIL	8	1	[1,2]	0.65	INS	500	500	[120,220]	[55,65]	[BRAF]
+part	seq_id	aliquot	chromosome	start	end	type	length	name	quality	calls	filter	bc	cn	pe	sm	svtype	svlen	reflen	ciend	cipos	symbol	cytoband
+1	1	AQ001	1	10000	10500	DEL	500	CNV1	0.995	[1,0,1]	PASS	10	2	[5,3]	0.95	DEL	500	500	[100,200]	[50,60]	[BRAF, AA2]	NULL
+1	1	AQ002	2	20000	20500	DUP	500	CNV2	0.887	[0,1,1]	PASS	12	3	[2,4]	0.85	DUP	500	500	[150,250]	[70,80]	[TML1]	NULL
+1	2	AQ003	X	30000	30500	INS	500	CNV3	0.772	[1,1,0]	FAIL	8	1	[1,2]	0.65	INS	500	500	[120,220]	[55,65]	[BRAF, TML1]	[p1, p2]
+1	2	AQ003	X	30000	30500	INS	500	CNV4	0.772	[1,1,0]	FAIL	8	1	[1,2]	0.65	INS	500	500	[120,220]	[55,65]	[BRAF, TP53]	[p1]
+1	2	AQ003	X	30000	30500	INS	500	CNV5	0.772	[1,1,0]	FAIL	8	1	[1,2]	0.65	INS	500	500	[120,220]	[55,65]	[TP53]	NULL


### PR DESCRIPTION
This pull request introduces aggregation functionality for germline CNV occurrences, enabling the backend to aggregate CNV data by fields such as gene panel or cytoband. The changes include updates to the repository interface and implementation, new API handler and endpoint, expanded tests, and data/test configuration changes to support aggregation.

**Aggregation functionality and API:**

* Added `AggregateOccurrences` method to the `GermlineCNVOccurrencesDAO` interface and implemented it in `GermlineCNVOccurrencesRepository`, supporting aggregation by both scalar and array fields (e.g., gene panel, cytoband). [[1]](diffhunk://#diff-a26b21db76fd097b2638195e0cda0baba144c0149b78be9735b2f47c35006cebR22) [[2]](diffhunk://#diff-a26b21db76fd097b2638195e0cda0baba144c0149b78be9735b2f47c35006cebR111-R139)
* Introduced `OccurrencesGermlineCNVAggregateHandler` to expose a new POST endpoint `/occurrences/germline/cnv/{seq_id}/aggregate` for aggregation queries, with OpenAPI documentation and input validation.

**Repository and query improvements:**

* Refactored repository query preparation by renaming `prepareListOrCountQuery` to `prepareQuery` and improving logic for handling filters and aggregation fields. [[1]](diffhunk://#diff-a26b21db76fd097b2638195e0cda0baba144c0149b78be9735b2f47c35006cebL34-R35) [[2]](diffhunk://#diff-a26b21db76fd097b2638195e0cda0baba144c0149b78be9735b2f47c35006cebL74-R75) [[3]](diffhunk://#diff-a26b21db76fd097b2638195e0cda0baba144c0149b78be9735b2f47c35006cebL89-R90) [[4]](diffhunk://#diff-a26b21db76fd097b2638195e0cda0baba144c0149b78be9735b2f47c35006cebL99-R100)

**Testing enhancements:**

* Added tests for aggregation by gene panel, cytoband, and cytoband with gene panel filtering in `germline_cnv_occurrences_test.go`.
* Added a mock repository and a test for the aggregate handler in `handlers_germline_cnv_occurrences_test.go`. [[1]](diffhunk://#diff-721946fc2eedf5bf0e26c38ec82c77262064390c3cd35dc2016a739e4ca43886R17-R24) [[2]](diffhunk://#diff-721946fc2eedf5bf0e26c38ec82c77262064390c3cd35dc2016a739e4ca43886R102-R126)

**Data model and test data updates:**

* Enabled aggregation on the `cytoband` field by setting `CanBeAggregated: true`.
* Updated test data to include the `cytoband` field and additional rows for more comprehensive aggregation testing.