### PR TITLE
feat: SJRA-1349 Adjust Cypress tests related to recent changes

### DIFF
--- a/cypress/api/Occurrences/Germline/SNV/Count/Frequency.cy.ts
+++ b/cypress/api/Occurrences/Germline/SNV/Count/Frequency.cy.ts
@@ -37,7 +37,11 @@ describe('Occurrences - Germline - SNV - Count - Frequency', () => {
         cy.apiCall('POST', `occurrences/germline/snv/${case_id}/${seq_id}/count`, body, Auth.token).then(res => {
           response = res;
           expect(response.status).to.eq(200);
-          expect(response.body.count).to.eq(facetData.count);
+          if (facetData.count instanceof RegExp) {
+            expect(response.body.count.toString()).to.match(facetData.count);
+          } else {
+            expect(response.body.count).to.eq(facetData.count);
+          };
         });
       });
     });

--- a/cypress/pom/shared/Data.ts
+++ b/cypress/pom/shared/Data.ts
@@ -100,7 +100,7 @@ export const data = {
     exomiser: '0.438',
     acmg_exomiser: ['LB'],
     gnomad: '1.66e-3',
-    freq: '8.33e-2',
+    freq: /(1.43e-1|8.33e-2)/,
     gq: '99.00',
     zyg: '0/1',
     ad_ratio: '0.46',

--- a/cypress/support/globalData.js
+++ b/cypress/support/globalData.js
@@ -184,19 +184,19 @@ const globalData = {
           field: 'germline_pf_wgs',
           value: '0.5',
           op: '<',
-          count: 2180139,
+          count: /(2073057|2180139)/,
         },
         {
           field: 'germline_pf_wgs_affected',
           value: '0.5',
           op: '<',
-          count: 2298376,
+          count: /(2006606|2298376)/,
         },
         {
           field: 'germline_pf_wgs_not_affected',
           value: '0.5',
           op: '<',
-          count: 2473724,
+          count: /(1866517|2473724)/,
         },
         {
           field: 'gnomad_v3_af',


### PR DESCRIPTION
# feat: SJRA-1349 Adjust Cypress tests related to recent changes

## 📌 Contexte

Ajustement des tests Cypress suite à des changements récents qui ont modifié certaines valeurs de données dans l'environnement QA.

## 📝 Changements

- **Frequency.cy.ts** : Ajout d'une condition pour supporter les assertions par regex (`RegExp`) en plus des valeurs exactes lors de la validation du count des occurrences germline SNV.
- **Data.ts** : La valeur de `freq` est maintenant un pattern regex acceptant deux valeurs possibles (`1.43e-1` ou `8.33e-2`).
- **globalData.js** : Les counts des facettes de fréquence (`germline_pf_wgs`, `germline_pf_wgs_affected`, `germline_pf_wgs_not_affected`) utilisent maintenant des regex pour accepter l'ancienne et la nouvelle valeur.

## 🧪 Tests

- Les tests impactés ont été exécutés localement et passent avec succès.

## 🔗 Issues associées

<!-- Begin JIRA Issues -->
- [SJRA-1349](https://d3b.atlassian.net/browse/SJRA-1349)<!-- End JIRA Issues -->

[SJRA-1349]: https://d3b.atlassian.net/browse/SJRA-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ