### PR TITLE
feat: SJRA-1340 Adjust Cypress tests related to recent changes

### DIFF
--- a/cypress/e2e/VariantEntity/Patients/Patients_Uninterpreted_InformationDisplayed.cy.ts
+++ b/cypress/e2e/VariantEntity/Patients/Patients_Uninterpreted_InformationDisplayed.cy.ts
@@ -8,6 +8,8 @@ describe('VariantEntity - Patients - Uninterpreted - Information displayed', () 
     cy.login();
     cy.visitVariantPatientsPage(data.variantGermline.locus_id);
     VariantEntity_Patients.uninterpreted.actions.selectTab();
+    VariantEntity_Patients.uninterpreted.actions.sortColumn('case');
+    VariantEntity_Patients.uninterpreted.actions.sortColumn('case');
   };
 
   it('Case [SJRA-1168]', () => {
@@ -20,17 +22,17 @@ describe('VariantEntity - Patients - Uninterpreted - Information displayed', () 
     VariantEntity_Patients.uninterpreted.validations.shouldShowColumnContent('sequencing', data.variantGermline.uninterpreted);
   });
 
-  it('Patient [SJRA-1168]', () => {
+  it('Patient', () => {
     setupTest();
     VariantEntity_Patients.uninterpreted.validations.shouldShowColumnContent('patient', data.variantGermline.uninterpreted);
   });
 
-  it('Sample [SJRA-1168]', () => {
+  it('Sample', () => {
     setupTest();
     VariantEntity_Patients.uninterpreted.validations.shouldShowColumnContent('sample', data.variantGermline.uninterpreted);
   });
 
-  it('Aff. Status [SJRA-1205]', () => {
+  it('Aff. Status', () => {
     setupTest();
     VariantEntity_Patients.uninterpreted.validations.shouldShowColumnContent('aff_status', data.variantGermline.uninterpreted);
   });
@@ -45,12 +47,12 @@ describe('VariantEntity - Patients - Uninterpreted - Information displayed', () 
     VariantEntity_Patients.uninterpreted.validations.shouldShowColumnContent('zygosity', data.variantGermline.uninterpreted);
   });
 
-  it('Diagnostic Lab [SJRA-1168]', () => {
+  it('Diagnostic Lab', () => {
     setupTest();
     VariantEntity_Patients.uninterpreted.validations.shouldShowColumnContent('diag_lab', data.variantGermline.uninterpreted);
   });
 
-  it('Analysis [SJRA-1205]', () => {
+  it('Analysis', () => {
     setupTest();
     VariantEntity_Patients.uninterpreted.validations.shouldShowColumnContent('analysis', data.variantGermline.uninterpreted);
   });
@@ -58,10 +60,5 @@ describe('VariantEntity - Patients - Uninterpreted - Information displayed', () 
   it('Date [SJRA-1168]', () => {
     setupTest();
     VariantEntity_Patients.uninterpreted.validations.shouldShowColumnContent('date', data.variantGermline.uninterpreted);
-  });
-
-  it('Status [SJRA-1205]', () => {
-    setupTest();
-    VariantEntity_Patients.uninterpreted.validations.shouldShowColumnContent('status', data.variantGermline.uninterpreted);
   });
 });

--- a/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
@@ -11,17 +11,6 @@ const selectors = {
 
 const tableColumns = [
   {
-    id: 'variant',
-    name: 'Variant',
-    apiField: 'hgvsg',
-    isVisibleByDefault: true,
-    pinByDefault: 'left',
-    isSortable: true,
-    isPinnable: true,
-    position: 0,
-    tooltip: null,
-  },
-  {
     id: 'interpretation',
     name: '',
     apiField: 'has_interpretation',
@@ -29,6 +18,17 @@ const tableColumns = [
     pinByDefault: 'left',
     isSortable: false,
     isPinnable: false,
+    position: 0,
+    tooltip: null,
+  },
+  {
+    id: 'variant',
+    name: 'Variant',
+    apiField: 'hgvsg',
+    isVisibleByDefault: true,
+    pinByDefault: 'left',
+    isSortable: true,
+    isPinnable: true,
     position: 1,
     tooltip: null,
   },

--- a/cypress/pom/pages/VariantEntity_Patients.ts
+++ b/cypress/pom/pages/VariantEntity_Patients.ts
@@ -477,13 +477,13 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
    * @param columnID The ID of the column to validate.
    * @param data The data object containing the expected values.
    */
-  shouldShowColumnContent(columnID: string, data: any) {
+  shouldShowColumnContent(columnID: string, data: any, showColumnsAction: () => void) {
+    showColumnsAction();
     getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
       if (position !== -1) {
         if (customColumnContent) {
           customColumnContent(columnID, data, position);
         } else {
-          // Comportement par défaut
           cy.validateTableFirstRowContent(data[columnID], position, tableId);
         }
       } else {
@@ -698,6 +698,9 @@ export const VariantEntity_Patients = {
         shouldShowAllColumns() {
           baseValidations.shouldShowAllColumns(() => actions.showAllColumns());
         },
+        shouldShowColumnContent(columnID: string, data: any) {
+          baseValidations.shouldShowColumnContent(columnID, data, () => actions.showAllColumns());
+        },
         shouldShowColumnTooltips() {
           baseValidations.shouldShowColumnTooltips(() => actions.showAllColumns());
         },
@@ -736,6 +739,9 @@ export const VariantEntity_Patients = {
         },
         shouldShowAllColumns() {
           baseValidations.shouldShowAllColumns(() => actions.showAllColumns());
+        },
+        shouldShowColumnContent(columnID: string, data: any) {
+          baseValidations.shouldShowColumnContent(columnID, data, () => actions.showAllColumns());
         },
         shouldShowColumnTooltips() {
           baseValidations.shouldShowColumnTooltips(() => actions.showAllColumns());


### PR DESCRIPTION
# feat: SJRA-1340 Adjust Cypress tests related to recent changes

## 📌 Contexte

Ajustements des tests Cypress suite aux récentes modifications de l'interface et de la structure des colonnes dans les pages de variants et de patients.

## 📝 Modifications

- **Test Patients Uninterpreted**: Ajout d'un tri de colonne (case) pour assurer la stabilité des résultats
- **Réorganisation des colonnes**: Inversion de l'ordre des colonnes `interpretation` et `variant` dans `CaseEntity_Variants_SNV_Table.ts`
- **Fonction de validation**: Ajout du paramètre `showColumnsAction` dans `shouldShowColumnContent` pour garantir la visibilité des colonnes avant validation
- **Nettoyage des tags Jira**: Retrait des tags SJRA-1168 et SJRA-1205 des tests concernés
- **Suppression du test Status**: Retrait du test "Status" devenu obsolète

## 🧪 Tests

Les tests impactés ont été exécutés localement et passent avec succès:
- `VariantEntity/Patients/Patients_Uninterpreted_InformationDisplayed.cy.ts`
- Validation des colonnes pour les onglets "Interpreted" et "Uninterpreted"

## 🔗 Issues reliées

<!-- Begin JIRA Issues -->
- [SJRA-1340](https://d3b.atlassian.net/browse/SJRA-1340)<!-- End JIRA Issues --> 

[SJRA-1340]: https://d3b.atlassian.net/browse/SJRA-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ