### PR TITLE
fix(file): SJRA-1337 fix an issue where filter where refreshed when selecting a value

### DIFF
--- a/frontend/apps/file-archive/src/exploration/archive/files-archive-list-table-filters.tsx
+++ b/frontend/apps/file-archive/src/exploration/archive/files-archive-list-table-filters.tsx
@@ -15,7 +15,6 @@ import usePersistedFilters, { StringArrayRecord } from '@/components/hooks/usePe
 import { documentApi } from '@/utils/api';
 
 type FilesTableFilters = {
-  loading: boolean;
   setSearchCriteria: (searchCriteria: SearchCriterion[]) => void;
 };
 
@@ -40,14 +39,14 @@ async function fetchFilters() {
   return response.data;
 }
 
-function FilesTableFilters({ setSearchCriteria, loading }: FilesTableFilters) {
+function FilesTableFilters({ setSearchCriteria }: FilesTableFilters) {
   const { t } = useI18n();
   const [changedFilterButtons, setChangedFilterButtons] = useState<string[]>([]);
   const [openFilters, setOpenFilters] = useState<Record<string, boolean>>({});
   const [filters, setFilters] = usePersistedFilters<StringArrayRecord>('files-filters', {
     ...FILTER_DEFAULTS,
   });
-  const { data: apiFilters } = useSWR<DocumentFilters>('document-filters', () => fetchFilters(), {
+  const { data: apiFilters, isLoading } = useSWR<DocumentFilters>('document-filters', () => fetchFilters(), {
     revalidateOnFocus: false,
     revalidateOnMount: true,
     revalidateIfStale: false,
@@ -115,7 +114,7 @@ function FilesTableFilters({ setSearchCriteria, loading }: FilesTableFilters) {
       setFilters={setFilters}
       openFilters={openFilters}
       setOpenFilters={setOpenFilters}
-      loading={loading}
+      loading={isLoading}
       setSearchCriteria={setSearchCriteria}
       criterias={CRITERIAS}
       defaultFilters={FILTER_DEFAULTS}

--- a/frontend/apps/file-archive/src/exploration/archive/files-archive-list.tsx
+++ b/frontend/apps/file-archive/src/exploration/archive/files-archive-list.tsx
@@ -50,7 +50,7 @@ function FilesArchiveList() {
     <DataTable
       id="files-archive-list"
       columns={getFilesArchiveColumns(t)}
-      TableFilters={<FilesTableFilters setSearchCriteria={setSearchCriteria} loading={isLoading} />}
+      TableFilters={<FilesTableFilters setSearchCriteria={setSearchCriteria} loading={false} />}
       data={data?.list ?? []}
       defaultColumnSettings={defaultSettings}
       hasError={!!error}


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Fix the file repository facet filters to stay open when selecting a value, allowing users to select multiple values without the list collapsing after each selection.

## 📝 Changes

https://github.com/user-attachments/assets/5fe5b305-e096-47bb-b8f1-5c011291e199



## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1337](https://d3b.atlassian.net/browse/SJRA-1337)<!-- End JIRA Issues -->


[SJRA-1337]: https://d3b.atlassian.net/browse/SJRA-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ