### PR TITLE
feat: SJRA-1316 fix dockerfiles

### DIFF
--- a/backend/api.Dockerfile
+++ b/backend/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM golang:1.25 AS builder
 ARG CGO_ENABLED=0
 WORKDIR /app
 

--- a/backend/worker.Dockerfile
+++ b/backend/worker.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM golang:1.25 AS builder
 ARG CGO_ENABLED=0
 WORKDIR /app
 


### PR DESCRIPTION
# fix(backend): SJRA-1316 Fix docker/docker dependabot alert and broken Docker build

## 📌 Context

The upgrades also bumped the required Go toolchain to `1.25.0`, which broke the Docker image build since both Dockerfiles were pinned to `golang:1.24`.

## 📝 Changes

- Update `api.Dockerfile` and `worker.Dockerfile`: `golang:1.24` → `golang:1.25`

## ☑️ TO-DOs

- [ ] N/A

## 🧪 Tests

- Docker images build correctly now

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1316](https://d3b.atlassian.net/browse/SJRA-1316)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

[SJRA-1316]: https://d3b.atlassian.net/browse/SJRA-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ