### PR TITLE
feat: SJRA-1331 Remove Jira tags for fixed Cypress tests

### DIFF
--- a/cypress/api/Occurrences/Germline/SNV/Count/Occurrence.cy.ts
+++ b/cypress/api/Occurrences/Germline/SNV/Count/Occurrence.cy.ts
@@ -24,18 +24,6 @@ describe('Occurrences - Germline - SNV - Count - Occurrence', () => {
   sectionData.facets.forEach(facet => {
     let facetName = facet.name instanceof RegExp ? facet.name.source.replace(/^\^|\$$/g, '') : facet.name;
 
-    // Tag failed tests
-    switch (facetName) {
-      case 'Father’s Zygosity':
-      case 'Mother’s Zygosity':
-      case 'Parental Origin':
-      case 'Transmission':
-        facetName = `${facetName} [SJRA-1331]`;
-        break;
-      default:
-        break;
-    }
-
     it(`${facetName}`, () => {
       const facetData = globalData.Count.snv[sectionData.section].find((f: { field: string }) => f.field === facet.apiField);
 


### PR DESCRIPTION
# feat: SJRA-1331 Remove Jira tags for fixed Cypress tests

## 📌 Contexte

Retrait des tags `[SJRA-1331]` des tests Cypress suite à la résolution complète du bug concernant la zygosité parentale et la transmission. Les tests fonctionnent maintenant correctement sans nécessiter de suivi supplémentaire.

## 📝 Modifications

- **Cypress API Tests (Occurrences)**: Retrait des tags `[SJRA-1331]` pour les tests suivants (bug résolu):
  - Father's Zygosity
  - Mother's Zygosity
  - Parental Origin
  - Transmission

## 🧪 Tests

Tous les tests impactés ont été exécutés localement et passent avec succès.

## 🔗 Issues liées

<!-- Begin JIRA Issues -->
- [SJRA-1331](https://d3b.atlassian.net/browse/SJRA-1331)<!-- End JIRA Issues --> 

[SJRA-1331]: https://d3b.atlassian.net/browse/SJRA-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SJRA-1331]: https://d3b.atlassian.net/browse/SJRA-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ