### PR TITLE
fix(select): SJRA-1338 remove autoclose when selecting a value

### DIFF
--- a/frontend/components/base/data-entry/multi-selector/multi-selector.tsx
+++ b/frontend/components/base/data-entry/multi-selector/multi-selector.tsx
@@ -498,8 +498,6 @@ function MultiSelector({
                             setInputValue('');
                             // Clear search results by reverting to default options
                             setOptions(transToGroupOption(arrayDefaultOptions, groupBy));
-                            // Close the dropdown
-                            setOpen(false);
 
                             let newOptions: MultiSelectorOption[] = [];
 


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

 Fix the multi-select dropdown in the Clinical Interpretation modal to stay open after selecting an item, allowing users to pick multiple values without having to reopen the menu each time.

## 📝 Changes
- Remove autoclose when selecting a value for multi select

https://github.com/user-attachments/assets/c48c8a04-e4d4-4794-895c-ba848e60bbe7


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1338](https://d3b.atlassian.net/browse/SJRA-1338)<!-- End JIRA Issues -->


[SJRA-1338]: https://d3b.atlassian.net/browse/SJRA-1338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ