### PR TITLE
feat: SJRA-1346 Optimize integration test infrastructure

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -118,7 +118,12 @@ fga model test --tests ./scripts/init-openfga/tests.fga.yaml
 
 Test utilities in `test/testutils/`: DB container setup, fixtures, JWT generation, mock auth, object store setup.
 
-Parallel test helper: `testutils.ParallelTestWithPostgresAndStarrocks()`.
+Helpers in `test/testutils/fixtures.go`:
+- `ParallelTestWithStarrocks` / `ParallelTestWithPostgres` — read-only StarRocks or Postgres-only tests, run in parallel.
+- `ParallelTestWithReadOnlyPostgresAndStarrocks` — tests that read from both DBs (typically a handler composing a Postgres + StarRocks repository). Test body MUST NOT mutate Postgres.
+- `SequentialTestWithPostgresAndStarrocks` (and `...OpenFGA...`, `...All` variants) — tests that mutate Postgres while reading via the StarRocks JDBC federation. Run serially because concurrent runs race on federation visibility; Postgres is reset via `cleanUp` after each test.
+
+StarRocks fixtures (`test/data/<folder>/*.tsv`) are loaded once per process per folder and shared across tests; the StarRocks test database is treated as read-only.
 
 ## Adding a New API Endpoint
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -118,10 +118,23 @@ fga model test --tests ./scripts/init-openfga/tests.fga.yaml
 
 Test utilities in `test/testutils/`: DB container setup, fixtures, JWT generation, mock auth, object store setup.
 
-Helpers in `test/testutils/fixtures.go`:
-- `ParallelTestWithStarrocks` / `ParallelTestWithPostgres` — read-only StarRocks or Postgres-only tests, run in parallel.
-- `ParallelTestWithReadOnlyPostgresAndStarrocks` — tests that read from both DBs (typically a handler composing a Postgres + StarRocks repository). Test body MUST NOT mutate Postgres.
-- `SequentialTestWithPostgresAndStarrocks` (and `...OpenFGA...`, `...All` variants) — tests that mutate Postgres while reading via the StarRocks JDBC federation. Run serially because concurrent runs race on federation visibility; Postgres is reset via `cleanUp` after each test.
+**Prefer `testutils.RunTest`** (in `test/testutils/fixtures.go`) for new tests. Declare what you need via `Need`; the framework derives parallel vs serial and cleanup behavior:
+
+```go
+testutils.RunTest(t, testutils.Need{Starrocks: "simple", Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+    repo := NewGenesRepository(env.Starrocks)
+    ...
+})
+```
+
+PostgresMode controls both cleanup and isolation:
+- `ReadPostgres` — read-only, no cleanup, parallel.
+- `WritePostgres` — writes with unique keys, cleanup after test, parallel.
+- `ExclusivePostgres` — writes to shared state (seed data, count assertions on shared keys), cleanup after test, forces serial. Use only when the test can't use unique keys.
+
+Serial is also forced when `MinIO: true` (t.Setenv incompatibility) or `OpenFGA: true` (process env mutation).
+
+Legacy shims (`ParallelTestWithStarrocks`, `ParallelTestWithPostgres`, `SequentialTestWithPostgres`, etc.) still exist and route through `RunTest`. New tests should use `RunTest` directly.
 
 StarRocks fixtures (`test/data/<folder>/*.tsv`) are loaded once per process per folder and shared across tests; the StarRocks test database is treated as read-only.
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -136,7 +136,7 @@ Serial is also forced when `MinIO: true` (t.Setenv incompatibility) or `OpenFGA:
 
 Legacy shims (`ParallelTestWithStarrocks`, `ParallelTestWithPostgres`, `SequentialTestWithPostgres`, etc.) still exist and route through `RunTest`. New tests should use `RunTest` directly.
 
-StarRocks fixtures (`test/data/<folder>/*.tsv`) are loaded once per process per folder and shared across tests; the StarRocks test database is treated as read-only.
+StarRocks fixtures (`test/data/<folder>/*.tsv`) are loaded once per process per folder and shared across tests; the StarRocks test database is treated as read-only. This invariant is enforced at runtime by a GORM read-only guard (`test/testutils/setup_starrocks.go`): any attempt to INSERT, UPDATE, DELETE, DROP, ALTER, or TRUNCATE through a test StarRocks connection will fail immediately with `testutils.ErrStarrocksReadOnly`. This applies to both ORM operations (`db.Create`, `db.Save`, `db.Delete`) and raw SQL (`db.Exec`).
 
 ## Adding a New API Endpoint
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -136,6 +136,10 @@ Serial is also forced when `MinIO: true` (t.Setenv incompatibility) or `OpenFGA:
 
 Legacy shims (`ParallelTestWithStarrocks`, `ParallelTestWithPostgres`, `SequentialTestWithPostgres`, etc.) still exist and route through `RunTest`. New tests should use `RunTest` directly.
 
+To make a Postgres write test parallel-safe (`WritePostgres` instead of `ExclusivePostgres`):
+- Use IDs/keys that `cleanUp` preserves (e.g., `case_id=1` or `case_id=71` for `occurrence_note`). Check `test/testutils/setup_postgres.go:cleanUp` for the full list of preserved ranges.
+- Use a unique identifier per test (e.g., a distinct `occurrence_id`) so count/list assertions don't see rows from other tests.
+
 StarRocks fixtures (`test/data/<folder>/*.tsv`) are loaded once per process per folder and shared across tests; the StarRocks test database is treated as read-only. This invariant is enforced at runtime by a GORM read-only guard (`test/testutils/setup_starrocks.go`): any attempt to INSERT, UPDATE, DELETE, DROP, ALTER, or TRUNCATE through a test StarRocks connection will fail immediately with `testutils.ErrStarrocksReadOnly`. This applies to both ORM operations (`db.Create`, `db.Save`, `db.Delete`) and raw SQL (`db.Exec`).
 
 ## Adding a New API Endpoint

--- a/backend/cmd/api/cases_integration_test.go
+++ b/backend/cmd/api/cases_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func assertSearchCasesHandler(t *testing.T, data string, body string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewCasesRepository(db)
 		router := gin.Default()
 		router.POST("/cases/search", server.SearchCasesHandler(repo))
@@ -69,7 +69,7 @@ func Test_SearchCasesHandler_WithVariants(t *testing.T) {
 }
 
 func assertCaseIdsAutoComplete(t *testing.T, data string, prefix string, limit int, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewCasesRepository(db)
 		router := gin.Default()
 		router.GET("/cases/autocomplete", server.CasesAutocompleteHandler(repo))
@@ -89,7 +89,7 @@ func Test_CaseIdsAutoComplete(t *testing.T) {
 }
 
 func assertGetCasesFilters(t *testing.T, data string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewCasesRepository(db)
 		router := gin.Default()
 		router.GET("/cases/filters", server.CasesFiltersHandler(repo))
@@ -158,7 +158,7 @@ func Test_GetCasesFilters(t *testing.T) {
 }
 
 func assertCaseEntityHandler(t *testing.T, data string, caseId int, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewCasesRepository(db)
 		router := gin.Default()
 		router.GET("/cases/:case_id", server.CaseEntityHandler(repo))
@@ -261,7 +261,7 @@ func Test_CaseEntityHandler(t *testing.T) {
 }
 
 func assertCaseEntityDocumentsSearchHandler(t *testing.T, data string, caseId int, body string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewDocumentsRepository(db)
 		router := gin.Default()
 		router.POST("/cases/:case_id/documents/search", server.CaseEntityDocumentsSearchHandler(repo))
@@ -318,7 +318,7 @@ func Test_CaseEntityDocumentsSearchHandler_WithSortAndLimit(t *testing.T) {
 }
 
 func assertCaseEntityDocumentsFiltersHandler(t *testing.T, data string, caseId int, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewDocumentsRepository(db)
 		router := gin.Default()
 		router.GET("/cases/:case_id/documents/filters", server.CaseEntityDocumentsFiltersHandler(repo))

--- a/backend/cmd/api/documents_integration_test.go
+++ b/backend/cmd/api/documents_integration_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func assertDocumentsSearchHandler(t *testing.T, data string, body string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewDocumentsRepository(db)
 		router := gin.Default()
 		router.POST("/documents/search", server.SearchDocumentsHandler(repo))
@@ -165,7 +165,7 @@ func Test_SearchDocumentsHandler_WithSortAndLimit(t *testing.T) {
 }
 
 func assertDocumentIdsAutoComplete(t *testing.T, data string, prefix string, limit int, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewDocumentsRepository(db)
 		router := gin.Default()
 		router.GET("/documents/autocomplete", server.DocumentsAutocompleteHandler(repo))
@@ -185,7 +185,7 @@ func Test_DocumentIdsAutoComplete(t *testing.T) {
 }
 
 func assertGetDocumentsFilters(t *testing.T, data string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewDocumentsRepository(db)
 		router := gin.Default()
 		router.GET("/documents/filters", server.DocumentsFiltersHandler(repo))
@@ -253,7 +253,7 @@ func Test_GetDocumentsFilters(t *testing.T) {
 }
 
 func Test_GetDocumentsDownloadUrl(t *testing.T) {
-	testutils.ParallelTestWithAll(t, "simple", func(t *testing.T, client *minio.Client, endpoint string, postgres *gorm.DB, starrocks *gorm.DB) {
+	testutils.SequentialTestWithMinIOPostgresStarrocks(t, "simple", func(t *testing.T, client *minio.Client, endpoint string, postgres *gorm.DB, starrocks *gorm.DB) {
 		_ = os.Setenv("AWS_REGION", "us-east-1")
 		_ = os.Setenv("AWS_ENDPOINT_URL", client.EndpointURL().String())
 		_ = os.Setenv("AWS_ACCESS_KEY_ID", "access")

--- a/backend/cmd/api/genes_integration_test.go
+++ b/backend/cmd/api/genes_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func assertGeneAutoComplete(t *testing.T, data string, prefix string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGenesRepository(db)
 		router := gin.Default()
 		router.GET("/genes/autocomplete", server.GetGeneAutoCompleteHandler(repo))
@@ -41,7 +41,7 @@ func Test_GeneAutoComplete(t *testing.T) {
 }
 
 func assertSearchGenes(t *testing.T, data string, body string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGenesRepository(db)
 		router := gin.Default()
 		router.POST("/genes/search", server.SearchGenesHandler(repo))

--- a/backend/cmd/api/germline_occurrences_integration_test.go
+++ b/backend/cmd/api/germline_occurrences_integration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func testList(t *testing.T, data string, body string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGermlineSNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.POST("/occurrences/germline/snv/:case_id/:seq_id/list", server.OccurrencesGermlineSNVListHandler(repo))
@@ -31,7 +31,7 @@ func testList(t *testing.T, data string, body string, expected string) {
 	})
 }
 func testCount(t *testing.T, data string, body string, expected int) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGermlineSNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.POST("/occurrences/germline/snv/:case_id/:seq_id/count", server.OccurrencesGermlineSNVCountHandler(repo))
@@ -45,7 +45,7 @@ func testCount(t *testing.T, data string, body string, expected int) {
 	})
 }
 func testAggregation(t *testing.T, data string, body string, queryParams []string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGermlineSNVOccurrencesRepository(db)
 		facetsRepo := repository.NewFacetsRepository()
 		router := gin.Default()
@@ -63,7 +63,7 @@ func testAggregation(t *testing.T, data string, body string, queryParams []strin
 	})
 }
 func testStatistics(t *testing.T, data string, body string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGermlineSNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.POST("/occurrences/germline/snv/:case_id/:seq_id/statistics", server.OccurrencesGermlineSNVStatisticsHandler(repo))
@@ -266,7 +266,7 @@ func Test_SNVOccurrence_List_Filter_On_Consequence_Column(t *testing.T) {
 }
 
 func Test_CNVOccurrence_List(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGermlineCNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.POST("/occurrences/germline/cnv/:case_id/:seq_id/list", server.OccurrencesGermlineCNVListHandler(repo))
@@ -287,7 +287,7 @@ func Test_CNVOccurrence_List(t *testing.T) {
 }
 
 func Test_CNVOccurrence_List_Filter_On_Chromosome(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGermlineCNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.POST("/occurrences/germline/cnv/:case_id/:seq_id/list", server.OccurrencesGermlineCNVListHandler(repo))
@@ -333,7 +333,7 @@ func Test_CNVOccurrence_List_Filter_On_Chromosome(t *testing.T) {
 }
 
 func Test_CNVOccurrence_Count(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGermlineCNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.POST("/occurrences/germline/cnv/:case_id/:seq_id/count", server.OccurrencesGermlineCNVCountHandler(repo))
@@ -351,7 +351,7 @@ func Test_CNVOccurrence_Count(t *testing.T) {
 }
 
 func Test_CNVOccurrence_Count_Filter_On_Quality(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGermlineCNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.POST("/occurrences/germline/cnv/:case_id/:seq_id/count", server.OccurrencesGermlineCNVCountHandler(repo))
@@ -382,7 +382,7 @@ func Test_CNVOccurrence_Count_Filter_On_Quality(t *testing.T) {
 }
 
 func assertGetExpandedOccurrence(t *testing.T, data string, caseId int, seqId int, locusId int, expected string) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.ParallelTestWithReadOnlyPostgresAndStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
 		repo := repository.NewGermlineSNVOccurrencesRepository(starrocks)
 		exomiserRepo := repository.NewExomiserRepository(starrocks)
 		pubmedClient := &MockExternalClient{}
@@ -492,7 +492,7 @@ func Test_CNVOccurrence_GetGenesOverlap(t *testing.T) {
 			"symbol": "TNMD"
 		  }
 		]`
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGermlineCNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.GET("/occurrences/germline/cnv/:case_id/:seq_id/:cnv_id/genes_overlap", server.OccurrencesGermlineCNVGenesOverlapHandler(repo))

--- a/backend/cmd/api/igv_integration_test.go
+++ b/backend/cmd/api/igv_integration_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func Test_GetIGVBySeqIdHandler(t *testing.T) {
-	testutils.ParallelTestWithAll(t, "simple", func(t *testing.T, client *minio.Client, endpoint string, postgres *gorm.DB, starrocks *gorm.DB) {
+	testutils.SequentialTestWithMinIOPostgresStarrocks(t, "simple", func(t *testing.T, client *minio.Client, endpoint string, postgres *gorm.DB, starrocks *gorm.DB) {
 		// Setup env vars for S3
 		_ = os.Setenv("AWS_REGION", "us-east-1")
 		_ = os.Setenv("AWS_ENDPOINT_URL", client.EndpointURL().String())

--- a/backend/cmd/api/integration_test.go
+++ b/backend/cmd/api/integration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Test_SecureRoutes(t *testing.T) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.ParallelTestWithReadOnlyPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
 
 		os.Setenv("CORS_ALLOWED_ORIGINS", "*")
 		defer os.Unsetenv("CORS_ALLOWED_ORIGINS")
@@ -107,7 +107,7 @@ func Test_SecureRoutes(t *testing.T) {
 }
 
 func Test_OpenFGA_Authorization(t *testing.T) {
-	testutils.ParallelTestWithOpenFGAAndPostgresAndStarrocks(t, "simple",
+	testutils.SequentialTestWithOpenFGAAndPostgresAndStarrocks(t, "simple",
 		func(t *testing.T, openfga *authorization.OpenFGAModelConfiguration, starrocks *gorm.DB, postgres *gorm.DB) {
 			token, err := jwt.GenerateMockJWT("radiant", []string{"data_manager"})
 			assert.NoError(t, err)

--- a/backend/cmd/api/interpretations_integration_test.go
+++ b/backend/cmd/api/interpretations_integration_test.go
@@ -110,7 +110,7 @@ func assertPostInterpretationGermline(t *testing.T, repo repository.Interpretati
 }
 
 func Test_GetInterpretationsomatic(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		pubmedService := &MockExternalClient{}
 		repo := repository.NewPostgresRepository(db, pubmedService)
 		// not found
@@ -136,7 +136,7 @@ func Test_GetInterpretationsomatic(t *testing.T) {
 }
 
 func Test_GetInterpretationSomaticWithPartialContent(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		pubmedService := &MockExternalClient{}
 		repo := repository.NewPostgresRepository(db, pubmedService)
 		interpretation := &types.InterpretationSomatic{}
@@ -182,7 +182,7 @@ func assertPostInterpretationSomatic(t *testing.T, repo repository.Interpretatio
 }
 
 func Test_SearchGermline(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		// db + repo
 		pubmedService := &MockExternalClient{}
 		repo := repository.NewPostgresRepository(db, pubmedService).Interpretations
@@ -218,7 +218,7 @@ func assertSearchInterpretationGermline(t *testing.T, repo repository.Interpreta
 }
 
 func Test_SearchSomatic(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		// db + repo
 		pubmedService := &MockExternalClient{}
 		repo := repository.NewPostgresRepository(db, pubmedService).Interpretations

--- a/backend/cmd/api/mondo_integration_test.go
+++ b/backend/cmd/api/mondo_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func assertMondoTermAutoComplete(t *testing.T, data string, prefix string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewTermsRepository(db)
 		router := gin.Default()
 		router.GET("/mondo/autocomplete", server.GetMondoTermAutoComplete(repo))

--- a/backend/cmd/api/occurrence_notes_integration_test.go
+++ b/backend/cmd/api/occurrence_notes_integration_test.go
@@ -94,7 +94,7 @@ func assertGetOccurrenceNoteCount(t *testing.T, repo repository.OccurrenceNotesD
 }
 
 func Test_GetOccurrenceNoteCount(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -107,7 +107,7 @@ func Test_GetOccurrenceNoteCount(t *testing.T) {
 }
 
 func Test_GetOccurrenceNoteCount_EmptyResult(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 
 		count := assertGetOccurrenceNoteCount(t, repo, 2, 1, 1, "99999", http.StatusOK)
@@ -116,7 +116,7 @@ func Test_GetOccurrenceNoteCount_EmptyResult(t *testing.T) {
 }
 
 func Test_GetOccurrenceNoteCount_ExcludesDeletedNotes(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -132,7 +132,7 @@ func Test_GetOccurrenceNoteCount_ExcludesDeletedNotes(t *testing.T) {
 }
 
 func Test_PostOccurrenceNote(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -154,7 +154,7 @@ func Test_PostOccurrenceNote(t *testing.T) {
 }
 
 func Test_PostOccurrenceNote_MissingContent(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -163,7 +163,7 @@ func Test_PostOccurrenceNote_MissingContent(t *testing.T) {
 }
 
 func Test_GetOccurrenceNotes_EmptyResult(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 
 		notes := assertGetOccurrenceNotes(t, repo, 2, 1, 1, "99999", http.StatusOK)
@@ -172,7 +172,7 @@ func Test_GetOccurrenceNotes_EmptyResult(t *testing.T) {
 }
 
 func Test_GetOccurrenceNotes(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -190,7 +190,7 @@ func Test_GetOccurrenceNotes(t *testing.T) {
 }
 
 func Test_PutOccurrenceNote(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -210,7 +210,7 @@ func Test_PutOccurrenceNote(t *testing.T) {
 }
 
 func Test_PutOccurrenceNote_NoteNotFound(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -231,7 +231,7 @@ func assertDeleteOccurrenceNote(t *testing.T, repo repository.OccurrenceNotesDAO
 }
 
 func Test_PutOccurrenceNote_Forbidden(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		ownerAuth := &testutils.MockAuth{Id: mockUserUUID}
 		otherAuth := &testutils.MockAuth{Id: "22222222-2222-2222-2222-222222222222"}
@@ -246,7 +246,7 @@ func Test_PutOccurrenceNote_Forbidden(t *testing.T) {
 }
 
 func Test_DeleteOccurrenceNote(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -263,7 +263,7 @@ func Test_DeleteOccurrenceNote(t *testing.T) {
 }
 
 func Test_DeleteOccurrenceNote_NoteNotFound(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -272,7 +272,7 @@ func Test_DeleteOccurrenceNote_NoteNotFound(t *testing.T) {
 }
 
 func Test_DeleteOccurrenceNote_Forbidden(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		ownerAuth := &testutils.MockAuth{Id: mockUserUUID}
 		otherAuth := &testutils.MockAuth{Id: "22222222-2222-2222-2222-222222222222"}

--- a/backend/cmd/api/occurrence_notes_integration_test.go
+++ b/backend/cmd/api/occurrence_notes_integration_test.go
@@ -93,15 +93,30 @@ func assertGetOccurrenceNoteCount(t *testing.T, repo repository.OccurrenceNotesD
 	return count.Count
 }
 
+func assertDeleteOccurrenceNote(t *testing.T, repo repository.OccurrenceNotesDAO, auth *testutils.MockAuth, id string, expectedStatus int) {
+	t.Helper()
+	router := gin.Default()
+	router.DELETE("/notes/:id", server.DeleteOccurrenceNoteHandler(repo, auth))
+
+	req, _ := http.NewRequest("DELETE", fmt.Sprintf("/notes/%s", id), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, expectedStatus, w.Code)
+}
+
+// All tests below use case_id=1 (preserved by cleanUp) and a unique
+// occurrence_id per test so they can run in parallel without interfering.
+
 func Test_GetOccurrenceNoteCount(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
-		assertPostOccurrenceNote(t, repo, auth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "10000", "content": "First note"}`, http.StatusCreated)
-		assertPostOccurrenceNote(t, repo, auth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "10000", "content": "Second note"}`, http.StatusCreated)
+		assertPostOccurrenceNote(t, repo, auth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90001", "content": "First note"}`, http.StatusCreated)
+		assertPostOccurrenceNote(t, repo, auth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90001", "content": "Second note"}`, http.StatusCreated)
 
-		count := assertGetOccurrenceNoteCount(t, repo, 2, 1, 1, "10000", http.StatusOK)
+		count := assertGetOccurrenceNoteCount(t, repo, 1, 1, 1, "90001", http.StatusOK)
 		assert.Equal(t, int64(2), count)
 	})
 }
@@ -110,23 +125,23 @@ func Test_GetOccurrenceNoteCount_EmptyResult(t *testing.T) {
 	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 
-		count := assertGetOccurrenceNoteCount(t, repo, 2, 1, 1, "99999", http.StatusOK)
+		count := assertGetOccurrenceNoteCount(t, repo, 1, 1, 1, "99999", http.StatusOK)
 		assert.Equal(t, int64(0), count)
 	})
 }
 
 func Test_GetOccurrenceNoteCount_ExcludesDeletedNotes(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
-		created := assertPostOccurrenceNote(t, repo, auth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "10000", "content": "Note to delete"}`, http.StatusCreated)
+		created := assertPostOccurrenceNote(t, repo, auth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90002", "content": "Note to delete"}`, http.StatusCreated)
 		if !assert.NotNil(t, created) {
 			return
 		}
 		assertDeleteOccurrenceNote(t, repo, auth, created.ID, http.StatusNoContent)
 
-		count := assertGetOccurrenceNoteCount(t, repo, 2, 1, 1, "10000", http.StatusOK)
+		count := assertGetOccurrenceNoteCount(t, repo, 1, 1, 1, "90002", http.StatusOK)
 		assert.Equal(t, int64(0), count)
 	})
 }
@@ -136,14 +151,14 @@ func Test_PostOccurrenceNote(t *testing.T) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
-		created := assertPostOccurrenceNote(t, repo, auth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "20000", "content": "Integration test note"}`, http.StatusCreated)
+		created := assertPostOccurrenceNote(t, repo, auth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90003", "content": "Integration test note"}`, http.StatusCreated)
 
 		if assert.NotNil(t, created) {
 			assert.NotEmpty(t, created.ID)
-			assert.Equal(t, 2, created.CaseID)
+			assert.Equal(t, 1, created.CaseID)
 			assert.Equal(t, 1, created.SeqID)
 			assert.Equal(t, 1, created.TaskID)
-			assert.Equal(t, "20000", created.OccurrenceID)
+			assert.Equal(t, "90003", created.OccurrenceID)
 			assert.Equal(t, mockUserUUID, created.UserID)
 			assert.Equal(t, testutils.DefaultMockFullName, created.UserName)
 			assert.Equal(t, "Integration test note", created.Content)
@@ -158,7 +173,7 @@ func Test_PostOccurrenceNote_MissingContent(t *testing.T) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
-		assertPostOccurrenceNote(t, repo, auth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "10000"}`, http.StatusBadRequest)
+		assertPostOccurrenceNote(t, repo, auth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90004"}`, http.StatusBadRequest)
 	})
 }
 
@@ -166,20 +181,20 @@ func Test_GetOccurrenceNotes_EmptyResult(t *testing.T) {
 	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 
-		notes := assertGetOccurrenceNotes(t, repo, 2, 1, 1, "99999", http.StatusOK)
+		notes := assertGetOccurrenceNotes(t, repo, 1, 1, 1, "99998", http.StatusOK)
 		assert.Empty(t, notes)
 	})
 }
 
 func Test_GetOccurrenceNotes(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
-		assertPostOccurrenceNote(t, repo, auth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "10000", "content": "First note"}`, http.StatusCreated)
-		assertPostOccurrenceNote(t, repo, auth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "10000", "content": "Second note"}`, http.StatusCreated)
+		assertPostOccurrenceNote(t, repo, auth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90005", "content": "First note"}`, http.StatusCreated)
+		assertPostOccurrenceNote(t, repo, auth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90005", "content": "Second note"}`, http.StatusCreated)
 
-		notes := assertGetOccurrenceNotes(t, repo, 2, 1, 1, "10000", http.StatusOK)
+		notes := assertGetOccurrenceNotes(t, repo, 1, 1, 1, "90005", http.StatusOK)
 
 		if assert.Len(t, notes, 2) {
 			// Most recently created note should be first (ORDER BY created_at DESC)
@@ -194,7 +209,7 @@ func Test_PutOccurrenceNote(t *testing.T) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
-		created := assertPostOccurrenceNote(t, repo, auth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "10000", "content": "Original content"}`, http.StatusCreated)
+		created := assertPostOccurrenceNote(t, repo, auth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90006", "content": "Original content"}`, http.StatusCreated)
 		if !assert.NotNil(t, created) {
 			return
 		}
@@ -218,25 +233,13 @@ func Test_PutOccurrenceNote_NoteNotFound(t *testing.T) {
 	})
 }
 
-func assertDeleteOccurrenceNote(t *testing.T, repo repository.OccurrenceNotesDAO, auth *testutils.MockAuth, id string, expectedStatus int) {
-	t.Helper()
-	router := gin.Default()
-	router.DELETE("/notes/:id", server.DeleteOccurrenceNoteHandler(repo, auth))
-
-	req, _ := http.NewRequest("DELETE", fmt.Sprintf("/notes/%s", id), nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, expectedStatus, w.Code)
-}
-
 func Test_PutOccurrenceNote_Forbidden(t *testing.T) {
 	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		ownerAuth := &testutils.MockAuth{Id: mockUserUUID}
 		otherAuth := &testutils.MockAuth{Id: "22222222-2222-2222-2222-222222222222"}
 
-		created := assertPostOccurrenceNote(t, repo, ownerAuth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "10000", "content": "Original content"}`, http.StatusCreated)
+		created := assertPostOccurrenceNote(t, repo, ownerAuth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90007", "content": "Original content"}`, http.StatusCreated)
 		if !assert.NotNil(t, created) {
 			return
 		}
@@ -246,18 +249,18 @@ func Test_PutOccurrenceNote_Forbidden(t *testing.T) {
 }
 
 func Test_DeleteOccurrenceNote(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
-		created := assertPostOccurrenceNote(t, repo, auth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "10000", "content": "Note to delete"}`, http.StatusCreated)
+		created := assertPostOccurrenceNote(t, repo, auth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90008", "content": "Note to delete"}`, http.StatusCreated)
 		if !assert.NotNil(t, created) {
 			return
 		}
 
 		assertDeleteOccurrenceNote(t, repo, auth, created.ID, http.StatusNoContent)
 
-		notes := assertGetOccurrenceNotes(t, repo, 2, 1, 1, "10000", http.StatusOK)
+		notes := assertGetOccurrenceNotes(t, repo, 1, 1, 1, "90008", http.StatusOK)
 		assert.Empty(t, notes)
 	})
 }
@@ -272,12 +275,12 @@ func Test_DeleteOccurrenceNote_NoteNotFound(t *testing.T) {
 }
 
 func Test_DeleteOccurrenceNote_Forbidden(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		ownerAuth := &testutils.MockAuth{Id: mockUserUUID}
 		otherAuth := &testutils.MockAuth{Id: "22222222-2222-2222-2222-222222222222"}
 
-		created := assertPostOccurrenceNote(t, repo, ownerAuth, `{"case_id": 2, "seq_id": 1, "task_id": 1, "occurrence_id": "10000", "content": "Note to delete"}`, http.StatusCreated)
+		created := assertPostOccurrenceNote(t, repo, ownerAuth, `{"case_id": 1, "seq_id": 1, "task_id": 1, "occurrence_id": "90009", "content": "Note to delete"}`, http.StatusCreated)
 		if !assert.NotNil(t, created) {
 			return
 		}
@@ -285,7 +288,7 @@ func Test_DeleteOccurrenceNote_Forbidden(t *testing.T) {
 		assertDeleteOccurrenceNote(t, repo, otherAuth, created.ID, http.StatusForbidden)
 
 		// Note should still be visible after failed delete attempt
-		notes := assertGetOccurrenceNotes(t, repo, 2, 1, 1, "10000", http.StatusOK)
+		notes := assertGetOccurrenceNotes(t, repo, 1, 1, 1, "90009", http.StatusOK)
 		assert.Len(t, notes, 1)
 	})
 }

--- a/backend/cmd/api/occurrence_notes_integration_test.go
+++ b/backend/cmd/api/occurrence_notes_integration_test.go
@@ -107,7 +107,7 @@ func Test_GetOccurrenceNoteCount(t *testing.T) {
 }
 
 func Test_GetOccurrenceNoteCount_EmptyResult(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 
 		count := assertGetOccurrenceNoteCount(t, repo, 2, 1, 1, "99999", http.StatusOK)
@@ -132,7 +132,7 @@ func Test_GetOccurrenceNoteCount_ExcludesDeletedNotes(t *testing.T) {
 }
 
 func Test_PostOccurrenceNote(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -154,7 +154,7 @@ func Test_PostOccurrenceNote(t *testing.T) {
 }
 
 func Test_PostOccurrenceNote_MissingContent(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -163,7 +163,7 @@ func Test_PostOccurrenceNote_MissingContent(t *testing.T) {
 }
 
 func Test_GetOccurrenceNotes_EmptyResult(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 
 		notes := assertGetOccurrenceNotes(t, repo, 2, 1, 1, "99999", http.StatusOK)
@@ -190,7 +190,7 @@ func Test_GetOccurrenceNotes(t *testing.T) {
 }
 
 func Test_PutOccurrenceNote(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -210,7 +210,7 @@ func Test_PutOccurrenceNote(t *testing.T) {
 }
 
 func Test_PutOccurrenceNote_NoteNotFound(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 
@@ -231,7 +231,7 @@ func assertDeleteOccurrenceNote(t *testing.T, repo repository.OccurrenceNotesDAO
 }
 
 func Test_PutOccurrenceNote_Forbidden(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		ownerAuth := &testutils.MockAuth{Id: mockUserUUID}
 		otherAuth := &testutils.MockAuth{Id: "22222222-2222-2222-2222-222222222222"}
@@ -263,7 +263,7 @@ func Test_DeleteOccurrenceNote(t *testing.T) {
 }
 
 func Test_DeleteOccurrenceNote_NoteNotFound(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewOccurrenceNotesRepository(db)
 		auth := &testutils.MockAuth{Id: mockUserUUID}
 

--- a/backend/cmd/api/saved_filters_integration_test.go
+++ b/backend/cmd/api/saved_filters_integration_test.go
@@ -30,14 +30,14 @@ func assertGetSavedFilterByIDHandler(t *testing.T, repo repository.SavedFiltersD
 }
 
 func Test_GetSavedFilterByIDHandler_NotFound(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		assertGetSavedFilterByIDHandler(t, repo, "ac2df672-9702-4dcf-8cfd-457494384762", http.StatusNotFound, `{"status": 404, "message":"saved filter not found"}`)
 	})
 }
 
 func Test_GetSavedFilterByIDHandler(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		expected := `{
 			"created_on":"2021-09-12T13:08:00Z", 
@@ -77,7 +77,7 @@ func assertGetSavedFiltersHandler(t *testing.T, repo repository.SavedFiltersDAO,
 }
 
 func Test_GetSavedFiltersHandler(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		expected := `[{
@@ -116,7 +116,7 @@ func Test_GetSavedFiltersHandler(t *testing.T) {
 }
 
 func Test_GetSavedFiltersHandler_FilterOnType(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		savedFilterType := types.GERMLINE_SNV_OCCURRENCE
@@ -152,7 +152,7 @@ func assertPostSavedFilterHandler(t *testing.T, repo repository.SavedFiltersDAO,
 }
 
 func Test_PostSavedFilterHandler_ErrorDuplicateName(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		body := `{
@@ -165,7 +165,7 @@ func Test_PostSavedFilterHandler_ErrorDuplicateName(t *testing.T) {
 }
 
 func Test_PostSavedFilterHandler_InvalidInput(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		body := `{
@@ -178,7 +178,7 @@ func Test_PostSavedFilterHandler_InvalidInput(t *testing.T) {
 }
 
 func Test_PostSavedFilterHandler_Success(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		body := `{
@@ -202,7 +202,7 @@ func assertPutSavedFilterHandler(t *testing.T, repo repository.SavedFiltersDAO, 
 }
 
 func Test_PutSavedFilterHandler_InvalidInput(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		body := `{
@@ -214,7 +214,7 @@ func Test_PutSavedFilterHandler_InvalidInput(t *testing.T) {
 }
 
 func Test_PutSavedFilterHandler_NotExistingSavedFilter(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		body := `{
@@ -227,7 +227,7 @@ func Test_PutSavedFilterHandler_NotExistingSavedFilter(t *testing.T) {
 }
 
 func Test_PutSavedFilterHandler_UserIdIsDifferent(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		body := `{
@@ -240,7 +240,7 @@ func Test_PutSavedFilterHandler_UserIdIsDifferent(t *testing.T) {
 }
 
 func Test_PutSavedFilterHandler_Success(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		body := `{
@@ -264,7 +264,7 @@ func assertDeleteSavedFilterHandler(t *testing.T, repo repository.SavedFiltersDA
 }
 
 func Test_DeleteSavedFilterHandler_NotExistingSavedFilter(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		assertDeleteSavedFilterHandler(t, repo, auth, "ac2df672-9702-4dcf-8cfd-457494384762", http.StatusNotFound)
@@ -272,7 +272,7 @@ func Test_DeleteSavedFilterHandler_NotExistingSavedFilter(t *testing.T) {
 }
 
 func Test_DeleteSavedFilterHandler_UserIdIsDifferent(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		assertDeleteSavedFilterHandler(t, repo, auth, "dddfa647-b0df-4ce7-807d-5b8775ee8fcb", http.StatusNotFound)
@@ -280,7 +280,7 @@ func Test_DeleteSavedFilterHandler_UserIdIsDifferent(t *testing.T) {
 }
 
 func Test_DeleteSavedFilterHandler_Success(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSavedFiltersRepository(db)
 		auth := &testutils.MockAuth{}
 		assertDeleteSavedFilterHandler(t, repo, auth, "1e1c5bc3-4f65-496a-ad61-cab239bf72d5", http.StatusNoContent)

--- a/backend/cmd/api/sequencing_integration_test.go
+++ b/backend/cmd/api/sequencing_integration_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func assertGetSequencing(t *testing.T, data string, seqId int, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSequencingRepository(db)
 		router := gin.Default()
 		router.GET("/sequencing/:seq_id", server.GetSequencing(repo))
@@ -36,7 +36,7 @@ func Test_GetSequencing(t *testing.T) {
 }
 
 func assertGetSequencingExperimentDetailByIdHandler(t *testing.T, data string, seqId int, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSequencingExperimentRepository(db)
 		router := gin.Default()
 		router.GET("/sequencing/:seq_id/details", server.GetSequencingExperimentDetailByIdHandler(repo))

--- a/backend/cmd/api/somatic_snv_occurrences_integration_test.go
+++ b/backend/cmd/api/somatic_snv_occurrences_integration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func testSomaticSNVList(t *testing.T, data string, body string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSomaticSNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.POST("/occurrences/somatic/snv/:case_id/:seq_id/list", server.OccurrencesSomaticSNVListHandler(repo))
@@ -31,7 +31,7 @@ func testSomaticSNVList(t *testing.T, data string, body string, expected string)
 	})
 }
 func testSomaticSNVCount(t *testing.T, data string, body string, expected int) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSomaticSNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.POST("/occurrences/somatic/snv/:case_id/:seq_id/count", server.OccurrencesSomaticSNVCountHandler(repo))
@@ -45,7 +45,7 @@ func testSomaticSNVCount(t *testing.T, data string, body string, expected int) {
 	})
 }
 func testSomaticSNVAggregation(t *testing.T, data string, body string, queryParams []string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSomaticSNVOccurrencesRepository(db)
 		facetsRepo := repository.NewFacetsRepository()
 		router := gin.Default()
@@ -63,7 +63,7 @@ func testSomaticSNVAggregation(t *testing.T, data string, body string, queryPara
 	})
 }
 func testSomaticSNVStatistics(t *testing.T, data string, body string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewSomaticSNVOccurrencesRepository(db)
 		router := gin.Default()
 		router.POST("/occurrences/somatic/snv/:case_id/:seq_id/statistics", server.OccurrencesSomaticSNVStatisticsHandler(repo))
@@ -198,7 +198,7 @@ func Test_Somatic_SNV_Statistics(t *testing.T) {
 }
 
 func assertGetExpandedSomaticOccurrence(t *testing.T, data string, caseId int, seqId int, locusId int, expected string) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.ParallelTestWithReadOnlyPostgresAndStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
 		repo := repository.NewSomaticSNVOccurrencesRepository(starrocks)
 		pubmedClient := &MockExternalClient{}
 		interpretationRepo := repository.NewInterpretationsRepository(postgres, pubmedClient)

--- a/backend/cmd/api/user_preferences_integration_test.go
+++ b/backend/cmd/api/user_preferences_integration_test.go
@@ -29,7 +29,7 @@ func assertGetUserPreferencesHandler(t *testing.T, repo repository.UserPreferenc
 }
 
 func Test_GetUserPreferencesHandler_NotFound(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewUserPreferencesRepository(db)
 		auth := &testutils.MockAuth{}
 		assertGetUserPreferencesHandler(t, repo, auth, http.StatusNotFound, "table_1", `{"status": 404, "message":"user preferences not found"}`)
@@ -37,7 +37,7 @@ func Test_GetUserPreferencesHandler_NotFound(t *testing.T) {
 }
 
 func Test_GetUserPreferencesHandler_Found(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewUserPreferencesRepository(db)
 		auth := &testutils.MockAuth{
 			Id: "b3a74785-b0a9-4a45-879e-f13c476976f7",
@@ -65,7 +65,7 @@ func assertUpdateUserPreferencesHandler(t *testing.T, repo repository.UserPrefer
 }
 
 func Test_UpdateUserPreferencesHandler(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewUserPreferencesRepository(db)
 		auth := &testutils.MockAuth{
 			Id: "b3a74785-b0a9-4a45-879e-f13c476976f7",

--- a/backend/cmd/api/user_preferences_integration_test.go
+++ b/backend/cmd/api/user_preferences_integration_test.go
@@ -29,7 +29,7 @@ func assertGetUserPreferencesHandler(t *testing.T, repo repository.UserPreferenc
 }
 
 func Test_GetUserPreferencesHandler_NotFound(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewUserPreferencesRepository(db)
 		auth := &testutils.MockAuth{}
 		assertGetUserPreferencesHandler(t, repo, auth, http.StatusNotFound, "table_1", `{"status": 404, "message":"user preferences not found"}`)

--- a/backend/cmd/api/user_preferences_integration_test.go
+++ b/backend/cmd/api/user_preferences_integration_test.go
@@ -29,7 +29,7 @@ func assertGetUserPreferencesHandler(t *testing.T, repo repository.UserPreferenc
 }
 
 func Test_GetUserPreferencesHandler_NotFound(t *testing.T) {
-	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewUserPreferencesRepository(db)
 		auth := &testutils.MockAuth{}
 		assertGetUserPreferencesHandler(t, repo, auth, http.StatusNotFound, "table_1", `{"status": 404, "message":"user preferences not found"}`)

--- a/backend/cmd/api/users_integration_test.go
+++ b/backend/cmd/api/users_integration_test.go
@@ -28,7 +28,7 @@ func assertGetUserSet(t *testing.T, repo repository.UserSetsDAO, userSetId strin
 }
 
 func Test_GetUserSet(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		pubmedService := &MockExternalClient{}
 		repo := repository.NewPostgresRepository(db, pubmedService)
 		// not found

--- a/backend/cmd/api/users_integration_test.go
+++ b/backend/cmd/api/users_integration_test.go
@@ -28,7 +28,7 @@ func assertGetUserSet(t *testing.T, repo repository.UserSetsDAO, userSetId strin
 }
 
 func Test_GetUserSet(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		pubmedService := &MockExternalClient{}
 		repo := repository.NewPostgresRepository(db, pubmedService)
 		// not found

--- a/backend/cmd/api/variants_integration_test.go
+++ b/backend/cmd/api/variants_integration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func assertGetVariantHeader(t *testing.T, data string, locusId int, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewVariantsRepository(db)
 		router := gin.Default()
 		router.GET("/variants/germline/:locus_id/header", server.GetGermlineVariantHeader(repo))
@@ -37,7 +37,7 @@ func Test_GetVariantHeader(t *testing.T) {
 }
 
 func assertGetVariantOverview(t *testing.T, data string, locusId int, expected string) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.ParallelTestWithReadOnlyPostgresAndStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
 		repo := repository.NewVariantsRepository(starrocks)
 		exomiserRepository := repository.NewExomiserRepository(starrocks)
 		pubmedClient := &MockExternalClient{}
@@ -65,7 +65,7 @@ func Test_GetVariantOverview_With_ExomiserACMGClassificationCounts(t *testing.T)
 }
 
 func assertGetVariantConsequences(t *testing.T, data string, locusId int, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewVariantsRepository(db)
 		router := gin.Default()
 		router.GET("/variants/germline/:locus_id/consequences", server.GetGermlineVariantConsequences(repo))
@@ -85,7 +85,7 @@ func Test_GetVariantConsequences(t *testing.T) {
 }
 
 func assertGetVariantInterpretedCases(t *testing.T, data string, locusId int, body string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewVariantsRepository(db)
 		router := gin.Default()
 		router.POST("/variants/germline/:locus_id/cases/interpreted", server.GetGermlineVariantInterpretedCases(repo))
@@ -130,7 +130,7 @@ func Test_GetVariantInterpretedCases(t *testing.T) {
 	assertGetVariantInterpretedCases(t, "simple", 1000, body, expected)
 }
 func assertGetVariantUninterpretedCases(t *testing.T, data string, locusId int, body string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewVariantsRepository(db)
 		router := gin.Default()
 		router.POST("/variants/germline/:locus_id/cases/uninterpreted", server.GetGermlineVariantUninterpretedCases(repo))
@@ -187,7 +187,7 @@ func Test_GetVariantUninterpretedCases(t *testing.T) {
 }
 
 func assertGetVariantCasesCount(t *testing.T, data string, locusId int, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewVariantsRepository(db)
 		router := gin.Default()
 		router.GET("/variants/germline/:locus_id/cases/count", server.GetGermlineVariantCasesCount(repo))
@@ -207,7 +207,7 @@ func Test_GetVariantCasesCount(t *testing.T) {
 }
 
 func assertGetVariantCasesFilters(t *testing.T, data string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewVariantsRepository(db)
 		router := gin.Default()
 		router.GET("/variants/germline/cases/filters", server.GetGermlineVariantCasesFilters(repo))
@@ -270,7 +270,7 @@ func Test_GetVariantCasesFilters(t *testing.T) {
 }
 
 func assertGetGermlineVariantConditions(t *testing.T, data string, locusId int, panelType string, filter string, expected string) {
-	testutils.ParallelTestWithDb(t, data, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewGenePanelsRepository(db)
 		router := gin.Default()
 		router.GET("/variants/germline/:locus_id/conditions/:panel_type", server.GetGermlineVariantConditions(repo))
@@ -351,7 +351,7 @@ func Test_GetGermlineVariantConditions_Orphanet(t *testing.T) {
 }
 
 func Test_GetGermlineVariantConditions_Clinvar(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "clinvar", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "clinvar", func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewClinvarRCVRepository(db)
 		router := gin.Default()
 		router.GET("/variants/germline/:locus_id/conditions/clinvar", server.GetGermlineVariantConditionsClinvar(repo))
@@ -367,7 +367,7 @@ func Test_GetGermlineVariantConditions_Clinvar(t *testing.T) {
 }
 
 func assertGetGermlineVariantExternalFrequencies(t *testing.T, data string, locusId int, expected string) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB) {
 		repo := repository.NewVariantsRepository(starrocks)
 		router := gin.Default()
 		router.GET("/variants/germline/:locus_id/external_frequencies", server.GetGermlineVariantExternalFrequenciesHandler(repo))
@@ -394,7 +394,7 @@ func Test_GetGermlineVariantExternalFrequenciesHandler(t *testing.T) {
 }
 
 func assertGetGermlineVariantGlobalInternalFrequencies(t *testing.T, data string, locusId int, status int, expected string) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB) {
 		repo := repository.NewVariantsRepository(starrocks)
 		router := gin.Default()
 		router.GET("/variants/germline/:locus_id/internal_frequencies/global", server.GetGermlineVariantGlobalInternalFrequenciesHandler(repo))
@@ -424,7 +424,7 @@ func Test_GetGermlineVariantGlobalInternalFrequenciesHandler_NotFound(t *testing
 }
 
 func assertGetGermlineVariantInternalFrequencies(t *testing.T, data string, locusId int, split string, status int, expected string) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, data, func(t *testing.T, starrocks *gorm.DB) {
 		repo := repository.NewVariantsRepository(starrocks)
 		router := gin.Default()
 		router.GET("/variants/germline/:locus_id/internal_frequencies", server.GetGermlineVariantInternalFrequenciesHandler(repo))

--- a/backend/cmd/worker/case_validation_integration_test.go
+++ b/backend/cmd/worker/case_validation_integration_test.go
@@ -1097,7 +1097,7 @@ func Test_ProcessBatch_Case_Exomiser_TaskContext(t *testing.T) {
 }
 
 func Test_ProcessBatch_Case_Template(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		t.Skip("Template test - implement specific error case tests as needed")
 
 		//// FIXME: The following test is for example purposes only.

--- a/backend/cmd/worker/integration_test.go
+++ b/backend/cmd/worker/integration_test.go
@@ -49,7 +49,7 @@ func assertBatchProcessing(t *testing.T, db *gorm.DB, id string, expectedStatus 
 }
 
 func Test_ProcessBatch_Patient_Success_Dry_Run(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
 			{
 				"submitter_patient_id": "MRN-TEST-123",
@@ -98,7 +98,7 @@ func Test_ProcessBatch_Patient_Success_Dry_Run(t *testing.T) {
 }
 
 func Test_ProcessBatch_Patient_Skipped(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
 			{
 				"submitter_patient_id": "MRN-283773",
@@ -144,7 +144,7 @@ func Test_ProcessBatch_Patient_Skipped(t *testing.T) {
 }
 
 func Test_ProcessBatch_Patient_Errors(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
 			{
 				"submitter_patient_id": "MRN-283773",
@@ -259,7 +259,7 @@ func Test_ProcessBatch_Patient_All_Codes(t *testing.T) {
 }
 
 func Test_ProcessBatch_Patient_Success_Not_Dry_Run(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
 			{
 				"submitter_patient_id": "MRN-TEST-123",
@@ -308,7 +308,7 @@ func Test_ProcessBatch_Patient_Success_Not_Dry_Run(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Success_Dry_Run(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
             {
                 "submitter_sample_id": "SAMPLE-001",
@@ -356,7 +356,7 @@ func Test_ProcessBatch_Sample_Success_Dry_Run(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Success_Not_Dry_Run(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
             {
                 "submitter_sample_id": "SAMPLE-NEW-001",
@@ -404,7 +404,7 @@ func Test_ProcessBatch_Sample_Success_Not_Dry_Run(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Already_Exists_Skipped(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		db.Exec(`
             INSERT INTO sample (submitter_sample_id, type_code, tissue_site, histology_code, organization_id, patient_id)
             VALUES ('SAMPLE-EXISTS', 'dna', 'blood', 'normal', 3, 1)
@@ -447,7 +447,7 @@ func Test_ProcessBatch_Sample_Already_Exists_Skipped(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Existing_Different_Field_Warning(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		db.Exec(`
             INSERT INTO sample (submitter_sample_id, type_code, tissue_site, histology_code, organization_id, patient_id)
             VALUES ('SAMPLE-DIFF', 'dna', 'liver', 'normal', 3, 1)
@@ -490,7 +490,7 @@ func Test_ProcessBatch_Sample_Existing_Different_Field_Warning(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Patient_Not_Exist(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
             {
                 "submitter_sample_id": "SAMPLE-003",
@@ -526,7 +526,7 @@ func Test_ProcessBatch_Sample_Patient_Not_Exist(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Organization_Not_Exist(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
             {
                 "submitter_sample_id": "SAMPLE-004",
@@ -562,7 +562,7 @@ func Test_ProcessBatch_Sample_Organization_Not_Exist(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Parent_Sample_In_Batch(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
             {
                 "submitter_sample_id": "SAMPLE-PARENT",
@@ -624,7 +624,7 @@ func Test_ProcessBatch_Sample_Parent_Sample_In_Batch(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Parent_Sample_In_Db(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
             {
                 "submitter_sample_id": "SAMPLE-CHILD-DB-PARENT",
@@ -677,7 +677,7 @@ func Test_ProcessBatch_Sample_Parent_Sample_In_Db(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Unknown_Parent_Sample(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
             {
                 "submitter_sample_id": "SAMPLE-CHILD-ORPHAN",
@@ -715,7 +715,7 @@ func Test_ProcessBatch_Sample_Unknown_Parent_Sample(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Invalid_Patient_For_Parent_Sample(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		// Insert parent sample for a different patient
 		db.Exec(`
             INSERT INTO sample (submitter_sample_id, type_code, tissue_site, histology_code, organization_id, patient_id)
@@ -758,7 +758,7 @@ func Test_ProcessBatch_Sample_Invalid_Patient_For_Parent_Sample(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Duplicate_In_Batch(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
             {
                 "submitter_sample_id": "SAMPLE-DUP",
@@ -803,7 +803,7 @@ func Test_ProcessBatch_Sample_Duplicate_In_Batch(t *testing.T) {
 }
 
 func Test_ProcessBatch_Sample_Field_Too_Long(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		longString := strings.Repeat("a", TextMaxLength+1)
 		payload := fmt.Sprintf(`[
             {
@@ -897,7 +897,7 @@ func Test_ProcessBatch_Sample_All_Codes(t *testing.T) {
 }
 
 func Test_ProcessBatch_SequencingExperiment_Success_Dry_Run(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
 			{
 				"aliquot": "ALIQUOT-12345",
@@ -949,7 +949,7 @@ func Test_ProcessBatch_SequencingExperiment_Success_Dry_Run(t *testing.T) {
 }
 
 func Test_ProcessBatch_SequencingExperiment_Success_Not_Dry_Run(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
 			{
 				"aliquot": "ALIQUOT-12345",
@@ -1024,7 +1024,7 @@ func Test_ProcessBatch_SequencingExperiment_Success_Not_Dry_Run(t *testing.T) {
 }
 
 func Test_ProcessBatch_SequencingExperiment_Info_Skipped(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 
 		payload := `[
 			{
@@ -1096,7 +1096,7 @@ func Test_ProcessBatch_SequencingExperiment_Info_Skipped(t *testing.T) {
 }
 
 func Test_ProcessBatch_SequencingExperiment_Warning_Skipped(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 
 		payload := `[
 			{
@@ -1190,7 +1190,7 @@ func Test_ProcessBatch_SequencingExperiment_Warning_Skipped(t *testing.T) {
 }
 
 func Test_ProcessBatch_SequencingExperiment_Errors(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 
 		payload := `[
 			{
@@ -1248,7 +1248,7 @@ func Test_ProcessBatch_SequencingExperiment_Errors(t *testing.T) {
 }
 
 func Test_ProcessBatch_SequencingExperiment_Errors_InvalidOrgs(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 
 		payload := `[
 			{
@@ -1306,7 +1306,7 @@ func Test_ProcessBatch_SequencingExperiment_Errors_InvalidOrgs(t *testing.T) {
 }
 
 func Test_ProcessBatch_SequencingExperiment_DuplicateInBatch(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 
 		payload := `[
 			{
@@ -1454,7 +1454,7 @@ func Test_ProcessBatch_SequencingExperiment_All_Codes(t *testing.T) {
 }
 
 func Test_ProcessBatch_Using_Cache(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewValueSetsRepository(db)
 		ctx := batchval.BatchValidationContext{
 			ValueSetsRepo: repo,
@@ -1492,7 +1492,7 @@ func Test_ProcessBatch_Using_Cache(t *testing.T) {
 }
 
 func Test_ProcessBatch_Unsupported_Type(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		payload := `[
 			{
 				"batch": "fake"	

--- a/backend/cmd/worker/patient_validation_test.go
+++ b/backend/cmd/worker/patient_validation_test.go
@@ -320,7 +320,7 @@ func Test_ValidateExistingPatient_DifferentValues(t *testing.T) {
 }
 
 func Test_Persist_Batch_And_Patient_Records_Rollback_On_Error(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		/* This test verifies that rollback occurs when there is an error inserting patient records. */
 		var id string
 		initErr := db.Raw(`

--- a/backend/internal/batchval/utils_test.go
+++ b/backend/internal/batchval/utils_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_Process_Unexpected_Errors(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := repository.NewBatchRepository(db)
 
 		var id string

--- a/backend/internal/repository/batch_test.go
+++ b/backend/internal/repository/batch_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_CreateBatch_Valid(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 		type samplePayload struct {
 			Message string `json:"message"`
@@ -40,7 +40,7 @@ func Test_CreateBatch_Valid(t *testing.T) {
 }
 
 func Test_GetBatchByID_Success(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 		batchId := uuid.NewString()
 		initErr := db.Exec(`
@@ -118,7 +118,7 @@ func Test_ClaimNextBatch_Several_Entries(t *testing.T) {
 }
 
 func Test_UpdateBatch(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 
 		var id string

--- a/backend/internal/repository/batch_test.go
+++ b/backend/internal/repository/batch_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_CreateBatch_Valid(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 		type samplePayload struct {
 			Message string `json:"message"`
@@ -40,7 +40,7 @@ func Test_CreateBatch_Valid(t *testing.T) {
 }
 
 func Test_GetBatchByID_Success(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 		batchId := uuid.NewString()
 		initErr := db.Exec(`
@@ -91,7 +91,7 @@ func Test_ClaimNextBatch_Without_Pending(t *testing.T) {
 }
 
 func Test_ClaimNextBatch_Several_Entries(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 		// Add two pending batches
 		initErr := db.Exec(`
@@ -118,7 +118,7 @@ func Test_ClaimNextBatch_Several_Entries(t *testing.T) {
 }
 
 func Test_UpdateBatch(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 
 		var id string
@@ -147,7 +147,7 @@ func Test_UpdateBatch(t *testing.T) {
 }
 
 func Test_UpdateStuckBatch(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 
 		timeMoreThan24hAgo := time.Now().Add(-48 * time.Hour).Format("2006-01-02")

--- a/backend/internal/repository/batch_test.go
+++ b/backend/internal/repository/batch_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_CreateBatch_Valid(t *testing.T) {
-	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 		type samplePayload struct {
 			Message string `json:"message"`
@@ -40,7 +40,7 @@ func Test_CreateBatch_Valid(t *testing.T) {
 }
 
 func Test_GetBatchByID_Success(t *testing.T) {
-	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 		batchId := uuid.NewString()
 		initErr := db.Exec(`
@@ -118,7 +118,7 @@ func Test_ClaimNextBatch_Several_Entries(t *testing.T) {
 }
 
 func Test_UpdateBatch(t *testing.T) {
-	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)
 
 		var id string

--- a/backend/internal/repository/cases_test.go
+++ b/backend/internal/repository/cases_test.go
@@ -29,7 +29,7 @@ var CasesQueryConfigForTest = types.QueryConfig{
 }
 
 func Test_CreateCases(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		orgId := 1
 		labId := 6

--- a/backend/internal/repository/cases_test.go
+++ b/backend/internal/repository/cases_test.go
@@ -29,7 +29,7 @@ var CasesQueryConfigForTest = types.QueryConfig{
 }
 
 func Test_CreateCases(t *testing.T) {
-	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		orgId := 1
 		labId := 6

--- a/backend/internal/repository/cases_test.go
+++ b/backend/internal/repository/cases_test.go
@@ -29,7 +29,7 @@ var CasesQueryConfigForTest = types.QueryConfig{
 }
 
 func Test_CreateCases(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		orgId := 1
 		labId := 6
@@ -85,7 +85,7 @@ func Test_GetCaseAnalysisCatalogIdByCode_NotFound(t *testing.T) {
 }
 
 func Test_SearchCasesNoFilters(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		query, err := types.NewListQueryFromCriteria(CasesQueryConfigForTest, allCasesFields, nil, nil, nil)
 		cases, count, err := repo.SearchCases(query)
@@ -115,7 +115,7 @@ func Test_SearchCasesNoFilters(t *testing.T) {
 }
 
 func Test_SearchCasesNoResult(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -132,7 +132,7 @@ func Test_SearchCasesNoResult(t *testing.T) {
 }
 
 func Test_SearchCases(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -149,7 +149,7 @@ func Test_SearchCases(t *testing.T) {
 }
 
 func Test_SearchCases_OnProbandOrganizationID(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -168,7 +168,7 @@ func Test_SearchCases_OnProbandOrganizationID(t *testing.T) {
 }
 
 func Test_SearchCases_OnPatientMRN(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -187,7 +187,7 @@ func Test_SearchCases_OnPatientMRN(t *testing.T) {
 }
 
 func Test_SearchCases_OnProbandID(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -206,7 +206,7 @@ func Test_SearchCases_OnProbandID(t *testing.T) {
 }
 
 func Test_SearchCases_OnPatientID(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -225,7 +225,7 @@ func Test_SearchCases_OnPatientID(t *testing.T) {
 }
 
 func Test_SearchCases_OnSequencingExperimentID(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -243,7 +243,7 @@ func Test_SearchCases_OnSequencingExperimentID(t *testing.T) {
 }
 
 func Test_SearchCases_OnResolutionStatusCode(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -270,7 +270,7 @@ func Test_SearchCases_OnResolutionStatusCode(t *testing.T) {
 }
 
 func Test_SearchCases_OnPrimaryConditionId(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -297,7 +297,7 @@ func Test_SearchCases_OnPrimaryConditionId(t *testing.T) {
 }
 
 func Test_SearchCases_OnPanelCode(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -313,7 +313,7 @@ func Test_SearchCases_OnPanelCode(t *testing.T) {
 }
 
 func Test_SearchCases_OnProbandLifeStatusCode(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -340,7 +340,7 @@ func Test_SearchCases_OnProbandLifeStatusCode(t *testing.T) {
 }
 
 func Test_SearchCases_OnCaseCategoryCode(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -367,7 +367,7 @@ func Test_SearchCases_OnCaseCategoryCode(t *testing.T) {
 }
 
 func Test_SearchCases_OnCaseTypeCode(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -394,7 +394,7 @@ func Test_SearchCases_OnCaseTypeCode(t *testing.T) {
 }
 
 func Test_Cases_SearchById(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		autocompleteResult, err := repo.SearchById("1", 5)
 		assert.NoError(t, err)
@@ -408,7 +408,7 @@ func Test_Cases_SearchById(t *testing.T) {
 }
 
 func Test_SearchById_CaseInsensitive(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		autocompleteResultLower, errLower := repo.SearchById("mrn", 5)
 		autocompleteResultUpper, errUpper := repo.SearchById("MRN", 5)
@@ -424,7 +424,7 @@ func Test_SearchById_CaseInsensitive(t *testing.T) {
 }
 
 func Test_GetCasesFilters(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		filters, err := repo.GetCasesFilters()
 		assert.NoError(t, err)
@@ -443,7 +443,7 @@ func Test_GetCasesFilters(t *testing.T) {
 }
 
 func Test_GetCaseEntity(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		caseEntity, err := repo.GetCaseEntity(1)
 		assert.NoError(t, err)
@@ -456,7 +456,7 @@ func Test_GetCaseEntity(t *testing.T) {
 }
 
 func Test_RetrieveCaseLevelData(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		caseEntity, err := repo.retrieveCaseLevelData(1)
 		assert.NoError(t, err)
@@ -487,7 +487,7 @@ func Test_RetrieveCaseLevelData(t *testing.T) {
 }
 
 func Test_RetrieveCaseSequencingExperiments_Germline(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		sequencingExperiments, err := repo.retrieveCaseSequencingExperiments(1)
 		assert.NoError(t, err)
@@ -528,7 +528,7 @@ func Test_RetrieveCaseSequencingExperiments_Germline(t *testing.T) {
 }
 
 func Test_RetrieveCaseSequencingExperiments_Somatic(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		sequencingExperiments, err := repo.retrieveCaseSequencingExperiments(71)
 		assert.NoError(t, err)
@@ -555,7 +555,7 @@ func Test_RetrieveCaseSequencingExperiments_Somatic(t *testing.T) {
 }
 
 func Test_RetrieveCasePatients(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		members, err := repo.retrieveCasePatients(1)
 		assert.NoError(t, err)
@@ -617,7 +617,7 @@ func Test_RetrieveCasePatients(t *testing.T) {
 }
 
 func Test_RetrieveCaseTasks(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		tasks, err := repo.retrieveCaseTasks(1)
 		assert.NoError(t, err)
@@ -641,7 +641,7 @@ func Test_RetrieveCaseTasks(t *testing.T) {
 }
 
 func Test_RetrieveCaseTasks_DeduplicatePatients(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 		tasks, err := repo.retrieveCaseTasks(71)
 		assert.NoError(t, err)
@@ -655,7 +655,7 @@ func Test_RetrieveCaseTasks_DeduplicatePatients(t *testing.T) {
 }
 
 func Test_CreateDuplicateSubmitterCaseId_Error(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 
 		diagLab := 6
@@ -690,7 +690,7 @@ func Test_CreateDuplicateSubmitterCaseId_Error(t *testing.T) {
 }
 
 func Test_CreateEmptySubmitterCaseId_Ok(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewCasesRepository(db)
 
 		diagLab := 6

--- a/backend/internal/repository/clinvar_rcv_test.go
+++ b/backend/internal/repository/clinvar_rcv_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_GetClinvarRCV(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "clinvar", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "clinvar", func(t *testing.T, db *gorm.DB) {
 		repo := NewClinvarRCVRepository(db)
 		clinvarRcv, err := repo.GetVariantClinvarConditions(1000)
 		assert.NoError(t, err)
@@ -25,7 +25,7 @@ func Test_GetClinvarRCV(t *testing.T) {
 }
 
 func Test_GetClinvarRCV_Empty(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "clinvar", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "clinvar", func(t *testing.T, db *gorm.DB) {
 		repo := NewClinvarRCVRepository(db)
 		clinvarRcv, err := repo.GetVariantClinvarConditions(42)
 		assert.NoError(t, err)

--- a/backend/internal/repository/documents_test.go
+++ b/backend/internal/repository/documents_test.go
@@ -26,7 +26,7 @@ var DocumentsQueryConfigForTest = types.QueryConfig{
 }
 
 func Test_SearchDocumentsNoFilters(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		query, err := types.NewListQueryFromCriteria(DocumentsQueryConfigForTest, allDocumentsFields, nil, nil, nil)
 		documents, count, err := repo.SearchDocuments(query)
@@ -55,7 +55,7 @@ func Test_SearchDocumentsNoFilters(t *testing.T) {
 }
 
 func Test_SearchDocumentsCustomSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		query, err := types.NewListQueryFromCriteria(DocumentsQueryConfigForTest, allDocumentsFields, nil, nil, []types.SortBody{{Field: types.DocumentNameField.Name, Order: "asc"}})
 		documents, count, err := repo.SearchDocuments(query)
@@ -69,7 +69,7 @@ func Test_SearchDocumentsCustomSort(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnDocumentId(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -89,7 +89,7 @@ func Test_SearchDocumentsFilterOnDocumentId(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnDocumentName(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -109,7 +109,7 @@ func Test_SearchDocumentsFilterOnDocumentName(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnRunName(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -129,7 +129,7 @@ func Test_SearchDocumentsFilterOnRunName(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnSampleId(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -149,7 +149,7 @@ func Test_SearchDocumentsFilterOnSampleId(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnPatientId(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -169,7 +169,7 @@ func Test_SearchDocumentsFilterOnPatientId(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnCaseId(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -189,7 +189,7 @@ func Test_SearchDocumentsFilterOnCaseId(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnSeqId(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -209,7 +209,7 @@ func Test_SearchDocumentsFilterOnSeqId(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnTaskId(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -229,7 +229,7 @@ func Test_SearchDocumentsFilterOnTaskId(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnProjectCode(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -249,7 +249,7 @@ func Test_SearchDocumentsFilterOnProjectCode(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnDiagnosisLabCode(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -269,7 +269,7 @@ func Test_SearchDocumentsFilterOnDiagnosisLabCode(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnRelationshipToProbandMother(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -289,7 +289,7 @@ func Test_SearchDocumentsFilterOnRelationshipToProbandMother(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnRelationshipToProbandFather(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -309,7 +309,7 @@ func Test_SearchDocumentsFilterOnRelationshipToProbandFather(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnRelationshipToProbandProband(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -329,7 +329,7 @@ func Test_SearchDocumentsFilterOnRelationshipToProbandProband(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnFormatCode(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -349,7 +349,7 @@ func Test_SearchDocumentsFilterOnFormatCode(t *testing.T) {
 }
 
 func Test_SearchDocumentsFilterOnDataTypeCode(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		searchCriteria := []types.SearchCriterion{
 			{
@@ -369,7 +369,7 @@ func Test_SearchDocumentsFilterOnDataTypeCode(t *testing.T) {
 }
 
 func Test_Documents_SearchById(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		autocompleteResult, err := repo.SearchById("1", 10)
 		assert.NoError(t, err)
@@ -398,7 +398,7 @@ func Test_Documents_SearchById(t *testing.T) {
 }
 
 func Test_GetDocumentsFilters_WithLabAndProject(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		filters, err := repo.GetDocumentsFilters(true)
 		assert.NoError(t, err)
@@ -411,7 +411,7 @@ func Test_GetDocumentsFilters_WithLabAndProject(t *testing.T) {
 }
 
 func Test_GetDocumentsFilters_WithoutLabAndProject(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		filters, err := repo.GetDocumentsFilters(false)
 		assert.NoError(t, err)
@@ -424,7 +424,7 @@ func Test_GetDocumentsFilters_WithoutLabAndProject(t *testing.T) {
 }
 
 func Test_GetById_Success(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		document, err := repo.GetById(264)
 		assert.NoError(t, err)
@@ -436,7 +436,7 @@ func Test_GetById_Success(t *testing.T) {
 }
 
 func Test_GetById_NotFound(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		document, err := repo.GetById(999999)
 		assert.NoError(t, err)
@@ -445,7 +445,7 @@ func Test_GetById_NotFound(t *testing.T) {
 }
 
 func Test_GetById_FilteredIndexFile(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewDocumentsRepository(db)
 		var indexDoc Document
 		db.Table("document doc").Where("doc.format_code IN ('crai', 'tbi')").First(&indexDoc)

--- a/backend/internal/repository/exomiser_test.go
+++ b/backend/internal/repository/exomiser_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_GetExomiser(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "exomiser", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "exomiser", func(t *testing.T, db *gorm.DB) {
 		repo := NewExomiserRepository(db)
 		expected := []types.Exomiser{
 			{
@@ -66,7 +66,7 @@ func Test_GetExomiser(t *testing.T) {
 }
 
 func Test_GetExomiser_Empty(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "exomiser", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "exomiser", func(t *testing.T, db *gorm.DB) {
 		repo := NewExomiserRepository(db)
 		exomiser, err := repo.GetExomiser(42)
 		assert.NoError(t, err)
@@ -75,7 +75,7 @@ func Test_GetExomiser_Empty(t *testing.T) {
 }
 
 func Test_GetExomiserACMGClassificationCounts(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "exomiser", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "exomiser", func(t *testing.T, db *gorm.DB) {
 		repo := NewExomiserRepository(db)
 		expected := map[string]int{"Pathogenic": 2, "VUS": 1}
 
@@ -86,7 +86,7 @@ func Test_GetExomiserACMGClassificationCounts(t *testing.T) {
 }
 
 func Test_GetExomiserACMGClassificationCounts_Empty(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "exomiser", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "exomiser", func(t *testing.T, db *gorm.DB) {
 		repo := NewExomiserRepository(db)
 		exomiser, err := repo.GetExomiserACMGClassificationCounts(42)
 		assert.NoError(t, err)

--- a/backend/internal/repository/family_history_test.go
+++ b/backend/internal/repository/family_history_test.go
@@ -32,7 +32,7 @@ func Test_GetFamilyHistoryById_NotFound(t *testing.T) {
 }
 
 func Test_CreateFamilyHistory_OK(t *testing.T) {
-	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newFamilyHistory := &types.FamilyHistory{
 			ID:               9999,
 			CaseID:           1,

--- a/backend/internal/repository/family_history_test.go
+++ b/backend/internal/repository/family_history_test.go
@@ -32,7 +32,7 @@ func Test_GetFamilyHistoryById_NotFound(t *testing.T) {
 }
 
 func Test_CreateFamilyHistory_OK(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newFamilyHistory := &types.FamilyHistory{
 			ID:               9999,
 			CaseID:           1,

--- a/backend/internal/repository/family_history_test.go
+++ b/backend/internal/repository/family_history_test.go
@@ -32,7 +32,7 @@ func Test_GetFamilyHistoryById_NotFound(t *testing.T) {
 }
 
 func Test_CreateFamilyHistory_OK(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newFamilyHistory := &types.FamilyHistory{
 			ID:               9999,
 			CaseID:           1,

--- a/backend/internal/repository/family_test.go
+++ b/backend/internal/repository/family_test.go
@@ -37,7 +37,7 @@ func Test_GetFamilyById_NotFound(t *testing.T) {
 }
 
 func Test_CreateFamily_OK(t *testing.T) {
-	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newFamily := &types.Family{
 			ID:                        999,
 			CaseID:                    1,

--- a/backend/internal/repository/family_test.go
+++ b/backend/internal/repository/family_test.go
@@ -37,7 +37,7 @@ func Test_GetFamilyById_NotFound(t *testing.T) {
 }
 
 func Test_CreateFamily_OK(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newFamily := &types.Family{
 			ID:                        999,
 			CaseID:                    1,

--- a/backend/internal/repository/family_test.go
+++ b/backend/internal/repository/family_test.go
@@ -37,7 +37,7 @@ func Test_GetFamilyById_NotFound(t *testing.T) {
 }
 
 func Test_CreateFamily_OK(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newFamily := &types.Family{
 			ID:                        999,
 			CaseID:                    1,

--- a/backend/internal/repository/gene_panels_test.go
+++ b/backend/internal/repository/gene_panels_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_GetVariantGenePanelConditions_Omim(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenePanelsRepository(db)
 		result, err := repo.GetVariantGenePanelConditions("omim", 1000, "")
 		assert.NoError(t, err)
@@ -22,7 +22,7 @@ func Test_GetVariantGenePanelConditions_Omim(t *testing.T) {
 }
 
 func Test_GetVariantGenePanelConditions_Omim_WithFilter(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenePanelsRepository(db)
 		result, err := repo.GetVariantGenePanelConditions("omim", 1000, "2")
 		assert.NoError(t, err)
@@ -36,7 +36,7 @@ func Test_GetVariantGenePanelConditions_Omim_WithFilter(t *testing.T) {
 }
 
 func Test_GetVariantGenePanelConditions_Hpo(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenePanelsRepository(db)
 		result, err := repo.GetVariantGenePanelConditions("hpo", 1000, "")
 		assert.NoError(t, err)
@@ -50,7 +50,7 @@ func Test_GetVariantGenePanelConditions_Hpo(t *testing.T) {
 }
 
 func Test_GetVariantGenePanelConditions_Hpo_WithFilter(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenePanelsRepository(db)
 		result, err := repo.GetVariantGenePanelConditions("hpo", 1000, "Canthus")
 		assert.NoError(t, err)
@@ -64,7 +64,7 @@ func Test_GetVariantGenePanelConditions_Hpo_WithFilter(t *testing.T) {
 }
 
 func Test_GetVariantGenePanelConditions_Orphanet(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenePanelsRepository(db)
 		result, err := repo.GetVariantGenePanelConditions("orphanet", 1000, "")
 		assert.NoError(t, err)
@@ -78,7 +78,7 @@ func Test_GetVariantGenePanelConditions_Orphanet(t *testing.T) {
 }
 
 func Test_GetVariantGenePanelConditions_Orphanet_WithFilter(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenePanelsRepository(db)
 		result, err := repo.GetVariantGenePanelConditions("orphanet", 1000, "1")
 		assert.NoError(t, err)
@@ -92,7 +92,7 @@ func Test_GetVariantGenePanelConditions_Orphanet_WithFilter(t *testing.T) {
 }
 
 func Test_GetVariantGenePanelConditions_InvalidTable(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenePanelsRepository(db)
 		result, err := repo.GetVariantGenePanelConditions("invalid_table", 1000, "")
 		assert.Error(t, err)

--- a/backend/internal/repository/genes_test.go
+++ b/backend/internal/repository/genes_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_GetGeneAutoComplete(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenesRepository(db)
 		genes, err := repo.GetGeneAutoComplete("F", 10)
 		assert.NoError(t, err)
@@ -25,7 +25,7 @@ func Test_GetGeneAutoComplete(t *testing.T) {
 }
 
 func Test_GetGeneAutoComplete_FindOnGeneId(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenesRepository(db)
 		genes, err := repo.GetGeneAutoComplete("ENSG000000004", 10)
 		assert.NoError(t, err)
@@ -37,7 +37,7 @@ func Test_GetGeneAutoComplete_FindOnGeneId(t *testing.T) {
 }
 
 func Test_GetGeneAutoComplete_FindOnNameFirst(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenesRepository(db)
 		genes, err := repo.GetGeneAutoComplete("ENS", 10)
 		assert.NoError(t, err)
@@ -49,7 +49,7 @@ func Test_GetGeneAutoComplete_FindOnNameFirst(t *testing.T) {
 }
 
 func Test_GetGeneAutoComplete_FindOnAlias(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenesRepository(db)
 		genes, err := repo.GetGeneAutoComplete("HF", 10)
 		assert.NoError(t, err)
@@ -59,7 +59,7 @@ func Test_GetGeneAutoComplete_FindOnAlias(t *testing.T) {
 }
 
 func Test_GetGeneAutoComplete_WithLimit(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenesRepository(db)
 		genes, err := repo.GetGeneAutoComplete("F", 1)
 		assert.NoError(t, err)
@@ -72,7 +72,7 @@ func Test_GetGeneAutoComplete_WithLimit(t *testing.T) {
 }
 
 func Test_GetGeneAutoComplete_NoResult(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenesRepository(db)
 		genes, err := repo.GetGeneAutoComplete("not_here", 20)
 		assert.NoError(t, err)
@@ -81,7 +81,7 @@ func Test_GetGeneAutoComplete_NoResult(t *testing.T) {
 }
 
 func Test_SearchGenes(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenesRepository(db)
 		genes, err := repo.SearchGenes([]string{"ENSG00000000003", "TNMD", "ensg00000157764", "ensa", "ENSG000000011671111", "BAD_SYMBOL"})
 		assert.NoError(t, err)
@@ -94,7 +94,7 @@ func Test_SearchGenes(t *testing.T) {
 }
 
 func Test_SearchGenes_NoResult(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenesRepository(db)
 		genes, err := repo.SearchGenes([]string{"ENSG000000011671111", "BAD_SYMBOL"})
 		assert.NoError(t, err)
@@ -103,7 +103,7 @@ func Test_SearchGenes_NoResult(t *testing.T) {
 }
 
 func Test_SearchGenes_NoInput(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenesRepository(db)
 		genes, err := repo.SearchGenes([]string{})
 		assert.NoError(t, err)

--- a/backend/internal/repository/germline_cnv_occurrences_test.go
+++ b/backend/internal/repository/germline_cnv_occurrences_test.go
@@ -27,7 +27,7 @@ var GermlineCnvQueryConfigForTest = types.QueryConfig{
 }
 
 func Test_GermlineCNV_GetOccurrences(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 		query, err := types.NewListQueryFromSqon(GermlineCnvQueryConfigForTest, allGermlineCnvFields, nil, nil, nil)
 		assert.NoError(t, err)
@@ -42,7 +42,7 @@ func Test_GermlineCNV_GetOccurrences(t *testing.T) {
 }
 
 func Test_GermlineCNV_GetOccurrences_HasNote_False_When_Note_Is_Deleted(t *testing.T) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.SequentialTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(starrocks)
 		notesRepo := NewOccurrenceNotesRepository(postgres)
 
@@ -78,7 +78,7 @@ func Test_GermlineCNV_GetOccurrences_HasNote_False_When_Note_Is_Deleted(t *testi
 }
 
 func Test_GermlineCNV_GetOccurrences_QualityFilter(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 
 		sqon := &types.Sqon{
@@ -101,7 +101,7 @@ func Test_GermlineCNV_GetOccurrences_QualityFilter(t *testing.T) {
 }
 
 func Test_GermlineCNV_GetOccurrences_PanelFilter(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 
 		sqon := &types.Sqon{
@@ -124,7 +124,7 @@ func Test_GermlineCNV_GetOccurrences_PanelFilter(t *testing.T) {
 }
 
 func Test_GermlineCNV_GetOccurrences_PaginationAndSorting(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 
 		sortedBody := []types.SortBody{
@@ -167,7 +167,7 @@ func Test_GermlineCNV_GetOccurrences_PaginationAndSorting(t *testing.T) {
 }
 
 func Test_GermlineCNV_CountOccurrences(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 		query, err := types.NewListQueryFromSqon(GermlineCnvQueryConfigForTest, allGermlineCnvFields, nil, nil, nil)
 		assert.NoError(t, err)
@@ -178,7 +178,7 @@ func Test_GermlineCNV_CountOccurrences(t *testing.T) {
 }
 
 func Test_GermlineCNV_CountOccurrences_With_Filtering(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 
 		sqon := &types.Sqon{
@@ -197,7 +197,7 @@ func Test_GermlineCNV_CountOccurrences_With_Filtering(t *testing.T) {
 }
 
 func Test_GermlineCNV_CountOccurrences_PanelFilter(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 
 		sqon := &types.Sqon{
@@ -216,7 +216,7 @@ func Test_GermlineCNV_CountOccurrences_PanelFilter(t *testing.T) {
 }
 
 func Test_GermlineCNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By_Gene_Panel(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 		query, err := types.NewAggregationQueryFromSqon("omim_gene_panel", nil, GermlineCnvQueryConfigForTest.AllFields)
 		assert.NoError(t, err)
@@ -236,7 +236,7 @@ func Test_GermlineCNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By
 }
 
 func Test_GermlineCNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By_Cytoband(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 		query, err := types.NewAggregationQueryFromSqon("cytoband", nil, GermlineCnvQueryConfigForTest.AllFields)
 		assert.NoError(t, err)
@@ -252,7 +252,7 @@ func Test_GermlineCNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By
 }
 
 func Test_GermlineCNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By_Cytoband_Filter_By_Panel(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: types.SqonArray{
@@ -275,7 +275,7 @@ func Test_GermlineCNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By
 }
 
 func Test_GermlineCNV_GetStatisticsOccurrences_Length(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 		query, err := types.NewStatisticsQueryFromSqon("length", nil, types.GermlineCNVOccurrencesFields)
 		assert.NoError(t, err)
@@ -288,7 +288,7 @@ func Test_GermlineCNV_GetStatisticsOccurrences_Length(t *testing.T) {
 }
 
 func Test_GermlineCNV_GetStatisticsOccurrences_Pe(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 		query, err := types.NewStatisticsQueryFromSqon("pe", nil, types.GermlineCNVOccurrencesFields)
 		assert.NoError(t, err)
@@ -301,7 +301,7 @@ func Test_GermlineCNV_GetStatisticsOccurrences_Pe(t *testing.T) {
 }
 
 func Test_GermlineCNV_GetGenesOverlap(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineCNVOccurrencesRepository(db)
 		overlaps, err := repo.GetGenesOverlap(1, 1, 1)
 		if assert.NoError(t, err) {

--- a/backend/internal/repository/germline_snv_occurrences_test.go
+++ b/backend/internal/repository/germline_snv_occurrences_test.go
@@ -27,7 +27,7 @@ var GermlineSNVQueryConfigForTest = types.QueryConfig{
 }
 
 func Test_Germline_SNV_GetOccurrences(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		query, err := types.NewListQueryFromSqon(GermlineSNVQueryConfigForTest, allGermlineSNVFields, nil, nil, nil)
 		assert.NoError(t, err)
@@ -50,7 +50,7 @@ func Test_Germline_SNV_GetOccurrences(t *testing.T) {
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_Selected_Columns_Only(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		selectedFields := []string{"seq_id", "locus_id", "ad_ratio", "filter"}
 
@@ -68,7 +68,7 @@ func Test_Germline_SNV_GetOccurrences_Return_Selected_Columns_Only(t *testing.T)
 }
 
 func Test_Germline_SNV_GetOccurrencesReturn_Default_Column_If_No_One_Specified(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		query, err := types.NewListQueryFromSqon(GermlineSNVQueryConfigForTest, nil, nil, nil, nil)
@@ -85,7 +85,7 @@ func Test_Germline_SNV_GetOccurrencesReturn_Default_Column_If_No_One_Specified(t
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_A_Proper_Array_Column(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "clinvar", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "clinvar", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		selectedFields := []string{"clinvar"}
 		sort := []types.SortBody{
@@ -104,7 +104,7 @@ func Test_Germline_SNV_GetOccurrences_Return_A_Proper_Array_Column(t *testing.T)
 }
 
 func Test_Germline_SNV_CountOccurrences(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		count, err := repo.CountOccurrences(1, 1, nil)
 		assert.NoError(t, err)
@@ -113,7 +113,7 @@ func Test_Germline_SNV_CountOccurrences(t *testing.T) {
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_When_Filter_By_Exomiser_Gene_Combined_Score(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: types.SqonArray{
@@ -139,7 +139,7 @@ func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_When_Filter_By_Exo
 }
 
 func Test_Germline_SNV_CountOccurrences_Return_Count_That_Match_Filters(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
@@ -161,7 +161,7 @@ func Test_Germline_SNV_CountOccurrences_Return_Count_That_Match_Filters(t *testi
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_Occurrences_That_Match_Filters(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
@@ -190,7 +190,7 @@ func Test_Germline_SNV_GetOccurrences_Return_Occurrences_That_Match_Filters(t *t
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_Matching_Array(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "clinvar", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "clinvar", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: &types.LeafContent{
@@ -221,7 +221,7 @@ func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_Matching_Array(t *
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_Matching_Array_When_All(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "clinvar", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "clinvar", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: &types.LeafContent{
@@ -250,7 +250,7 @@ func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_Matching_Array_Whe
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_N_Occurrences_When_Limit_Specified(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "pagination", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "pagination", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewGermlineSNVOccurrencesRepository(db)
 
@@ -267,7 +267,7 @@ func Test_Germline_SNV_GetOccurrences_Return_N_Occurrences_When_Limit_Specified(
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_Expected_Occurrences_When_Limit_And_Offset_Specified(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "pagination", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "pagination", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewGermlineSNVOccurrencesRepository(db)
 
@@ -294,7 +294,7 @@ func Test_Germline_SNV_GetOccurrences_Return_Expected_Occurrences_When_Limit_And
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_Expected_Occurrences_When_Limit_And_PageIndex_Specified(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "pagination", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "pagination", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewGermlineSNVOccurrencesRepository(db)
 
@@ -321,7 +321,7 @@ func Test_Germline_SNV_GetOccurrences_Return_Expected_Occurrences_When_Limit_And
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_Expected_Occurrences_When_Filter_By_Impact_Score(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "consequence", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "consequence", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
@@ -351,7 +351,7 @@ func Test_Germline_SNV_GetOccurrences_Return_Expected_Occurrences_When_Filter_By
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_Expected_Occurrences_When_Filter_By_Impact_ScoreAnd_Quality(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "consequence", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "consequence", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
@@ -379,7 +379,7 @@ func Test_Germline_SNV_GetOccurrences_Return_Expected_Occurrences_When_Filter_By
 }
 
 func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By_Zygosity(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "aggregation", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "aggregation", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		query, err := types.NewAggregationQueryFromSqon("zygosity", nil, types.GermlineSNVOccurrencesFields)
 		assert.NoError(t, err)
@@ -395,7 +395,7 @@ func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_B
 }
 
 func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By_Zygosity_With_Filter(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "aggregation", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "aggregation", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: types.LeafContent{
@@ -418,7 +418,7 @@ func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_B
 }
 
 func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By_Zygosity_With_Filter_But_Ignore_Self_Filter(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "aggregation", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "aggregation", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: types.SqonArray{
@@ -441,7 +441,7 @@ func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_B
 }
 
 func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By_Clinvar(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "clinvar", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "clinvar", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		query, err := types.NewAggregationQueryFromSqon("clinvar", nil, types.GermlineSNVOccurrencesFields)
 		assert.NoError(t, err)
@@ -459,7 +459,7 @@ func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_B
 }
 
 func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By_Impact_Score(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "consequence", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "consequence", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		query, err := types.NewAggregationQueryFromSqon("impact_score", nil, types.GermlineSNVOccurrencesFields)
 		assert.NoError(t, err)
@@ -478,7 +478,7 @@ func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_B
 }
 
 func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By_Impact_Score_Combined_With_Filter(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "consequence", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "consequence", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: types.SqonArray{
@@ -504,7 +504,7 @@ func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_B
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_Matching_Gene_panel(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: types.LeafContent{
@@ -533,7 +533,7 @@ func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_Matching_Gene_pane
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_Matching_Gene_panel_And_Impact_Score(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: types.SqonArray{
@@ -560,7 +560,7 @@ func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_Matching_Gene_pane
 }
 
 func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_Matching_Multiple_Gene_panel_And_Impact_Score(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: types.SqonArray{
@@ -587,7 +587,7 @@ func Test_Germline_SNV_GetOccurrences_Return_List_Occurrences_Matching_Multiple_
 }
 
 func Test_Germline_SNV_CountOccurrences_Return_Number_Occurrences_Matching_Multiple_Gene_panel_And_Impact_Score(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
 			Content: types.SqonArray{
@@ -607,7 +607,7 @@ func Test_Germline_SNV_CountOccurrences_Return_Number_Occurrences_Matching_Multi
 }
 
 func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_By_Gene_Panel(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "gene_panels", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		query, err := types.NewAggregationQueryFromSqon("omim_gene_panel", nil, types.GermlineSNVOccurrencesFields)
 		assert.NoError(t, err)
@@ -628,7 +628,7 @@ func Test_Germline_SNV_AggregateOccurrences_Return_Expected_Aggregate_When_Agg_B
 }
 
 func Test_Germline_SNV_GetStatisticsOccurrences_Decimal(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "pagination", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "pagination", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		query, err := types.NewStatisticsQueryFromSqon("germline_pf_wgs", nil, types.GermlineSNVOccurrencesFields)
 		assert.NoError(t, err)
@@ -641,7 +641,7 @@ func Test_Germline_SNV_GetStatisticsOccurrences_Decimal(t *testing.T) {
 }
 
 func Test_Germline_SNV_GetStatisticsOccurrences_Integer(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "pagination", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "pagination", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		query, err := types.NewStatisticsQueryFromSqon("germline_pc_wgs", nil, types.GermlineSNVOccurrencesFields)
 		assert.NoError(t, err)
@@ -654,14 +654,14 @@ func Test_Germline_SNV_GetStatisticsOccurrences_Integer(t *testing.T) {
 }
 
 func Test_Germline_SNV_GetStatisticsOccurrences_Non_Numeric_Field(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "pagination", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "pagination", func(t *testing.T, db *gorm.DB) {
 		_, err := types.NewStatisticsQueryFromSqon("hgvsg", nil, types.GermlineSNVOccurrencesFields)
 		assert.Error(t, err)
 	})
 }
 
 func Test_Germline_SNV_GetExpandedOccurrence(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		expandedOccurrence, err := repo.GetExpandedOccurrence(1, 1, 1000)
 		assert.NoError(t, err)
@@ -689,7 +689,7 @@ func Test_Germline_SNV_GetExpandedOccurrence(t *testing.T) {
 }
 
 func Test_Germline_SNV_GetOccurrences_HasNote_False_When_Note_Is_Deleted(t *testing.T) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.SequentialTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(starrocks)
 		notesRepo := NewOccurrenceNotesRepository(postgres)
 

--- a/backend/internal/repository/igv_test.go
+++ b/backend/internal/repository/igv_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_IGVInternal_GetIGV(t *testing.T) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB) {
 		repo := NewIGVRepository(starrocks)
 		igvInternal, err := repo.GetIGV(70)
 		assert.NoError(t, err)

--- a/backend/internal/repository/interpretations_test.go
+++ b/backend/internal/repository/interpretations_test.go
@@ -53,7 +53,7 @@ func Test_Interpretations_FirstGermline_NotFound(t *testing.T) {
 }
 
 func Test_Interpretations_CreateOrUpdateGermline_Create(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := newTestInterpretationsRepo(db)
 		interpretation := &types.InterpretationGermline{
 			InterpretationCommon: types.InterpretationCommon{
@@ -83,7 +83,7 @@ func Test_Interpretations_CreateOrUpdateGermline_Create(t *testing.T) {
 }
 
 func Test_Interpretations_CreateOrUpdateGermline_Update(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := newTestInterpretationsRepo(db)
 
 		// Create a fresh record (not fixture) to update
@@ -178,7 +178,7 @@ func Test_Interpretations_FirstSomatic_NotFound(t *testing.T) {
 }
 
 func Test_Interpretations_CreateOrUpdateSomatic_Create(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := newTestInterpretationsRepo(db)
 		interpretation := &types.InterpretationSomatic{
 			InterpretationCommon: types.InterpretationCommon{
@@ -208,7 +208,7 @@ func Test_Interpretations_CreateOrUpdateSomatic_Create(t *testing.T) {
 }
 
 func Test_Interpretations_CreateOrUpdateSomatic_Update(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := newTestInterpretationsRepo(db)
 
 		interpretation := &types.InterpretationSomatic{

--- a/backend/internal/repository/obs_categorical_test.go
+++ b/backend/internal/repository/obs_categorical_test.go
@@ -36,7 +36,7 @@ func Test_GetObservationCategoricalById_NotFound(t *testing.T) {
 }
 
 func Test_CreateObservationCategorical_OK(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newObs := &types.ObsCategorical{
 			ID:                 9999,
 			CaseID:             1,

--- a/backend/internal/repository/obs_categorical_test.go
+++ b/backend/internal/repository/obs_categorical_test.go
@@ -36,7 +36,7 @@ func Test_GetObservationCategoricalById_NotFound(t *testing.T) {
 }
 
 func Test_CreateObservationCategorical_OK(t *testing.T) {
-	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newObs := &types.ObsCategorical{
 			ID:                 9999,
 			CaseID:             1,

--- a/backend/internal/repository/obs_categorical_test.go
+++ b/backend/internal/repository/obs_categorical_test.go
@@ -36,7 +36,7 @@ func Test_GetObservationCategoricalById_NotFound(t *testing.T) {
 }
 
 func Test_CreateObservationCategorical_OK(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newObs := &types.ObsCategorical{
 			ID:                 9999,
 			CaseID:             1,

--- a/backend/internal/repository/obs_string_test.go
+++ b/backend/internal/repository/obs_string_test.go
@@ -32,7 +32,7 @@ func Test_GetObservationStringById_NotFound(t *testing.T) {
 }
 
 func Test_CreateObservationString_OK(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newObs := &types.ObsString{
 			ID:              9999,
 			CaseID:          1,

--- a/backend/internal/repository/obs_string_test.go
+++ b/backend/internal/repository/obs_string_test.go
@@ -32,7 +32,7 @@ func Test_GetObservationStringById_NotFound(t *testing.T) {
 }
 
 func Test_CreateObservationString_OK(t *testing.T) {
-	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newObs := &types.ObsString{
 			ID:              9999,
 			CaseID:          1,

--- a/backend/internal/repository/obs_string_test.go
+++ b/backend/internal/repository/obs_string_test.go
@@ -32,7 +32,7 @@ func Test_GetObservationStringById_NotFound(t *testing.T) {
 }
 
 func Test_CreateObservationString_OK(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		newObs := &types.ObsString{
 			ID:              9999,
 			CaseID:          1,

--- a/backend/internal/repository/occurrence_notes_test.go
+++ b/backend/internal/repository/occurrence_notes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_CreateOccurrenceNote(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)
 		note := types.OccurrenceNote{
 			CaseID:       2,
@@ -41,7 +41,7 @@ func Test_CreateOccurrenceNote(t *testing.T) {
 }
 
 func Test_GetByOccurrence(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)
 
 		note1 := types.OccurrenceNote{
@@ -79,7 +79,7 @@ func Test_GetByOccurrence(t *testing.T) {
 }
 
 func Test_GetByOccurrence_EmptyResult(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)
 
 		notes, err := repo.GetByOccurrence(1, 1, 1, "99999")
@@ -90,7 +90,7 @@ func Test_GetByOccurrence_EmptyResult(t *testing.T) {
 }
 
 func Test_GetByID(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)
 		note := types.OccurrenceNote{
 			CaseID:       2,
@@ -115,7 +115,7 @@ func Test_GetByID(t *testing.T) {
 }
 
 func Test_GetByID_NotFound(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)
 
 		found, err := repo.GetByID("00000000-0000-0000-0000-000000000000")
@@ -126,7 +126,7 @@ func Test_GetByID_NotFound(t *testing.T) {
 }
 
 func Test_UpdateOccurrenceNote(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)
 		note := types.OccurrenceNote{
 			CaseID:       2,
@@ -152,7 +152,7 @@ func Test_UpdateOccurrenceNote(t *testing.T) {
 }
 
 func Test_DeleteOccurrenceNote(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)
 		note := types.OccurrenceNote{
 			CaseID:       2,
@@ -176,7 +176,7 @@ func Test_DeleteOccurrenceNote(t *testing.T) {
 }
 
 func Test_CountByOccurrence(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)
 
 		_, err := repo.Create(types.OccurrenceNote{CaseID: 2, SeqID: 1, TaskID: 1, OccurrenceID: "10000", UserID: "11111111-1111-1111-1111-111111111111", UserName: "John Doe", Content: "Note 1"})
@@ -192,7 +192,7 @@ func Test_CountByOccurrence(t *testing.T) {
 }
 
 func Test_CountByOccurrence_IgnoresDeletedNotes(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)
 
 		created, err := repo.Create(types.OccurrenceNote{CaseID: 2, SeqID: 1, TaskID: 1, OccurrenceID: "10000", UserID: "11111111-1111-1111-1111-111111111111", UserName: "John Doe", Content: "Deleted note"})
@@ -207,7 +207,7 @@ func Test_CountByOccurrence_IgnoresDeletedNotes(t *testing.T) {
 }
 
 func Test_GetByOccurrence_IgnoresDeletedNotes(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)
 
 		note := types.OccurrenceNote{

--- a/backend/internal/repository/saved_filters_test.go
+++ b/backend/internal/repository/saved_filters_test.go
@@ -79,7 +79,7 @@ func Test_GetSavedFiltersByUserID_NotFound(t *testing.T) {
 }
 
 func Test_CreateSavedFilter(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewSavedFiltersRepository(db)
 		savedFilterInput := types.SavedFilterCreationInput{
 			Name: "new_saved_filter_somatic_snv_occurrence",
@@ -115,7 +115,7 @@ func Test_CreateSavedFilter(t *testing.T) {
 }
 
 func Test_CreateSavedFilter_ErrorUniqueConstraint(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewSavedFiltersRepository(db)
 		savedFilterInput := types.SavedFilterCreationInput{
 			Name: "new_saved_filter_somatic_snv_occurrence_1",
@@ -147,7 +147,7 @@ func Test_CreateSavedFilter_ErrorUniqueConstraint(t *testing.T) {
 }
 
 func Test_UpdateSavedFilter(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewSavedFiltersRepository(db)
 		savedFilterCreationInput := types.SavedFilterCreationInput{
 			Name: "new_saved_filter_somatic_snv_occurrence_2",
@@ -203,7 +203,7 @@ func Test_UpdateSavedFilter(t *testing.T) {
 }
 
 func Test_UpdateSavedFilter_ErrorUniqueConstraint(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewSavedFiltersRepository(db)
 		savedFilterCreationInput := types.SavedFilterCreationInput{
 			Name:    "new_saved_filter_somatic_snv_occurrence",
@@ -236,7 +236,7 @@ func Test_UpdateSavedFilter_ErrorUniqueConstraint(t *testing.T) {
 }
 
 func Test_DeleteSavedFilter(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewSavedFiltersRepository(db)
 		savedFilterCreationInput := types.SavedFilterCreationInput{
 			Name:    "new_saved_filter_somatic_snv_occurrence",

--- a/backend/internal/repository/sequencing_experiment_test.go
+++ b/backend/internal/repository/sequencing_experiment_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_GetSequencingExperimentDetailById(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewSequencingExperimentRepository(db)
 		sequencingExperiment, err := repo.GetSequencingExperimentDetailById(1)
 		assert.NoError(t, err)

--- a/backend/internal/repository/sequencing_test.go
+++ b/backend/internal/repository/sequencing_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_GetSequencing(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewSequencingRepository(db)
 		sequencing, err := repo.GetSequencing(1)
 		assert.NoError(t, err)
@@ -20,7 +20,7 @@ func Test_GetSequencing(t *testing.T) {
 }
 
 func Test_GetSequencingNotFound(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewSequencingRepository(db)
 		sequencing, err := repo.GetSequencing(11)
 		assert.NoError(t, err)

--- a/backend/internal/repository/somatic_snv_occurrences_test.go
+++ b/backend/internal/repository/somatic_snv_occurrences_test.go
@@ -26,7 +26,7 @@ var SomaticSNVQueryConfigForTest = types.QueryConfig{
 }
 
 func Test_Somatic_SNV_GetOccurrences(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewSomaticSNVOccurrencesRepository(db)
 		query, err := types.NewListQueryFromSqon(SomaticSNVQueryConfigForTest, allSomaticSNVFields, nil, nil, nil)
 		assert.NoError(t, err)
@@ -62,7 +62,7 @@ func Test_Somatic_SNV_GetOccurrences(t *testing.T) {
 }
 
 func Test_Somatic_SNV_GetOccurrences_Return_Selected_Columns_Only(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewSomaticSNVOccurrencesRepository(db)
 		selectedFields := []string{"seq_id", "locus_id", "ad_ratio", "symbol"}
 
@@ -80,7 +80,7 @@ func Test_Somatic_SNV_GetOccurrences_Return_Selected_Columns_Only(t *testing.T) 
 }
 
 func Test_Somatic_SNV_GetOccurrences_Return_Default_Column_If_No_One_Specified(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewSomaticSNVOccurrencesRepository(db)
 		query, err := types.NewListQueryFromSqon(SomaticSNVQueryConfigForTest, nil, nil, nil, nil)
@@ -97,7 +97,7 @@ func Test_Somatic_SNV_GetOccurrences_Return_Default_Column_If_No_One_Specified(t
 }
 
 func Test_Somatic_SNV_GetOccurrences_Return_A_Proper_Array_Column(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewSomaticSNVOccurrencesRepository(db)
 		selectedFields := []string{"clinvar"}
 		query, err := types.NewListQueryFromSqon(SomaticSNVQueryConfigForTest, selectedFields, nil, nil, nil)
@@ -112,7 +112,7 @@ func Test_Somatic_SNV_GetOccurrences_Return_A_Proper_Array_Column(t *testing.T) 
 }
 
 func Test_Somatic_SNV_GetOccurrences_Return_Occurrences_That_Match_Filters(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "multiple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewSomaticSNVOccurrencesRepository(db)
 		sqon := &types.Sqon{
@@ -134,7 +134,7 @@ func Test_Somatic_SNV_GetOccurrences_Return_Occurrences_That_Match_Filters(t *te
 }
 
 func Test_Somatic_SNV_GetOccurrences_HasNote_False_When_Note_Is_Deleted(t *testing.T) {
-	testutils.ParallelTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+	testutils.SequentialTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
 		repo := NewSomaticSNVOccurrencesRepository(starrocks)
 		notesRepo := NewOccurrenceNotesRepository(postgres)
 
@@ -170,7 +170,7 @@ func Test_Somatic_SNV_GetOccurrences_HasNote_False_When_Note_Is_Deleted(t *testi
 }
 
 func Test_Somatic_SNV_GetOccurrences_Return_Expected_Occurrences_When_Limit_And_Offset_Specified(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "pagination", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "pagination", func(t *testing.T, db *gorm.DB) {
 
 		repo := NewSomaticSNVOccurrencesRepository(db)
 
@@ -197,7 +197,7 @@ func Test_Somatic_SNV_GetOccurrences_Return_Expected_Occurrences_When_Limit_And_
 }
 
 func Test_Somatic_SNV_GetExpandedOccurrence(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewSomaticSNVOccurrencesRepository(db)
 		expandedOccurrence, err := repo.GetExpandedOccurrence(71, 74, 1000)
 		assert.NoError(t, err)

--- a/backend/internal/repository/starrocks_repository_test.go
+++ b/backend/internal/repository/starrocks_repository_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_CheckDatabaseConnection_Return_up(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewStarrocksRepository(db)
 		status := repo.CheckDatabaseConnection()
 		assert.Equal(t, "up", status)

--- a/backend/internal/repository/starrocks_repository_test.go
+++ b/backend/internal/repository/starrocks_repository_test.go
@@ -15,7 +15,22 @@ func Test_CheckDatabaseConnection_Return_up(t *testing.T) {
 		repo := NewStarrocksRepository(db)
 		status := repo.CheckDatabaseConnection()
 		assert.Equal(t, "up", status)
+	})
+}
 
+func Test_StarrocksReadOnlyGuard_RejectsCreate(t *testing.T) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
+		err := db.Exec("INSERT INTO ensembl_gene (gene_id, name) VALUES ('TEST', 'TEST')").Error
+		assert.ErrorIs(t, err, testutils.ErrStarrocksReadOnly)
+	})
+}
+
+func Test_StarrocksReadOnlyGuard_AllowsRead(t *testing.T) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
+		var count int64
+		err := db.Table("ensembl_gene").Count(&count).Error
+		assert.NoError(t, err)
+		assert.Greater(t, count, int64(0))
 	})
 }
 

--- a/backend/internal/repository/task_test.go
+++ b/backend/internal/repository/task_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_CreateAndGetTask_OK(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewTaskRepository(db)
 
 		newTask := &types.Task{
@@ -56,7 +56,7 @@ func Test_GetTaskById_NotFound(t *testing.T) {
 }
 
 func Test_CreateAndGetTaskContext_OK(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewTaskRepository(db)
 
 		se := 72
@@ -99,7 +99,7 @@ func Test_GetTaskContextByTaskId_NotFound(t *testing.T) {
 }
 
 func Test_CreateAndGetTaskHasDocument_OK(t *testing.T) {
-	testutils.SequentialPostgresTestWithDb(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewTaskRepository(db)
 
 		doc := &types.TaskHasDocument{

--- a/backend/internal/repository/task_test.go
+++ b/backend/internal/repository/task_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_CreateAndGetTask_OK(t *testing.T) {
-	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewTaskRepository(db)
 
 		newTask := &types.Task{

--- a/backend/internal/repository/task_test.go
+++ b/backend/internal/repository/task_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_CreateAndGetTask_OK(t *testing.T) {
-	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewTaskRepository(db)
 
 		newTask := &types.Task{

--- a/backend/internal/repository/terms_test.go
+++ b/backend/internal/repository/terms_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_GetTermAutoComplete(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewTermsRepository(db)
 		terms, err := repo.GetTermAutoComplete(types.MondoTable.Name, "blood", 20)
 		assert.NoError(t, err)
@@ -25,7 +25,7 @@ func Test_GetTermAutoComplete(t *testing.T) {
 }
 
 func Test_GetTermAutoCompleteWithLimit(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewTermsRepository(db)
 		terms, err := repo.GetTermAutoComplete(types.MondoTable.Name, "blood", 1)
 		assert.NoError(t, err)
@@ -38,7 +38,7 @@ func Test_GetTermAutoCompleteWithLimit(t *testing.T) {
 }
 
 func Test_GetTermAutoCompleteNoResult(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewTermsRepository(db)
 		terms, err := repo.GetTermAutoComplete(types.MondoTable.Name, "not_here", 20)
 		assert.NoError(t, err)
@@ -47,7 +47,7 @@ func Test_GetTermAutoCompleteNoResult(t *testing.T) {
 }
 
 func Test_GetTermNameById(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewTermsRepository(db)
 		term, err := repo.GetTermNameById(types.MondoTable.Name, "MONDO:0000003")
 		assert.NoError(t, err)
@@ -56,7 +56,7 @@ func Test_GetTermNameById(t *testing.T) {
 }
 
 func Test_GetTermNameByIdNoResult(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewTermsRepository(db)
 		term, err := repo.GetTermNameById(types.MondoTable.Name, "MONDO:not_existing")
 		assert.NoError(t, err)

--- a/backend/internal/repository/variants_test.go
+++ b/backend/internal/repository/variants_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_GetVariantHeader(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		variantHeader, err := repo.GetVariantHeader(1000)
 		assert.NoError(t, err)
@@ -23,7 +23,7 @@ func Test_GetVariantHeader(t *testing.T) {
 }
 
 func Test_GetVariantOverview(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		variantOverview, err := repo.GetVariantOverview(1000)
 		assert.NoError(t, err)
@@ -36,7 +36,7 @@ func Test_GetVariantOverview(t *testing.T) {
 }
 
 func Test_GetVariantConsequences(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		variantConsequences, err := repo.GetVariantConsequences(1000)
 		assert.NoError(t, err)
@@ -47,7 +47,7 @@ func Test_GetVariantConsequences(t *testing.T) {
 }
 
 func Test_GetVariantInterpretedCases_NoCriteria_NoPagination_DefaultSorted(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		query, err := types.NewListQueryFromCriteria(types.VariantInterpretedCasesQueryConfig, []string{}, []types.SearchCriterion{}, nil, nil)
 		interpretedCases, count, err := repo.GetVariantInterpretedCases(1000, query)
@@ -64,7 +64,7 @@ func Test_GetVariantInterpretedCases_NoCriteria_NoPagination_DefaultSorted(t *te
 }
 
 func Test_GetVariantInterpretedCases_NoCriteria_WithPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		pagination := types.Pagination{Limit: 2}
 		query, err := types.NewListQueryFromCriteria(types.VariantInterpretedCasesQueryConfig, []string{}, []types.SearchCriterion{}, &pagination, nil)
@@ -78,7 +78,7 @@ func Test_GetVariantInterpretedCases_NoCriteria_WithPagination_DefaultSort(t *te
 }
 
 func Test_GetVariantInterpretedCases_NoCriteria_WithPagination_CustomSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		pagination := types.Pagination{Limit: 2}
 		sort := types.SortBody{Field: types.ConditionIdField.Alias, Order: "asc"}
@@ -93,7 +93,7 @@ func Test_GetVariantInterpretedCases_NoCriteria_WithPagination_CustomSort(t *tes
 }
 
 func Test_GetVariantInterpretedCases_WithCriteria_NoPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.ConditionTermField.Alias, Value: []interface{}{"incompatibility"}, Operator: "contains"},
@@ -110,7 +110,7 @@ func Test_GetVariantInterpretedCases_WithCriteria_NoPagination_DefaultSort(t *te
 }
 
 func Test_GetVariantInterpretedCases_NoResult(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.ConditionTermField.Alias, Value: []interface{}{"not found"}, Operator: "contains"},
@@ -124,7 +124,7 @@ func Test_GetVariantInterpretedCases_NoResult(t *testing.T) {
 }
 
 func Test_GetVariantUninterpretedCases_DefaultFields(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		query, err := types.NewListQueryFromCriteria(types.VariantUninterpretedCasesQueryConfig, []string{}, []types.SearchCriterion{}, nil, nil)
 		uninterpretedCases, count, err := repo.GetVariantUninterpretedCases(1000, query)
@@ -151,7 +151,7 @@ func Test_GetVariantUninterpretedCases_DefaultFields(t *testing.T) {
 }
 
 func Test_GetVariantUninterpretedCases_AdditionalFields(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		query, err := types.NewListQueryFromCriteria(types.VariantUninterpretedCasesQueryConfig, []string{
 			"primary_condition_id", "primary_condition_name", "analysis_catalog_code", "analysis_catalog_name",
@@ -179,7 +179,7 @@ func Test_GetVariantUninterpretedCases_AdditionalFields(t *testing.T) {
 }
 
 func Test_GetVariantUninterpretedCases_NoCriteria_NoPagination_DefaultSorted(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		query, err := types.NewListQueryFromCriteria(types.VariantUninterpretedCasesQueryConfig, []string{}, []types.SearchCriterion{}, nil, nil)
 		uninterpretedCases, count, err := repo.GetVariantUninterpretedCases(1000, query)
@@ -195,7 +195,7 @@ func Test_GetVariantUninterpretedCases_NoCriteria_NoPagination_DefaultSorted(t *
 }
 
 func Test_GetVariantUninterpretedCases_Add_phenotypes(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		query, err := types.NewListQueryFromCriteria(types.VariantUninterpretedCasesQueryConfig, []string{}, []types.SearchCriterion{}, nil, nil)
 		uninterpretedCases, _, err := repo.GetVariantUninterpretedCases(1000, query)
@@ -221,7 +221,7 @@ func Test_GetVariantUninterpretedCases_Add_phenotypes(t *testing.T) {
 }
 
 func Test_GetVariantUninterpretedCases_NoCriteria_WithPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		pagination := types.Pagination{Limit: 2}
 		query, err := types.NewListQueryFromCriteria(types.VariantUninterpretedCasesQueryConfig, []string{}, []types.SearchCriterion{}, &pagination, nil)
@@ -235,7 +235,7 @@ func Test_GetVariantUninterpretedCases_NoCriteria_WithPagination_DefaultSort(t *
 }
 
 func Test_GetVariantUninterpretedCases_NoCriteria_WithPagination_CustomSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		pagination := types.Pagination{Limit: 2}
 		sort := types.SortBody{Field: types.FamilyRelationshipToProbandCodeField.Name, Order: "asc"}
@@ -250,7 +250,7 @@ func Test_GetVariantUninterpretedCases_NoCriteria_WithPagination_CustomSort(t *t
 }
 
 func Test_GetVariantUninterpretedCases_WithCriteria_NoPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.PatientSexCodeField.Name, Value: []interface{}{"female"}},
@@ -267,7 +267,7 @@ func Test_GetVariantUninterpretedCases_WithCriteria_NoPagination_DefaultSort(t *
 }
 
 func Test_GetVariantUninterpretedCases_WithPhenotypeCriteria_NoPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.AggregatedPhenotypeTermField.Alias, Value: []interface{}{"seizure"}, Operator: "contains"},
@@ -283,7 +283,7 @@ func Test_GetVariantUninterpretedCases_WithPhenotypeCriteria_NoPagination_Defaul
 }
 
 func Test_GetVariantUninterpretedCases_WithDiagnosticLabCriteria_NoPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.CaseDiagnosisLabCodeField.Alias, Value: []interface{}{"CQGC"}, Operator: "in"},
@@ -302,7 +302,7 @@ func Test_GetVariantUninterpretedCases_WithDiagnosticLabCriteria_NoPagination_De
 }
 
 func Test_GetVariantUninterpretedCases_WithFilterCriteria_NoPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.GermlineSNVFilterIsPassField.Alias, Value: []interface{}{true}, Operator: "in"},
@@ -325,7 +325,7 @@ func Test_GetVariantUninterpretedCases_WithFilterCriteria_NoPagination_DefaultSo
 }
 
 func Test_GetVariantUninterpretedCases_WithZygosityCriteria_NoPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.GermlineSNVZygosityField.Name, Value: []interface{}{"HOM"}, Operator: "in"},
@@ -341,7 +341,7 @@ func Test_GetVariantUninterpretedCases_WithZygosityCriteria_NoPagination_Default
 }
 
 func Test_GetVariantUninterpretedCases_WithTransmissionModeCriteria_NoPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.GermlineSNVTransmissionModeField.Name, Value: []interface{}{"autosomal_dominant"}, Operator: "in"},
@@ -356,7 +356,7 @@ func Test_GetVariantUninterpretedCases_WithTransmissionModeCriteria_NoPagination
 }
 
 func Test_GetVariantUninterpretedCases_WithCaseAnalysisCriteria_NoPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.AnalysisCatalogCodeField.Alias, Value: []interface{}{"IDGD"}, Operator: "in"},
@@ -371,7 +371,7 @@ func Test_GetVariantUninterpretedCases_WithCaseAnalysisCriteria_NoPagination_Def
 }
 
 func Test_GetVariantUninterpretedCases_WithPatientSexCodeCriteria_NoPagination_DefaultSort(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.PatientSexCodeField.Name, Value: []interface{}{"female"}, Operator: "in"},
@@ -388,7 +388,7 @@ func Test_GetVariantUninterpretedCases_WithPatientSexCodeCriteria_NoPagination_D
 }
 
 func Test_GetVariantUninterpretedCases_NoResult(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		criteria := []types.SearchCriterion{
 			{FieldName: types.AggregatedPhenotypeTermField.Alias, Value: []interface{}{"not found"}, Operator: "contains"},
@@ -402,7 +402,7 @@ func Test_GetVariantUninterpretedCases_NoResult(t *testing.T) {
 }
 
 func Test_GetVariantCasesCount(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		counts, err := repo.GetVariantCasesCount(1000)
 		assert.NoError(t, err)
@@ -412,7 +412,7 @@ func Test_GetVariantCasesCount(t *testing.T) {
 }
 
 func Test_GetVariantCasesFilters(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		filters, err := repo.GetVariantCasesFilters()
 		assert.NoError(t, err)
@@ -426,7 +426,7 @@ func Test_GetVariantCasesFilters(t *testing.T) {
 }
 
 func Test_GetVariantExternalFrequencies(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		externalFrequencies, err := repo.GetVariantExternalFrequencies(1000)
 		assert.NoError(t, err)
@@ -458,7 +458,7 @@ func Test_GetVariantExternalFrequencies(t *testing.T) {
 }
 
 func Test_GetVariantExternalFrequencies_PartialFound(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		externalFrequencies, err := repo.GetVariantExternalFrequencies(3000)
 		assert.NoError(t, err)
@@ -490,7 +490,7 @@ func Test_GetVariantExternalFrequencies_PartialFound(t *testing.T) {
 }
 
 func Test_GetVariantExternalFrequencies_VariantNotFound(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		externalFrequencies, err := repo.GetVariantExternalFrequencies(4000)
 		assert.NoError(t, err)
@@ -499,7 +499,7 @@ func Test_GetVariantExternalFrequencies_VariantNotFound(t *testing.T) {
 }
 
 func Test_GetVariantGlobalInternalFrequencies_VariantNotFound(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		globalFrequencies, err := repo.GetGermlineVariantGlobalInternalFrequencies(4000)
 		assert.NoError(t, err)
@@ -508,7 +508,7 @@ func Test_GetVariantGlobalInternalFrequencies_VariantNotFound(t *testing.T) {
 }
 
 func Test_GetVariantGlobalInternalFrequencies(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		globalFrequencies, err := repo.GetGermlineVariantGlobalInternalFrequencies(1000)
 		assert.NoError(t, err)
@@ -529,7 +529,7 @@ func Test_GetVariantGlobalInternalFrequencies(t *testing.T) {
 }
 
 func Test_GetVariantInternalFrequenciesSplitBy_ByProject(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		splitRows, err := repo.GetGermlineVariantInternalFrequenciesSplitBy(1000, types.SPLIT_BY_PROJECT)
 		assert.NoError(t, err)
@@ -572,7 +572,7 @@ func Test_GetVariantInternalFrequenciesSplitBy_ByProject(t *testing.T) {
 }
 
 func Test_GetVariantInternalFrequenciesSplitBy_ByPrimaryCondition(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		splitRows, err := repo.GetGermlineVariantInternalFrequenciesSplitBy(1000, types.SPLIT_BY_PRIMARY_CONDITION)
 		assert.NoError(t, err)
@@ -615,7 +615,7 @@ func Test_GetVariantInternalFrequenciesSplitBy_ByPrimaryCondition(t *testing.T) 
 }
 
 func Test_GetVariantInternalFrequenciesSplitBy_ByAnalysis(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		splitRows, err := repo.GetGermlineVariantInternalFrequenciesSplitBy(1000, types.SPLIT_BY_ANALYSIS)
 		assert.NoError(t, err)
@@ -658,7 +658,7 @@ func Test_GetVariantInternalFrequenciesSplitBy_ByAnalysis(t *testing.T) {
 }
 
 func Test_GetVariantInternalFrequenciesSplitBy_IncorrectSplit(t *testing.T) {
-	testutils.ParallelTestWithDb(t, "simple", func(t *testing.T, db *gorm.DB) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewVariantsRepository(db)
 		splitRows, err := repo.GetGermlineVariantInternalFrequenciesSplitBy(1000, "incorrect")
 		assert.Nil(t, splitRows)

--- a/backend/test/testutils/fixtures.go
+++ b/backend/test/testutils/fixtures.go
@@ -10,166 +10,185 @@ import (
 	"gorm.io/gorm"
 )
 
-func SequentialPostgresTestWithDb(t *testing.T, testFunc func(t *testing.T, db *gorm.DB)) {
-	gormDb, err := initPostgresDb()
-	if err != nil {
-		log.Fatal("Failed to init db connection: ", err)
-	}
-	testFunc(t, gormDb)
-	// Clean up
-	cleanUp(gormDb)
+// =============================================================================
+// RunTest is the single entry point for setting up an integration test.
+// Callers describe what they need via Need; RunTest figures out the rest:
+//   - which resources to initialize
+//   - whether the test can run in parallel
+//   - whether to clean up Postgres after the test
+//
+// Resources requested via Need are exposed on Env. Unrequested fields are nil.
+// =============================================================================
+
+// PostgresMode describes how a test interacts with Postgres.
+type PostgresMode int
+
+const (
+	NoPostgres    PostgresMode = iota // not exposed on Env
+	ReadPostgres                      // exposed; test must not write
+	WritePostgres                     // exposed; cleanUp runs after the test
+)
+
+// Need declares which test resources are required.
+type Need struct {
+	Starrocks string       // fixture folder name under test/data/; "" = no StarRocks
+	Postgres  PostgresMode // see PostgresMode
+	MinIO     bool         // spin up a per-test MinIO container
+	OpenFGA   bool         // initialize a per-test OpenFGA store
 }
 
-func SequentialTestWithPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB)) {
-	starrocks, _, err := initDb(dbName)
-	if err != nil {
-		log.Fatal("Failed to init db connection:", err)
-
-	}
-	postgres, err := initPostgresDb()
-	if err != nil {
-		log.Fatal("Failed to init PostgreSQL db connection:", err)
-
-	}
-	testFunc(t, starrocks, postgres)
+// MinIOEnv groups the MinIO connection details exposed to a test.
+type MinIOEnv struct {
+	Client   *minio.Client
+	Endpoint string
 }
 
-func SequentialTestWithMinIO(t *testing.T, testFunc func(t *testing.T, context context.Context, client *minio.Client, endpoint string)) {
-	ctx := context.Background()
-	minioC, err := initMinioContainer(ctx)
-	if err != nil {
-		log.Fatalf("Failed to start MinIO container: %v", err)
-	}
-
-	client, err := initS3Client(minioC.Endpoint)
-	if err != nil {
-		log.Fatalf("Failed to init S3 bucket: %v", err)
-	}
-
-	t.Setenv("AWS_ENDPOINT_URL", minioC.Endpoint)
-	t.Setenv("AWS_ACCESS_KEY_ID", "admin")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "password")
-	t.Setenv("AWS_USE_SSL", "false")
-
-	testFunc(t, ctx, client, minioC.Endpoint)
+// Env holds the resources requested via Need. Unrequested fields are nil.
+type Env struct {
+	Ctx       context.Context
+	Starrocks *gorm.DB
+	Postgres  *gorm.DB
+	OpenFGA   *authorization.OpenFGAModelConfiguration
+	MinIO     *MinIOEnv
 }
 
-func SequentialTestWithPostgresAndMinIO(t *testing.T, testFunc func(t *testing.T, context context.Context, client *minio.Client, endpoint string, db *gorm.DB)) {
-	ctx := context.Background()
-	minioC, err := initMinioContainer(ctx)
-	if err != nil {
-		log.Fatalf("Failed to start MinIO container: %v", err)
+// RunTest sets up the requested resources and runs the test body.
+//
+// The test runs in parallel UNLESS one of the following makes that unsafe:
+//   - MinIO: the helper sets AWS_* env vars via t.Setenv, which is mutually
+//     exclusive with t.Parallel.
+//   - OpenFGA: in this codebase, OpenFGA tests mutate process env via
+//     os.Setenv, which would race with parallel tests.
+//   - Starrocks + WritePostgres: writes are read back through the StarRocks
+//     JDBC federation catalog and concurrent runs race on visibility.
+func RunTest(t *testing.T, need Need, fn func(t *testing.T, env *Env)) {
+	serial := need.MinIO || need.OpenFGA ||
+		(need.Starrocks != "" && need.Postgres == WritePostgres)
+	if !serial {
+		t.Parallel()
 	}
 
-	client, err := initS3Client(minioC.Endpoint)
-	if err != nil {
-		log.Fatalf("Failed to init S3 bucket: %v", err)
+	env := &Env{Ctx: context.Background()}
+
+	// StarRocks (always pulls Postgres up alongside it for the federation catalog).
+	if need.Starrocks != "" {
+		sr, _, err := initStarrocksDb(need.Starrocks)
+		if err != nil {
+			log.Fatal("Failed to init StarRocks: ", err)
+		}
+		env.Starrocks = sr
 	}
 
-	gormDb, err := initPostgresDb()
-	if err != nil {
-		log.Fatal("Failed to init db connection: ", err)
+	// Postgres (always required when StarRocks is requested, even if not exposed).
+	if need.Postgres != NoPostgres || need.Starrocks != "" {
+		pg, err := initPostgresDb()
+		if err != nil {
+			log.Fatal("Failed to init Postgres: ", err)
+		}
+		if need.Postgres != NoPostgres {
+			env.Postgres = pg
+		}
+		if need.Postgres == WritePostgres {
+			defer cleanUp(pg)
+		}
 	}
 
-	t.Setenv("AWS_ENDPOINT_URL", minioC.Endpoint)
-	t.Setenv("AWS_ACCESS_KEY_ID", "admin")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "password")
-	t.Setenv("AWS_USE_SSL", "false")
+	// OpenFGA (per-test store within the shared OpenFGA container).
+	if need.OpenFGA {
+		store, err := initOpenFGA()
+		if err != nil {
+			log.Fatal("Failed to init OpenFGA store: ", err)
+		}
+		env.OpenFGA = store
+	}
 
-	testFunc(t, ctx, client, minioC.Endpoint, gormDb)
+	// MinIO (per-test container; AWS_* env vars are exported via t.Setenv).
+	if need.MinIO {
+		minioC, err := initMinioContainer(env.Ctx)
+		if err != nil {
+			log.Fatalf("Failed to start MinIO container: %v", err)
+		}
+		client, err := initS3Client(minioC.Endpoint)
+		if err != nil {
+			log.Fatalf("Failed to init S3 bucket: %v", err)
+		}
+		t.Setenv("AWS_ENDPOINT_URL", minioC.Endpoint)
+		t.Setenv("AWS_ACCESS_KEY_ID", "admin")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "password")
+		t.Setenv("AWS_USE_SSL", "false")
+		env.MinIO = &MinIOEnv{Client: client, Endpoint: minioC.Endpoint}
+	}
+
+	fn(t, env)
 }
 
-func ParallelTestWithDb(t *testing.T, dbName string, testFunc func(t *testing.T, db *gorm.DB)) {
-	t.Parallel()
-	db, _, err := initDb(dbName)
-	if err != nil {
-		log.Fatal("Failed to init db connection:", err)
+// =============================================================================
+// Backward-compatible shims around RunTest.
+//
+// These exist so the call sites don't have to be migrated all at once.
+// New code should prefer RunTest directly. The shims will be removed once
+// every caller has been migrated.
+// =============================================================================
 
-	}
-	_, err = initPostgresDb()
-	if err != nil {
-		log.Fatal("Failed to init PostgreSQL db connection:", err)
-
-	}
-	testFunc(t, db)
+func ParallelTestWithStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, db *gorm.DB)) {
+	RunTest(t, Need{Starrocks: dbName}, func(t *testing.T, env *Env) {
+		testFunc(t, env.Starrocks)
+	})
 }
 
 func ParallelTestWithPostgres(t *testing.T, testFunc func(t *testing.T, postgres *gorm.DB)) {
-	t.Parallel()
-	postgres, err := initPostgresDb()
-	if err != nil {
-		log.Fatal("Failed to init PostgreSQL db connection:", err)
-
-	}
-	testFunc(t, postgres)
-	// Clean up
-	cleanUp(postgres)
+	RunTest(t, Need{Postgres: WritePostgres}, func(t *testing.T, env *Env) {
+		testFunc(t, env.Postgres)
+	})
 }
 
-func ParallelTestWithPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB)) {
-	// NOTE: despite the helper's name, tests using this combined Postgres +
-	// StarRocks helper do not call t.Parallel(). The StarRocks JDBC federation
-	// catalog reads Postgres state mutated by these tests, and concurrent runs
-	// race on visibility through the federation. Serializing them keeps the
-	// helper's contract observable while only adding a few seconds total.
-	starrocks, _, err := initDb(dbName)
-	if err != nil {
-		log.Fatal("Failed to init db connection:", err)
-
-	}
-	postgres, err := initPostgresDb()
-	if err != nil {
-		log.Fatal("Failed to init PostgreSQL db connection:", err)
-
-	}
-	defer cleanUp(postgres)
-	testFunc(t, starrocks, postgres)
+func ParallelTestWithReadOnlyPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB)) {
+	RunTest(t, Need{Starrocks: dbName, Postgres: ReadPostgres}, func(t *testing.T, env *Env) {
+		testFunc(t, env.Starrocks, env.Postgres)
+	})
 }
 
-func ParallelTestWithOpenFGAAndPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, openfga *authorization.OpenFGAModelConfiguration, starrocks *gorm.DB, postgres *gorm.DB)) {
-	// See note on ParallelTestWithPostgresAndStarrocks — runs serially.
-	storeID, err := initOpenFGA()
+// SequentialTestWithPostgres preserves its historical sequential semantics by
+// NOT routing through RunTest. Its callers were written without an explicit
+// parallel-safety contract — they assume no other test mutates the rows they
+// touch during their execution. (Empirically, switching them to parallel
+// breaks several handler tests.) Migrate individual callers to RunTest only
+// after auditing them.
+func SequentialTestWithPostgres(t *testing.T, testFunc func(t *testing.T, db *gorm.DB)) {
+	pg, err := initPostgresDb()
 	if err != nil {
-		log.Fatal("Failed to init OpenFGA store")
+		log.Fatal("Failed to init Postgres: ", err)
 	}
-
-	starrocks, _, err := initDb(dbName)
-	if err != nil {
-		log.Fatal("Failed to init db connection:", err)
-
-	}
-	postgres, err := initPostgresDb()
-	if err != nil {
-		log.Fatal("Failed to init PostgreSQL db connection:", err)
-
-	}
-	defer cleanUp(postgres)
-	testFunc(t, storeID, starrocks, postgres)
+	defer cleanUp(pg)
+	testFunc(t, pg)
 }
 
-func ParallelTestWithAll(t *testing.T, dbName string, testFunc func(t *testing.T, client *minio.Client, endpoint string, postgres *gorm.DB, starrocks *gorm.DB)) {
-	// See note on ParallelTestWithPostgresAndStarrocks — runs serially.
-	starrocks, _, err := initDb(dbName)
-	if err != nil {
-		log.Fatal("Failed to init db connection:", err)
+func SequentialTestWithMinIO(t *testing.T, testFunc func(t *testing.T, ctx context.Context, client *minio.Client, endpoint string)) {
+	RunTest(t, Need{MinIO: true}, func(t *testing.T, env *Env) {
+		testFunc(t, env.Ctx, env.MinIO.Client, env.MinIO.Endpoint)
+	})
+}
 
-	}
-	postgres, err := initPostgresDb()
-	if err != nil {
-		log.Fatal("Failed to init PostgreSQL db connection:", err)
+func SequentialTestWithPostgresAndMinIO(t *testing.T, testFunc func(t *testing.T, ctx context.Context, client *minio.Client, endpoint string, db *gorm.DB)) {
+	RunTest(t, Need{Postgres: WritePostgres, MinIO: true}, func(t *testing.T, env *Env) {
+		testFunc(t, env.Ctx, env.MinIO.Client, env.MinIO.Endpoint, env.Postgres)
+	})
+}
 
-	}
+func SequentialTestWithPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB)) {
+	RunTest(t, Need{Starrocks: dbName, Postgres: WritePostgres}, func(t *testing.T, env *Env) {
+		testFunc(t, env.Starrocks, env.Postgres)
+	})
+}
 
-	ctx := context.Background()
-	minioC, err := initMinioContainer(ctx)
-	if err != nil {
-		log.Fatalf("Failed to start MinIO container: %v", err)
-	}
+func SequentialTestWithOpenFGAAndPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, openfga *authorization.OpenFGAModelConfiguration, starrocks *gorm.DB, postgres *gorm.DB)) {
+	RunTest(t, Need{Starrocks: dbName, Postgres: WritePostgres, OpenFGA: true}, func(t *testing.T, env *Env) {
+		testFunc(t, env.OpenFGA, env.Starrocks, env.Postgres)
+	})
+}
 
-	client, err := initS3Client(minioC.Endpoint)
-	if err != nil {
-		log.Fatalf("Failed to init S3 bucket: %v", err)
-	}
-	defer cleanUp(postgres)
-	testFunc(t, client, minioC.Endpoint, postgres, starrocks)
+func SequentialTestWithMinIOPostgresStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, client *minio.Client, endpoint string, postgres *gorm.DB, starrocks *gorm.DB)) {
+	RunTest(t, Need{Starrocks: dbName, Postgres: WritePostgres, MinIO: true}, func(t *testing.T, env *Env) {
+		testFunc(t, env.MinIO.Client, env.MinIO.Endpoint, env.Postgres, env.Starrocks)
+	})
 }

--- a/backend/test/testutils/fixtures.go
+++ b/backend/test/testutils/fixtures.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"testing"
 
@@ -22,7 +21,7 @@ func SequentialPostgresTestWithDb(t *testing.T, testFunc func(t *testing.T, db *
 }
 
 func SequentialTestWithPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB)) {
-	starrocks, dbName, err := initDb(dbName)
+	starrocks, _, err := initDb(dbName)
 	if err != nil {
 		log.Fatal("Failed to init db connection:", err)
 
@@ -33,8 +32,6 @@ func SequentialTestWithPostgresAndStarrocks(t *testing.T, dbName string, testFun
 
 	}
 	testFunc(t, starrocks, postgres)
-	//Drop database
-	starrocks.Exec(fmt.Sprintf("DROP DATABASE %s;", dbName))
 }
 
 func SequentialTestWithMinIO(t *testing.T, testFunc func(t *testing.T, context context.Context, client *minio.Client, endpoint string)) {
@@ -84,7 +81,7 @@ func SequentialTestWithPostgresAndMinIO(t *testing.T, testFunc func(t *testing.T
 
 func ParallelTestWithDb(t *testing.T, dbName string, testFunc func(t *testing.T, db *gorm.DB)) {
 	t.Parallel()
-	db, dbName, err := initDb(dbName)
+	db, _, err := initDb(dbName)
 	if err != nil {
 		log.Fatal("Failed to init db connection:", err)
 
@@ -95,8 +92,6 @@ func ParallelTestWithDb(t *testing.T, dbName string, testFunc func(t *testing.T,
 
 	}
 	testFunc(t, db)
-	//Drop database
-	db.Exec(fmt.Sprintf("DROP DATABASE %s;", dbName))
 }
 
 func ParallelTestWithPostgres(t *testing.T, testFunc func(t *testing.T, postgres *gorm.DB)) {
@@ -112,8 +107,12 @@ func ParallelTestWithPostgres(t *testing.T, testFunc func(t *testing.T, postgres
 }
 
 func ParallelTestWithPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB)) {
-	t.Parallel()
-	starrocks, dbName, err := initDb(dbName)
+	// NOTE: despite the helper's name, tests using this combined Postgres +
+	// StarRocks helper do not call t.Parallel(). The StarRocks JDBC federation
+	// catalog reads Postgres state mutated by these tests, and concurrent runs
+	// race on visibility through the federation. Serializing them keeps the
+	// helper's contract observable while only adding a few seconds total.
+	starrocks, _, err := initDb(dbName)
 	if err != nil {
 		log.Fatal("Failed to init db connection:", err)
 
@@ -123,19 +122,18 @@ func ParallelTestWithPostgresAndStarrocks(t *testing.T, dbName string, testFunc 
 		log.Fatal("Failed to init PostgreSQL db connection:", err)
 
 	}
+	defer cleanUp(postgres)
 	testFunc(t, starrocks, postgres)
-	//Drop database
-	starrocks.Exec(fmt.Sprintf("DROP DATABASE %s;", dbName))
 }
 
 func ParallelTestWithOpenFGAAndPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, openfga *authorization.OpenFGAModelConfiguration, starrocks *gorm.DB, postgres *gorm.DB)) {
-	t.Parallel()
+	// See note on ParallelTestWithPostgresAndStarrocks — runs serially.
 	storeID, err := initOpenFGA()
 	if err != nil {
 		log.Fatal("Failed to init OpenFGA store")
 	}
 
-	starrocks, dbName, err := initDb(dbName)
+	starrocks, _, err := initDb(dbName)
 	if err != nil {
 		log.Fatal("Failed to init db connection:", err)
 
@@ -145,15 +143,13 @@ func ParallelTestWithOpenFGAAndPostgresAndStarrocks(t *testing.T, dbName string,
 		log.Fatal("Failed to init PostgreSQL db connection:", err)
 
 	}
+	defer cleanUp(postgres)
 	testFunc(t, storeID, starrocks, postgres)
-	//Drop database
-	starrocks.Exec(fmt.Sprintf("DROP DATABASE %s;", dbName))
 }
 
 func ParallelTestWithAll(t *testing.T, dbName string, testFunc func(t *testing.T, client *minio.Client, endpoint string, postgres *gorm.DB, starrocks *gorm.DB)) {
-	t.Parallel()
-
-	starrocks, dbName, err := initDb(dbName)
+	// See note on ParallelTestWithPostgresAndStarrocks — runs serially.
+	starrocks, _, err := initDb(dbName)
 	if err != nil {
 		log.Fatal("Failed to init db connection:", err)
 
@@ -163,8 +159,6 @@ func ParallelTestWithAll(t *testing.T, dbName string, testFunc func(t *testing.T
 		log.Fatal("Failed to init PostgreSQL db connection:", err)
 
 	}
-
-	defer starrocks.Exec(fmt.Sprintf("DROP DATABASE %s;", dbName))
 
 	ctx := context.Background()
 	minioC, err := initMinioContainer(ctx)
@@ -176,5 +170,6 @@ func ParallelTestWithAll(t *testing.T, dbName string, testFunc func(t *testing.T
 	if err != nil {
 		log.Fatalf("Failed to init S3 bucket: %v", err)
 	}
+	defer cleanUp(postgres)
 	testFunc(t, client, minioC.Endpoint, postgres, starrocks)
 }

--- a/backend/test/testutils/fixtures.go
+++ b/backend/test/testutils/fixtures.go
@@ -24,15 +24,16 @@ import (
 type PostgresMode int
 
 const (
-	NoPostgres    PostgresMode = iota // not exposed on Env
-	ReadPostgres                      // exposed; test must not write
-	WritePostgres                     // exposed; cleanUp runs after the test
+	NoPostgres        PostgresMode = iota
+	ReadPostgres                         // exposed; test must not write
+	WritePostgres                        // writes with unique keys; cleanUp runs; can run in parallel
+	ExclusivePostgres                    // writes to shared state; cleanUp runs; forces serial execution
 )
 
 // Need declares which test resources are required.
 type Need struct {
 	Starrocks string       // fixture folder name under test/data/; "" = no StarRocks
-	Postgres  PostgresMode // see PostgresMode
+	Postgres  PostgresMode // see PostgresMode constants
 	MinIO     bool         // spin up a per-test MinIO container
 	OpenFGA   bool         // initialize a per-test OpenFGA store
 }
@@ -55,15 +56,14 @@ type Env struct {
 // RunTest sets up the requested resources and runs the test body.
 //
 // The test runs in parallel UNLESS one of the following makes that unsafe:
+//   - ExclusivePostgres: the test touches shared rows (seed data, count
+//     assertions on shared keys) and needs the database to itself.
 //   - MinIO: the helper sets AWS_* env vars via t.Setenv, which is mutually
 //     exclusive with t.Parallel.
 //   - OpenFGA: in this codebase, OpenFGA tests mutate process env via
 //     os.Setenv, which would race with parallel tests.
-//   - Starrocks + WritePostgres: writes are read back through the StarRocks
-//     JDBC federation catalog and concurrent runs race on visibility.
 func RunTest(t *testing.T, need Need, fn func(t *testing.T, env *Env)) {
-	serial := need.MinIO || need.OpenFGA ||
-		(need.Starrocks != "" && need.Postgres == WritePostgres)
+	serial := need.Postgres == ExclusivePostgres || need.MinIO || need.OpenFGA
 	if !serial {
 		t.Parallel()
 	}
@@ -88,7 +88,7 @@ func RunTest(t *testing.T, need Need, fn func(t *testing.T, env *Env)) {
 		if need.Postgres != NoPostgres {
 			env.Postgres = pg
 		}
-		if need.Postgres == WritePostgres {
+		if need.Postgres == WritePostgres || need.Postgres == ExclusivePostgres {
 			defer cleanUp(pg)
 		}
 	}
@@ -148,19 +148,10 @@ func ParallelTestWithReadOnlyPostgresAndStarrocks(t *testing.T, dbName string, t
 	})
 }
 
-// SequentialTestWithPostgres preserves its historical sequential semantics by
-// NOT routing through RunTest. Its callers were written without an explicit
-// parallel-safety contract — they assume no other test mutates the rows they
-// touch during their execution. (Empirically, switching them to parallel
-// breaks several handler tests.) Migrate individual callers to RunTest only
-// after auditing them.
 func SequentialTestWithPostgres(t *testing.T, testFunc func(t *testing.T, db *gorm.DB)) {
-	pg, err := initPostgresDb()
-	if err != nil {
-		log.Fatal("Failed to init Postgres: ", err)
-	}
-	defer cleanUp(pg)
-	testFunc(t, pg)
+	RunTest(t, Need{Postgres: ExclusivePostgres}, func(t *testing.T, env *Env) {
+		testFunc(t, env.Postgres)
+	})
 }
 
 func SequentialTestWithMinIO(t *testing.T, testFunc func(t *testing.T, ctx context.Context, client *minio.Client, endpoint string)) {
@@ -170,25 +161,25 @@ func SequentialTestWithMinIO(t *testing.T, testFunc func(t *testing.T, ctx conte
 }
 
 func SequentialTestWithPostgresAndMinIO(t *testing.T, testFunc func(t *testing.T, ctx context.Context, client *minio.Client, endpoint string, db *gorm.DB)) {
-	RunTest(t, Need{Postgres: WritePostgres, MinIO: true}, func(t *testing.T, env *Env) {
+	RunTest(t, Need{Postgres: ExclusivePostgres, MinIO: true}, func(t *testing.T, env *Env) {
 		testFunc(t, env.Ctx, env.MinIO.Client, env.MinIO.Endpoint, env.Postgres)
 	})
 }
 
 func SequentialTestWithPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB)) {
-	RunTest(t, Need{Starrocks: dbName, Postgres: WritePostgres}, func(t *testing.T, env *Env) {
+	RunTest(t, Need{Starrocks: dbName, Postgres: ExclusivePostgres}, func(t *testing.T, env *Env) {
 		testFunc(t, env.Starrocks, env.Postgres)
 	})
 }
 
 func SequentialTestWithOpenFGAAndPostgresAndStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, openfga *authorization.OpenFGAModelConfiguration, starrocks *gorm.DB, postgres *gorm.DB)) {
-	RunTest(t, Need{Starrocks: dbName, Postgres: WritePostgres, OpenFGA: true}, func(t *testing.T, env *Env) {
+	RunTest(t, Need{Starrocks: dbName, Postgres: ExclusivePostgres, OpenFGA: true}, func(t *testing.T, env *Env) {
 		testFunc(t, env.OpenFGA, env.Starrocks, env.Postgres)
 	})
 }
 
 func SequentialTestWithMinIOPostgresStarrocks(t *testing.T, dbName string, testFunc func(t *testing.T, client *minio.Client, endpoint string, postgres *gorm.DB, starrocks *gorm.DB)) {
-	RunTest(t, Need{Starrocks: dbName, Postgres: WritePostgres, MinIO: true}, func(t *testing.T, env *Env) {
+	RunTest(t, Need{Starrocks: dbName, Postgres: ExclusivePostgres, MinIO: true}, func(t *testing.T, env *Env) {
 		testFunc(t, env.MinIO.Client, env.MinIO.Endpoint, env.Postgres, env.Starrocks)
 	})
 }

--- a/backend/test/testutils/setup_starrocks.go
+++ b/backend/test/testutils/setup_starrocks.go
@@ -55,7 +55,7 @@ func openStarrocksGorm(dbName string) (*gorm.DB, error) {
 	return gorm.Open(mysql.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Info)})
 }
 
-func initDb(folderName string) (*gorm.DB, string, error) {
+func initStarrocksDb(folderName string) (*gorm.DB, string, error) {
 	dbName := folderName
 
 	st := fixtureStateFor(folderName)

--- a/backend/test/testutils/setup_starrocks.go
+++ b/backend/test/testutils/setup_starrocks.go
@@ -6,70 +6,113 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
-func initDb(folderName string) (*gorm.DB, string, error) {
+// StarRocks is treated as read-only by the test suite: no repository code writes
+// to it. To avoid re-ingesting the same fixture folder for every test, we load
+// each folder into a stable database name once per process and hand out fresh
+// GORM connections pointed at the shared database on subsequent calls.
+type fixtureState struct {
+	once sync.Once
+	err  error
+}
+
+var (
+	fixtureStatesMu sync.Mutex
+	fixtureStates   = map[string]*fixtureState{}
+)
+
+func fixtureStateFor(folderName string) *fixtureState {
+	fixtureStatesMu.Lock()
+	defer fixtureStatesMu.Unlock()
+	st, ok := fixtureStates[folderName]
+	if !ok {
+		st = &fixtureState{}
+		fixtureStates[folderName] = st
+	}
+	return st
+}
+
+func openStarrocksGorm(dbName string) (*gorm.DB, error) {
 	ctx := context.Background()
 	host, err := StarrocksContainerSetup.Container.Host(ctx)
 	if err != nil {
-		log.Fatal("failed to get container host: ", err)
+		return nil, fmt.Errorf("failed to get container host: %w", err)
 	}
-
 	port, err := StarrocksContainerSetup.Container.MappedPort(ctx, "9030")
 	if err != nil {
-		log.Fatal("failed to get container port: ", err)
+		return nil, fmt.Errorf("failed to get container port: %w", err)
+	}
+	dsn := fmt.Sprintf("root:@tcp(%s:%s)/%s?interpolateParams=true&parseTime=true", host, port.Port(), dbName)
+	return gorm.Open(mysql.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Info)})
+}
+
+func initDb(folderName string) (*gorm.DB, string, error) {
+	dbName := folderName
+
+	st := fixtureStateFor(folderName)
+	st.once.Do(func() {
+		st.err = loadFixtureFolder(folderName, dbName)
+	})
+	if st.err != nil {
+		log.Fatal("failed to load fixture folder ", folderName, ": ", st.err)
 	}
 
-	dsn := fmt.Sprintf("root:@tcp(%s:%s)/?interpolateParams=true&parseTime=true", host, port.Port())
-	gormDb, err := gorm.Open(mysql.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Info)})
+	gormDb, err := openStarrocksGorm(dbName)
 	if err != nil {
-		log.Fatal("failed to open connection to tb", err)
-		return nil, "", nil
+		log.Fatal("failed to open connection to StarRocks: ", err)
 	}
-	var db *sql.DB
-	db, err = gormDb.DB()
+	return gormDb, dbName, nil
+}
+
+// loadFixtureFolder is run exactly once per fixture folder per process. It
+// drops any leftover database from a previous run, recreates it, ingests every
+// .tsv in the folder and ensures the JDBC federation catalog exists.
+func loadFixtureFolder(folderName, dbName string) error {
+	bootstrap, err := openStarrocksGorm("")
 	if err != nil {
-		log.Fatal("failed to connect to StarRocks", err)
-		return nil, "", nil
+		return fmt.Errorf("failed to open bootstrap connection: %w", err)
+	}
+	defer func() {
+		if sqlDB, err := bootstrap.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	}()
+
+	db, err := bootstrap.DB()
+	if err != nil {
+		return fmt.Errorf("failed to access bootstrap sql.DB: %w", err)
 	}
 
-	// Create a database with the name of the folder and a random number
-	dbName := fmt.Sprintf("%s_%d", folderName, rand.Intn(1000000))
-	_, err = db.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s;", dbName))
-	if err != nil {
-		log.Fatal("failed to create database", err)
+	if _, err := db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s;", dbName)); err != nil {
+		return fmt.Errorf("failed to drop existing database: %w", err)
 	}
-	_, err = db.Exec(fmt.Sprintf("USE %s;", dbName))
-	if err != nil {
-		log.Fatal("failed to use database", err)
+	if _, err := db.Exec(fmt.Sprintf("CREATE DATABASE %s;", dbName)); err != nil {
+		return fmt.Errorf("failed to create database: %w", err)
+	}
+	if _, err := db.Exec(fmt.Sprintf("USE %s;", dbName)); err != nil {
+		return fmt.Errorf("failed to use database: %w", err)
 	}
 
-	// Read the list of .tsv files in the folder
 	files, err := os.ReadDir(filepath.Join(TestResources, folderName))
 	if err != nil {
-		log.Fatal("failed to read directory test_resoures", err)
+		return fmt.Errorf("failed to read fixture directory: %w", err)
 	}
-
 	for _, file := range files {
-		if filepath.Ext(file.Name()) == ".tsv" {
-			err = createTableAndPopulateData(db, folderName, file)
-			if err != nil {
-				log.Println("file", file)
-				log.Fatal("failed to create table and populate data", err)
-			}
+		if filepath.Ext(file.Name()) != ".tsv" {
+			continue
 		}
-	}
-
-	if err != nil {
-		log.Fatal("failed to get container port: ", err)
+		if err := createTableAndPopulateData(db, folderName, file); err != nil {
+			return fmt.Errorf("failed to ingest %s: %w", file.Name(), err)
+		}
 	}
 
 	federationQuery := fmt.Sprintf(
@@ -77,7 +120,7 @@ func initDb(folderName string) (*gorm.DB, string, error) {
 		CREATE EXTERNAL CATALOG IF NOT EXISTS radiant_jdbc
 		PROPERTIES
 		(
-			"type"="jdbc", 
+			"type"="jdbc",
 			"user"="radiant",
 			"password"="radiant",
 			"jdbc_uri"="jdbc:postgresql://%s:5432/radiant",
@@ -85,12 +128,10 @@ func initDb(folderName string) (*gorm.DB, string, error) {
 			"driver_class"="org.postgresql.Driver"
 		);
 	`, PostgresContainerName)
-	_, err = db.Exec(federationQuery)
-	if err != nil {
-		log.Fatal("failed to create federation", err)
+	if _, err := db.Exec(federationQuery); err != nil {
+		return fmt.Errorf("failed to create federation catalog: %w", err)
 	}
-
-	return gormDb, dbName, nil
+	return nil
 }
 
 func createTableAndPopulateData(db *sql.DB, folderName string, file os.DirEntry) error {

--- a/backend/test/testutils/setup_starrocks.go
+++ b/backend/test/testutils/setup_starrocks.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -15,6 +16,9 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
+
+// ErrStarrocksReadOnly is returned when test code attempts to write to StarRocks.
+var ErrStarrocksReadOnly = errors.New("StarRocks is read-only in tests: writes are not allowed")
 
 // StarRocks is treated as read-only by the test suite: no repository code writes
 // to it. To avoid re-ingesting the same fixture folder for every test, we load
@@ -70,7 +74,38 @@ func initStarrocksDb(folderName string) (*gorm.DB, string, error) {
 	if err != nil {
 		log.Fatal("failed to open connection to StarRocks: ", err)
 	}
+	registerReadOnlyGuard(gormDb)
 	return gormDb, dbName, nil
+}
+
+// registerReadOnlyGuard registers GORM callbacks that reject write operations.
+// This enforces the read-only invariant at runtime: any production or test code
+// that attempts to INSERT, UPDATE, or DELETE through the StarRocks *gorm.DB
+// will get an immediate error instead of silently succeeding and breaking the
+// shared fixture cache.
+//
+// Guards are registered on both the ORM pipeline (Create/Update/Delete) and
+// the Raw pipeline (db.Exec) to cover all write paths.
+func registerReadOnlyGuard(db *gorm.DB) {
+	rejectWrite := func(db *gorm.DB) {
+		db.AddError(ErrStarrocksReadOnly)
+	}
+	db.Callback().Create().Before("gorm:create").Register("starrocksReadOnly:create", rejectWrite)
+	db.Callback().Update().Before("gorm:update").Register("starrocksReadOnly:update", rejectWrite)
+	db.Callback().Delete().Before("gorm:delete").Register("starrocksReadOnly:delete", rejectWrite)
+	db.Callback().Raw().Before("gorm:raw").Register("starrocksReadOnly:raw", func(db *gorm.DB) {
+		if db.Statement != nil && db.Statement.SQL.Len() > 0 {
+			upper := strings.ToUpper(db.Statement.SQL.String())
+			if strings.HasPrefix(upper, "INSERT") ||
+				strings.HasPrefix(upper, "UPDATE") ||
+				strings.HasPrefix(upper, "DELETE") ||
+				strings.HasPrefix(upper, "DROP") ||
+				strings.HasPrefix(upper, "ALTER") ||
+				strings.HasPrefix(upper, "TRUNCATE") {
+				db.AddError(ErrStarrocksReadOnly)
+			}
+		}
+	})
 }
 
 // loadFixtureFolder is run exactly once per fixture folder per process. It


### PR DESCRIPTION
# Optimize integration test infrastructure

## 📌 Context

Integration tests in `backend/` were slow primarily because every test created a fresh StarRocks database and re-ingested fixture data, despite repository code being read-only on StarRocks. Additionally, the test helper functions had confusing names, duplicated setup/cleanup logic, and no enforcement of the read-only invariant.

## 📝 Changes

- Cache StarRocks fixture databases per folder — each fixture folder is loaded once per `go test` process and shared across all tests (162 ingestions → 8)
- Introduce `testutils.RunTest` with `Need`/`Env` API — single entry point for integration tests; callers declare resources needed, framework auto-derives parallel vs serial execution and cleanup
- Add `PostgresMode` enum: `ReadPostgres`, `WritePostgres` (parallel, cleanup), `ExclusivePostgres` (serial, cleanup)
- Enforce StarRocks read-only invariant at runtime via GORM callbacks (`ErrStarrocksReadOnly`) on both ORM and raw SQL paths
- Make occurrence note integration tests parallel-safe using `case_id=1` (preserved by cleanUp) and unique `occurrence_id` per test
- Rename helpers for clarity: `ParallelTestWithDb` → `ParallelTestWithStarrocks`, `SequentialTestWithAll` → `SequentialTestWithMinIOPostgresStarrocks`, `SequentialPostgresTestWithDb` → `SequentialTestWithPostgres`, `initDb` → `initStarrocksDb`
- Reorganize `fixtures.go` with section comments and doc comments on each helper
- Update `CLAUDE.md` with testing conventions and parallel-safety guidance

## ☑️ TO-DOs

- [x] CI pipeline passes

## 🧪 Tests

- Added `Test_StarrocksReadOnlyGuard_RejectsCreate` — confirms `db.Exec("INSERT ...")` returns `ErrStarrocksReadOnly`
- Added `Test_StarrocksReadOnlyGuard_AllowsRead` — confirms `db.Table(...).Count(...)` works
- All existing tests pass: `internal/repository`, `cmd/api`, `cmd/worker`, `internal/batchval`
- Stability verified with 5 consecutive multi-package runs (`./internal/repository/ ./cmd/api/`) — zero flakes

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1346](https://d3b.atlassian.net/browse/SJRA-1346)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- Legacy shims in `fixtures.go` route through `RunTest` — they exist for backward compat and can be removed as callers migrate
- `SequentialTestWithPostgres` (78 callers) stays serial because its callers share mutable Postgres state; making them parallel requires per-test unique keys (as demonstrated in `occurrence_notes_integration_test.go`)
- The `cleanUp` function in `setup_postgres.go` is a broad sledgehammer — it's the main blocker for parallelizing the remaining Sequential tests. Future improvement: scope cleanup per test or use protected ID ranges
- StarRocks fixture caching relies on the read-only invariant; the GORM guard enforces this at runtime so a future write would fail loudly rather than silently breaking test isolation

[SJRA-1346]: https://d3b.atlassian.net/browse/SJRA-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ