### PR TITLE
feat: SJRA-1352 Add cypress_CLAUDE_md and some improvements

### DIFF
--- a/cypress/CLAUDE.md
+++ b/cypress/CLAUDE.md
@@ -1,0 +1,215 @@
+# CLAUDE.md — Cypress Tests
+
+This file provides guidance to Claude Code when working in the `cypress/` directory.
+
+## Overview
+
+End-to-end (E2E) and API test suite for the Radiant Portal. Tests run against a live QA environment using Cypress with a Page Object Model (POM) pattern.
+
+- **162 tests total**: 66 E2E (UI) + 96 API
+- **QA base URL**: `https://radiant.qa.juno.cqdg.ferlab.bio/`
+- **API base URL**: `https://radiant-api.qa.juno.cqdg.ferlab.bio/`
+- **Auth**: Keycloak at `https://auth.qa.juno.cqdg.ferlab.bio`
+
+## Directory Structure
+
+```
+cypress/
+├── api/                   # API tests (organized by resource)
+│   ├── Batches/           # Batch job management
+│   ├── Cases/
+│   │   ├── Autocomplete/  # Autocomplete suggestions
+│   │   ├── Batch/         # Batch case operations
+│   │   └── Search/        # Case search filtering
+│   ├── Documents/
+│   │   └── Search/        # Document/file search
+│   ├── Occurrences/
+│   │   └── Germline/
+│   │       ├── CNV/
+│   │       │   ├── Count/ # CNV facet counts (Variant, Gene, Frequency, MetricQC)
+│   │       │   └── List/  # CNV list pagination
+│   │       └── SNV/
+│   │           ├── Count/ # SNV facet counts (Variant, Gene, Pathogenicity, Frequency, Occurrence)
+│   │           └── List/  # SNV list pagination
+│   ├── Patients/
+│   │   └── Batch/         # Batch patient creation (Valid, BlankFields, InvalidValues, etc.)
+│   │       └── ProcessWorker/
+│   ├── Samples/
+│   │   └── Batch/         # Batch sample operations
+│   │       └── ProcessWorker/
+│   └── Sequencing/
+│       └── Batch/         # Batch sequencing operations
+│           └── ProcessWorker/
+├── e2e/                   # E2E UI tests (organized by feature/page)
+│   ├── Cases/             # Case list table tests
+│   ├── CaseEntity/        # Case detail page (Details, Files, Variants SNV/CNV)
+│   ├── Connexion/         # Login tests
+│   ├── DataQuality/       # Data quality checks
+│   ├── Files/             # Files list tests
+│   └── VariantEntity/     # Variant detail page (EvidCond, Frequency, Patients)
+├── pom/                   # Page Object Model
+│   ├── pages/             # 18 page objects (one per page/component)
+│   └── shared/            # Selectors.ts, Data.ts, Utils.ts, Texts.ts
+├── support/               # Custom commands and global setup
+│   ├── commands.ts        # UI commands (login, navigation, table ops, assertions)
+│   ├── apiCommands.ts     # API commands (getToken, apiCall, validators)
+│   ├── e2e.js             # Global before() hook, token caching
+│   ├── globalData.js      # Runtime shared data (token, batch IDs, counts)
+│   └── index.d.ts         # TypeScript definitions for custom commands
+├── fixtures/
+│   └── RequestBody/       # JSON templates (ApplyFacet, Sort payloads)
+└── plugins/
+    └── index.ts           # Env var loading from dotenv
+```
+
+Config lives at repo root: `cypress.config.ts`.
+
+## Running Tests
+
+```bash
+# Open Cypress UI (interactive)
+npx cypress open
+
+# Run all tests headless
+npx cypress run
+
+# Run a specific spec
+npx cypress run --spec "cypress/e2e/Cases/Columns.cy.ts"
+
+# Run only API tests
+npx cypress run --spec "cypress/api/**/*.cy.ts"
+
+# Formatting and type-checking (from repo root)
+npm run format:cypress
+npm run format:cypress:check
+npm run type-check:cypress
+```
+
+Environment variables are loaded from `.env` at repo root. Required:
+- `CYPRESS_USER_USERNAME`, `CYPRESS_USER_PASSWORD` — test user credentials
+- `KEYCLOAK_CLIENT_SECRET` — OAuth client secret
+
+## Page Object Model (POM) Pattern
+
+Each page object in `pom/pages/` exports an object with:
+
+- **`tableColumns[]`** — Column metadata (id, name, apiField, sortable, pinnable, tooltip, position)
+- **`actions`** — Methods that perform user interactions
+- **`validations`** — Methods that assert expected state
+
+```typescript
+// Example: pom/pages/CasesTable.ts
+export default {
+  tableColumns: [
+    { id: 'case_id', name: 'Case ID', sortable: true, pinnable: true, ... },
+  ],
+  actions: {
+    clickRow(caseId: string) { ... },
+  },
+  validations: {
+    shouldShowColumnContent(columnId, expected) { ... },
+  },
+};
+```
+
+Shared POM utilities in `pom/shared/`:
+- **`Selectors.ts`** — 60+ reusable CSS/data-cy selectors (`CommonSelectors`)
+- **`Data.ts`** — Test data constants (case IDs, patient info, expected values)
+- **`Utils.ts`** — Helpers: `buildBilingualRegExp()`, `getColumnPosition()`, `getDateTime()`, etc.
+- **`Texts.ts`** — Bilingual EN/FR text constants for validation
+
+## Custom Cypress Commands
+
+### UI Commands (`support/commands.ts`)
+
+| Command | Purpose |
+|---|---|
+| `cy.login()` | OAuth login via Keycloak (with session caching) |
+| `cy.logout()` | Logout |
+| `cy.visitCasesPage()`, `cy.visitFilesPage()`, etc. | Navigate to specific pages |
+| `cy.visitAndIntercept(url, method, routeAlias)` | Navigate and set up API intercept |
+| `cy.clickAndWait(selector)` | Click then wait for load spinner to disappear |
+| `cy.waitWhileLoad(ms)` | Poll for `.animate-pulse` disappearance |
+| `cy.sortTableAndIntercept(column, routeAlias)` | Click column header + wait for API |
+| `cy.pinColumn()` / `cy.unpinColumn()` | Pin/unpin table columns |
+| `cy.resetColumns()` | Reset column visibility and order |
+| `cy.hideColumn()` / `cy.showColumn()` | Toggle column visibility |
+| `cy.setLang('EN'\|'FR')` | Switch UI language |
+| `cy.validateTableFirstRowContent(colIdx, expected)` | Assert cell text content |
+| `cy.shouldBeSortable()`, `cy.shouldBePinnable()`, etc. | Column capability assertions |
+
+### API Commands (`support/apiCommands.ts`)
+
+| Command | Purpose |
+|---|---|
+| `cy.getToken()` | Password grant → returns access_token |
+| `cy.apiCall(method, path, body, token)` | Authenticated request with auto-retry on 500 |
+| `cy.validateAcceptedBatchResponse(resp, type)` | Assert batch creation response structure |
+| `cy.validateSuccessBatchProcessed(resp)` | Assert completed batch (status=SUCCESS) |
+| `cy.validateReport(resp, level, code, msg, path)` | Assert error/warning/info in report |
+| `cy.validateSummary(resp, created, updated, ...)` | Assert batch summary counts |
+
+## Authentication
+
+Two distinct auth flows:
+
+1. **E2E tests** — OAuth code flow via `cy.login()`. Uses `cy.origin()` for cross-origin Keycloak. Sessions are cached to avoid re-login per test.
+2. **API tests** — Password grant via `cy.getToken()`. Returns bearer token passed to `cy.apiCall()`.
+
+Token and global data are cached in `.cached-data.json` between runs (managed by `support/e2e.js`).
+
+## Common Test Patterns
+
+### E2E test structure
+
+```typescript
+describe('Feature', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visitCasesPage();
+    cy.setLang('EN');
+    cy.resetColumns();
+  });
+
+  it('should display column data', () => {
+    cy.validateTableFirstRowContent(colIdx, expectedData);
+  });
+
+  it('should sort by column', () => {
+    cy.sortTableAndIntercept('column_id', 'routeAlias');
+    cy.wait('@routeAlias');
+    // assert order
+  });
+});
+```
+
+### API test structure
+
+```typescript
+it('should create a batch', () => {
+  cy.getToken().then((token) => {
+    cy.apiCall('POST', 'patients/batch?dry_run=true', body, token).then((resp) => {
+      cy.validateAcceptedBatchResponse(resp, 'patient');
+    });
+  });
+});
+```
+
+### Waiting for page load
+
+Avoid using hardcoded `cy.wait(ms)`. Use `cy.waitWhileLoad()` which polls for the `.animate-pulse` spinner to disappear, or use intercept + `cy.wait('@alias')` to wait for specific API calls.
+
+## Writing New Tests
+
+1. **New page/feature** — Create a page object in `pom/pages/`, add selectors to `pom/shared/Selectors.ts` if reusable, add test data to `pom/shared/Data.ts`.
+2. **New E2E spec** — Place in the appropriate `e2e/{Feature}/` folder. Follow the `beforeEach` login + navigate.
+3. **New API spec** — Place in `api/{Resource}/`. Use `cy.getToken()` + `cy.apiCall()`.
+4. **New custom command** — Add to `support/commands.ts` (UI) or `support/apiCommands.ts` (API), and update type definitions in `support/index.d.ts`.
+
+## Conventions
+
+- **File naming**: PascalCase for page objects (`CasesTable.ts`), PascalCase for specs (`Columns.cy.ts`)
+- **Selectors**: Prefer `data-cy` attributes. Centralize reusable selectors in `CommonSelectors`.
+- **Bilingual tests**: Use `buildBilingualRegExp()` from Utils when validating text that could be EN or FR.
+- **Column testing**: Define column metadata in the POM (`tableColumns[]`), use `getColumnPosition()` to find columns dynamically rather than hardcoding indices.
+- **API retries**: `cy.apiCall()` auto-retries 500 errors (3 attempts). For async batch operations, poll until processed.

--- a/cypress/api/Patients/Batch/ProcessWorker/PartialKey.cy.ts
+++ b/cypress/api/Patients/Batch/ProcessWorker/PartialKey.cy.ts
@@ -25,11 +25,7 @@ describe('Patients - Batch - Process worker - Partial key', () => {
     cy.apiCall('POST', 'patients/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Patients/Batch/ProcessWorker/Patient001.cy.ts
+++ b/cypress/api/Patients/Batch/ProcessWorker/Patient001.cy.ts
@@ -26,11 +26,7 @@ describe('Patients - Batch - Process worker - Patient001', () => {
     cy.apiCall('POST', 'patients/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Patients/Batch/ProcessWorker/Patient002.cy.ts
+++ b/cypress/api/Patients/Batch/ProcessWorker/Patient002.cy.ts
@@ -26,11 +26,7 @@ describe('Patients - Batch - Process worker - Patient002', () => {
     cy.apiCall('POST', 'patients/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Patients/Batch/ProcessWorker/Patient003.cy.ts
+++ b/cypress/api/Patients/Batch/ProcessWorker/Patient003.cy.ts
@@ -26,11 +26,7 @@ describe('Patients - Batch - Process worker - Patient003', () => {
     cy.apiCall('POST', 'patients/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Patients/Batch/ProcessWorker/Patient004.cy.ts
+++ b/cypress/api/Patients/Batch/ProcessWorker/Patient004.cy.ts
@@ -26,11 +26,7 @@ describe('Patients - Batch - Process worker - Patient004', () => {
     cy.apiCall('POST', 'patients/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Patients/Batch/ProcessWorker/Patient005.cy.ts
+++ b/cypress/api/Patients/Batch/ProcessWorker/Patient005.cy.ts
@@ -26,11 +26,7 @@ describe('Patients - Batch - Process worker - Patient005', () => {
     cy.apiCall('POST', 'patients/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Patients/Batch/ProcessWorker/Patient006.cy.ts
+++ b/cypress/api/Patients/Batch/ProcessWorker/Patient006.cy.ts
@@ -37,11 +37,7 @@ describe('Patients - Batch - Process worker - Patient006', () => {
     cy.apiCall('POST', 'patients/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/PartialKey.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/PartialKey.cy.ts
@@ -22,11 +22,7 @@ describe('Samples - Batch - Process worker - Partial key', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/Sample001.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/Sample001.cy.ts
@@ -23,11 +23,7 @@ describe('Samples - Batch - Process worker - Sample001', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/Sample002.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/Sample002.cy.ts
@@ -25,11 +25,7 @@ describe('Samples - Batch - Process worker - Sample002', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/Sample003.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/Sample003.cy.ts
@@ -23,11 +23,7 @@ describe('Samples - Batch - Process worker - Sample003', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/Sample004.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/Sample004.cy.ts
@@ -23,11 +23,7 @@ describe('Samples - Batch - Process worker - Sample004', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/Sample005.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/Sample005.cy.ts
@@ -24,11 +24,7 @@ describe('Samples - Batch - Process worker - Sample005', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/Sample006.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/Sample006.cy.ts
@@ -24,11 +24,7 @@ describe('Samples - Batch - Process worker - Sample006', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/Sample007.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/Sample007.cy.ts
@@ -24,11 +24,7 @@ describe('Samples - Batch - Process worker - Sample007', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/Sample008.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/Sample008.cy.ts
@@ -31,11 +31,7 @@ describe('Samples - Batch - Process worker - Sample008', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/Trim.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/Trim.cy.ts
@@ -24,11 +24,7 @@ describe('Samples - Batch - Process worker - Trim', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Samples/Batch/ProcessWorker/Valid.cy.ts
+++ b/cypress/api/Samples/Batch/ProcessWorker/Valid.cy.ts
@@ -22,11 +22,7 @@ describe('Samples - Batch - Process worker - Valid', () => {
     cy.apiCall('POST', 'samples/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Sequencing/Batch/ProcessWorker/Seq001.cy.ts
+++ b/cypress/api/Sequencing/Batch/ProcessWorker/Seq001.cy.ts
@@ -28,11 +28,7 @@ describe('Sequencing - Batch - Process worker - Seq001', () => {
     cy.apiCall('POST', 'sequencing/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Sequencing/Batch/ProcessWorker/Seq002.cy.ts
+++ b/cypress/api/Sequencing/Batch/ProcessWorker/Seq002.cy.ts
@@ -29,11 +29,7 @@ describe('Sequencing - Batch - Process worker - Seq002', () => {
     cy.apiCall('POST', 'sequencing/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Sequencing/Batch/ProcessWorker/Seq003.cy.ts
+++ b/cypress/api/Sequencing/Batch/ProcessWorker/Seq003.cy.ts
@@ -29,11 +29,7 @@ describe('Sequencing - Batch - Process worker - Seq003', () => {
     cy.apiCall('POST', 'sequencing/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Sequencing/Batch/ProcessWorker/Seq004.cy.ts
+++ b/cypress/api/Sequencing/Batch/ProcessWorker/Seq004.cy.ts
@@ -29,11 +29,7 @@ describe('Sequencing - Batch - Process worker - Seq004', () => {
     cy.apiCall('POST', 'sequencing/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Sequencing/Batch/ProcessWorker/Seq005.cy.ts
+++ b/cypress/api/Sequencing/Batch/ProcessWorker/Seq005.cy.ts
@@ -29,11 +29,7 @@ describe('Sequencing - Batch - Process worker - Seq005', () => {
     cy.apiCall('POST', 'sequencing/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Sequencing/Batch/ProcessWorker/Seq006.cy.ts
+++ b/cypress/api/Sequencing/Batch/ProcessWorker/Seq006.cy.ts
@@ -43,11 +43,7 @@ describe('Sequencing - Batch - Process worker - Seq006', () => {
     cy.apiCall('POST', 'sequencing/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Sequencing/Batch/ProcessWorker/Trim.cy.ts
+++ b/cypress/api/Sequencing/Batch/ProcessWorker/Trim.cy.ts
@@ -28,11 +28,7 @@ describe('Sequencing - Batch - Process worker - Trim', () => {
     cy.apiCall('POST', 'sequencing/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/api/Sequencing/Batch/ProcessWorker/Valid.cy.ts
+++ b/cypress/api/Sequencing/Batch/ProcessWorker/Valid.cy.ts
@@ -28,11 +28,7 @@ describe('Sequencing - Batch - Process worker - Valid', () => {
     cy.apiCall('POST', 'sequencing/batch?dry_run=true', body, Auth.token)
       .then((postRes: any) => {
         batch_id = postRes.body.id;
-        return batch_id;
-      })
-      .then(id => {
-        cy.wait(1000);
-        cy.apiCall('GET', `batches/${id}`, '', Auth.token);
+        return cy.waitForBatchStatus(batch_id, Auth.token);
       })
       .then((getRes: any) => {
         response = getRes;

--- a/cypress/pom/pages/CaseEntity_Files.ts
+++ b/cypress/pom/pages/CaseEntity_Files.ts
@@ -1,5 +1,6 @@
 /// <reference types="cypress"/>
 import { CommonSelectors } from 'pom/shared/Selectors';
+import { CommonTexts } from 'pom/shared/Texts';
 import { getUrlLink, stringToRegExp } from 'pom/shared/Utils';
 import { getColumnName, getColumnPosition } from 'pom/shared/Utils';
 
@@ -170,7 +171,7 @@ export const CaseEntity_Files = {
      * @param dataValue The data value to filter.
      */
     filterFormat(dataValue: string) {
-      cy.get('button:has([class*="lucide-circle-plus"]):contains("Format")').clickAndWait({ force: true });
+      cy.get(`button:has(${CommonSelectors.circlePlusIcon}):contains("${CommonTexts.en.format}")`).clickAndWait({ force: true });
       cy.get(`[data-value="${dataValue}"] button[role="checkbox"]`).click({ force:true });
     },
     /**

--- a/cypress/pom/pages/CaseEntity_Variants_SavedFilters.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SavedFilters.ts
@@ -1,5 +1,6 @@
 /// <reference types="cypress"/>
 import { CommonSelectors } from 'pom/shared/Selectors';
+import { CommonTexts } from 'pom/shared/Texts';
 
 const generateSavedFiltersFunctions = () => {
   const actions = {
@@ -99,7 +100,7 @@ const generateSavedFiltersFunctions = () => {
      */
     openManager() {
       actions.openMyFiltersDropdown();
-      cy.get('body').contains('Manage filters').clickAndWait({ force: true });
+      cy.get('body').contains(CommonTexts.en.manageFilters).clickAndWait({ force: true });
     },
     /**
      * Opens the My Filters dropdown.

--- a/cypress/pom/shared/Selectors.ts
+++ b/cypress/pom/shared/Selectors.ts
@@ -6,6 +6,7 @@ export const CommonSelectors = {
   anchorIcon: '[class*="lucide-arrow-up-right"]',
   animateIn: '[class*="data-[state=open]:animate-in"]',
   checkIcon: '[class*="lucide-check"]',
+  circlePlusIcon: '[class*="lucide-circle-plus"]',
   closeButton: 'button:contains("Close")',
   colorIndicator: (color: string) => `[class*="text-indicator-${color}"]`,
   detailsButton: 'button:contains("Details")',

--- a/cypress/pom/shared/Texts.ts
+++ b/cypress/pom/shared/Texts.ts
@@ -1,23 +1,27 @@
 /// <reference types="cypress"/>
 export const CommonTexts = {
   en: {
+    collapseAll: 'Collapse all',
+    expandAll: 'Expand all',
+    format: 'Format',
     igvMaxZoom: '40 bp',
     igvTitle: 'Alignment and variant',
-    igvTrackRefseq: 'Refseq Genes',
     igvTrackReads: (sample: string, relationship: string) => `Reads: ${sample} ${relationship}`,
+    igvTrackRefseq: 'Refseq Genes',
     loginContent: 'Log in with',
+    manageFilters: 'Manage filters',
     switchLanguage: 'FR',
-    expandAll: 'Expand all',
-    collapseAll: 'Collapse all',
   },
   fr: {
+    collapseAll: 'Réduire tout',
+    expandAll: 'Développer tout',
+    format: 'Format',
     igvMaxZoom: '40 bp',
     igvTitle: 'Alignement et variant',
-    igvTrackRefseq: 'Refseq Genes',
     igvTrackReads: (sample: string, relationship: string) => `Reads: ${sample} ${relationship}`,
+    igvTrackRefseq: 'Refseq Genes',
     loginContent: 'Choisir votre identifiant',
+    manageFilters: 'Gérer les filtres',
     switchLanguage: 'EN',
-    expandAll: 'Développer tout',
-    collapseAll: 'Réduire tout',
   },
 };

--- a/cypress/support/apiCommands.ts
+++ b/cypress/support/apiCommands.ts
@@ -184,3 +184,29 @@ Cypress.Commands.add('validateSummary', (response: any, created: number, updated
     errors: errors,
   });
 });
+
+/**
+ * Polls a batch until it reaches the expected status or fails.
+ * Uses a polling mechanism with configurable retry attempts and wait intervals.
+ * Automatically stops if the status is ERROR or the maximum retries are reached.
+ * @param batchId The unique identifier of the batch to monitor.
+ * @param token The Bearer authentication token.
+ * @param expectedStatus The target status to wait for (default: 'SUCCESS').
+ * @param maxRetries The maximum number of polling attempts (default: 10).
+ * @returns A Cypress chain containing the final batch status response.
+ */
+Cypress.Commands.add('waitForBatchStatus', (batchId: string, token: string, expectedStatus: string = 'SUCCESS', maxRetries: number = 10) => {
+  const poll = (attempt: number): Cypress.Chainable => {
+    return cy.apiCall('GET', `batches/${batchId}`, '', token).then((res: any) => {
+      if (res.body.status === expectedStatus || res.body.status === 'ERROR') {
+        return res;
+      }
+      if (attempt >= maxRetries) {
+        throw new Error(`Batch ${batchId} did not reach status "${expectedStatus}" after ${maxRetries} attempts`);
+      }
+      cy.wait(500);
+      return poll(attempt + 1);
+    });
+  };
+  return poll(0);
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -97,11 +97,10 @@ Cypress.Commands.add('login', () => {
  */
 Cypress.Commands.add('logout', () => {
   cy.visit('/');
-  cy.wait(2000);
-
-  cy.get(CommonSelectors.userIcon).eq(0).click();
+  cy.waitWhileLoad(oneMinute);
+  cy.get(CommonSelectors.userIcon).eq(0).should('be.visible').click();
   cy.get(`${CommonSelectors.menuPopper} ${CommonSelectors.logoutIcon}`).click();
-  cy.wait(2000);
+  cy.url().should('include', '/realms/');
 });
 
 /**
@@ -115,7 +114,7 @@ Cypress.Commands.add('pinColumn', (position: number, tableId: string = '') => {
     .find(CommonSelectors.pinIcon)
     .click({ force: true });
   cy.get(`${CommonSelectors.menuPopper} ${CommonSelectors.pinLeftIcon}`).click({ force: true });
-  cy.wait(1000);
+  cy.get(CommonSelectors.menuPopper).should('not.exist');
 });
 
 /**
@@ -213,11 +212,10 @@ Cypress.Commands.add('shouldHaveTooltip', { prevSubject: 'element' }, (subject, 
       .scrollIntoView({ offset: { top: -300, left: -300 } })
       .should('be.visible');
   } else {
-    scrollIntoSubject = cy.wrap(subject).scrollIntoView().wait(1000).should('be.visible');
+    scrollIntoSubject = cy.wrap(subject).scrollIntoView().should('be.visible');
   }
   if (object.tooltip) {
-    cy.wait(6000);
-    scrollIntoSubject.find(`${CommonSelectors.underlineHeader}, ${CommonSelectors.facetTriggerTooltip}`).realHover();
+    scrollIntoSubject.find(`${CommonSelectors.underlineHeader}, ${CommonSelectors.facetTriggerTooltip}`).should('be.visible').realHover();
     cy.get(CommonSelectors.tooltipPopper).invoke('css', { position: 'fixed', left: '20px' } /*Avoid hiding the logo*/).contains(object.tooltip).first().should('exist');
     cy.get(CommonSelectors.logo).click(); // Close the popper
     cy.get(CommonSelectors.tooltipPopper).should('not.exist');
@@ -271,7 +269,10 @@ Cypress.Commands.add('sortTableAndWait', (position: number, tableId: string = ''
     .eq(position)
     .find(CommonSelectors.sortIcon)
     .click({ force: true });
-  cy.wait(1000);
+  cy.get(`${CommonSelectors.tableHeadCell(tableId)}`)
+    .eq(position)
+    .find(CommonSelectors.sortIcon)
+    .should('exist');
 });
 
 /**
@@ -285,7 +286,7 @@ Cypress.Commands.add('unpinColumn', (position: number, tableId: string = '') => 
     .find(CommonSelectors.pinIcon)
     .click({ force: true });
   cy.get(`${CommonSelectors.menuPopper} ${CommonSelectors.unpinIcon}`).click({ force: true });
-  cy.wait(1000);
+  cy.get(CommonSelectors.menuPopper).should('not.exist');
 });
 
 /**
@@ -314,7 +315,7 @@ Cypress.Commands.add('validatePillSelectedQuery', (facetTitle: string | RegExp, 
  * @param tableId The table ID to check (default: '').
  */
 Cypress.Commands.add('validateTableFirstRowAttr', (expectedAttr: string, expectedValue: string, columnIndex: number, tableId: string = '') => {
-  cy.wait(2000);
+  cy.get(CommonSelectors.tableRow(tableId)).should('have.length.gte', 1);
   cy.get(CommonSelectors.tableRow(tableId))
     .eq(0)
     .find(CommonSelectors.tableCellData)
@@ -330,7 +331,7 @@ Cypress.Commands.add('validateTableFirstRowAttr', (expectedAttr: string, expecte
  * @param tableId The table ID to check (default: '').
  */
 Cypress.Commands.add('validateTableFirstRowClass', (expectedClass: string, columnIndex: number, tableId: string = '') => {
-  cy.wait(2000);
+  cy.get(CommonSelectors.tableRow(tableId)).should('have.length.gte', 1);
   cy.get(CommonSelectors.tableRow(tableId)).eq(0).find(CommonSelectors.tableCellData).eq(columnIndex).find(expectedClass).should('exist');
 });
 
@@ -341,7 +342,7 @@ Cypress.Commands.add('validateTableFirstRowClass', (expectedClass: string, colum
  * @param tableId The table ID to check (default: '').
  */
 Cypress.Commands.add('validateTableFirstRowContent', (expectedValue: string | RegExp, columnIndex: number, tableId: string = '') => {
-  cy.wait(2000);
+  cy.get(CommonSelectors.tableRow(tableId)).should('have.length.gte', 1);
   cy.get(CommonSelectors.tableRow(tableId)).eq(0).find(CommonSelectors.tableCellData).eq(columnIndex).contains(expectedValue).should('exist');
 });
 

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -12,6 +12,7 @@ declare namespace Cypress {
     validateReport(response: any, level: string, code: string, message: string, path: string): cy & CyEventEmitter;
     validateSuccessBatchProcessed(response: any, batch_type: string, batch_id: string): cy & CyEventEmitter;
     validateSummary(response: any, created: number, updated: number, skipped: number, errors: number): cy & CyEventEmitter;
+    waitForBatchStatus(batchId: string, token: string, expectedStatus: string = 'SUCCESS', maxRetries: number = 10): Cypress.Chainable;
 
     // commands
     clickAndWait(options?: Partial<ClickOptions>): Chainable<Element>;


### PR DESCRIPTION
# feat: SJRA-1352 Add cypress_CLAUDE_md and some improvements

## 📌 Contexte

Ajout du fichier `CLAUDE.md` pour le répertoire Cypress et amélioration de la stabilité des tests en remplaçant les `cy.wait()` statiques par des assertions dynamiques et un mécanisme de polling pour les batch.

## 📝 Changements

- Ajout de `cypress/CLAUDE.md` : documentation complète de la suite de tests Cypress (structure, POM, commandes, conventions)
- Nouvelle commande `cy.waitForBatchStatus()` dans `apiCommands.ts` : polling avec retry configurable remplaçant les `cy.wait(1000)` + `cy.apiCall('GET', ...)` dans tous les tests batch (Patients, Samples, Sequencing)
- Remplacement des `cy.wait()` statiques par des assertions Cypress dans `commands.ts` :
  - `logout` : `cy.url().should('include', '/realms/')` au lieu de `cy.wait(2000)`
  - `pinColumn` / `unpinColumn` : `cy.get(menuPopper).should('not.exist')` au lieu de `cy.wait(1000)`
  - `shouldHaveTooltip` : `.should('be.visible').realHover()` au lieu de `cy.wait(6000)`
  - `sortTableAndWait` : assertion sur l'icône de tri au lieu de `cy.wait(1000)`
  - `validateTableFirstRowAttr/Class/Content` : `should('have.length.gte', 1)` au lieu de `cy.wait(2000)`
- Centralisation de sélecteurs et textes dans le POM :
  - Ajout de `circlePlusIcon` dans `Selectors.ts`
  - Ajout de `format`, `manageFilters` dans `Texts.ts` (EN/FR)
  - Tri alphabétique des entrées dans `Texts.ts`
  - Utilisation des constantes dans `CaseEntity_Files.ts` et `CaseEntity_Variants_SavedFilters.ts`
- Ajout de la définition TypeScript de `waitForBatchStatus` dans `index.d.ts`

## 🧪 Tests

- Les tests batch (Patients, Samples, Sequencing) utilisent maintenant `cy.waitForBatchStatus()` au lieu du pattern `cy.wait(1000)` + appel GET manuel
- Les tests impactés ont été exécutés localement et passent avec succès

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1352](https://d3b.atlassian.net/browse/SJRA-1352)<!-- End JIRA Issues -->

[SJRA-1352]: https://d3b.atlassian.net/browse/SJRA-1352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ