### PR TITLE
fix(snv): SJRA-1322 adjust variant table

### DIFF
--- a/frontend/apps/case/src/entity/variants/occurrence/table/snv-occurrence-table-settings.tsx
+++ b/frontend/apps/case/src/entity/variants/occurrence/table/snv-occurrence-table-settings.tsx
@@ -36,14 +36,6 @@ function getSNVOccurrenceColumns(t: TFunction<string, undefined>, onInterpretati
     //   enablePinning: false,
     //   enableResizing: false,
     // },
-    // Variant
-    columnHelper.accessor(row => row.hgvsg, {
-      id: 'hgvsg',
-      cell: info => <HgvsgCell occurrence={info.row.original} />,
-      header: t('variant.headers.hgvsg'),
-      size: 70,
-      minSize: 40,
-    }),
     // interpretation and note cell
     columnHelper.accessor(row => row, {
       id: 'row-info',
@@ -58,6 +50,14 @@ function getSNVOccurrenceColumns(t: TFunction<string, undefined>, onInterpretati
       enablePinning: false,
       enableResizing: false,
       enableSorting: false,
+    }),
+    // Variant
+    columnHelper.accessor(row => row.hgvsg, {
+      id: 'hgvsg',
+      cell: info => <HgvsgCell occurrence={info.row.original} />,
+      header: t('variant.headers.hgvsg'),
+      size: 70,
+      minSize: 40,
     }),
     // Gene
     columnHelper.accessor(row => row.symbol, {
@@ -247,7 +247,7 @@ function getSNVOccurrenceColumns(t: TFunction<string, undefined>, onInterpretati
     {
       id: 'actions',
       cell: info => <OccurrenceActionsMenu row={info.row} onInterpretationSaved={onInterpretationSaved} />,
-      size: 74,
+      size: 86,
       enableResizing: false,
       enablePinning: true,
     },
@@ -263,17 +263,17 @@ const defaultSNVSettings = createColumnSettings([
   //   pinningPosition: 'left',
   // },
   {
-    id: 'hgvsg',
-    visible: true,
-    pinningPosition: 'left',
-    label: 'variant.headers.hgvsg',
-  },
-  {
     id: 'row-info',
     visible: true,
     fixed: true,
     pinningPosition: 'left',
     additionalFields: ['transcript_id', 'has_interpretation'],
+  },
+  {
+    id: 'hgvsg',
+    visible: true,
+    pinningPosition: 'left',
+    label: 'variant.headers.hgvsg',
   },
   {
     id: 'symbol',


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

The actions column (comments, interpretation) should always be at far left of table

The button group column is clipped. Needs to be wider to fit entire component.

## 📝 Changes
- Move comment, interpretation colums to far left
- Set Actions columns to a new size to prevent clipping

<img width="1380" height="709" alt="image" src="https://github.com/user-attachments/assets/2bcf5de3-5ef4-43b9-b53f-f18407b914ae" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1322](https://d3b.atlassian.net/browse/SJRA-1322)<!-- End JIRA Issues -->


[SJRA-1322]: https://d3b.atlassian.net/browse/SJRA-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ