### PR TITLE
feat: SJRA-1355 Adjust Cypress tests - increase default page size

### DIFF
--- a/cypress/pom/pages/CaseEntity_Variants_CNV_Table.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_CNV_Table.ts
@@ -476,7 +476,7 @@ export const CaseEntity_Variants_CNV_Table = {
      */
     shouldRequestOnPageChange(dataCase: any) {
       cy.intercept('POST', '**/list', req => {
-        expect(req.body.limit).to.deep.equal(10);
+        expect(req.body.limit).to.deep.equal(30);
         expect(req.body.page_index).to.deep.equal(0);
         req.continue();
       }).as('listRequest1');
@@ -485,7 +485,7 @@ export const CaseEntity_Variants_CNV_Table = {
       cy.waitWhileLoad(60*1000);
 
       cy.intercept('POST', '**/list', req => {
-        expect(req.body.limit).to.deep.equal(10);
+        expect(req.body.limit).to.deep.equal(30);
         expect(req.body.page_index).to.deep.equal(1);
         req.continue();
       }).as('listRequest2');
@@ -494,7 +494,7 @@ export const CaseEntity_Variants_CNV_Table = {
       cy.waitWhileLoad(60*1000);
 
       cy.intercept('POST', '**/list', req => {
-        expect(req.body.limit).to.deep.equal(10);
+        expect(req.body.limit).to.deep.equal(30);
         expect(req.body.page_index).to.deep.equal(2);
         req.continue();
       }).as('listRequest3');
@@ -503,7 +503,7 @@ export const CaseEntity_Variants_CNV_Table = {
       cy.waitWhileLoad(60*1000);
 
       cy.intercept('POST', '**/list', req => {
-        expect(req.body.limit).to.deep.equal(10);
+        expect(req.body.limit).to.deep.equal(30);
         expect(req.body.page_index).to.deep.equal(1);
         req.continue();
       }).as('listRequest4');
@@ -512,7 +512,7 @@ export const CaseEntity_Variants_CNV_Table = {
       cy.waitWhileLoad(60*1000);
 
       cy.intercept('POST', '**/list', req => {
-        expect(req.body.limit).to.deep.equal(10);
+        expect(req.body.limit).to.deep.equal(30);
         expect(req.body.page_index).to.deep.equal(0);
         req.continue();
       }).as('listRequest5');

--- a/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
@@ -491,7 +491,7 @@ export const CaseEntity_Variants_SNV_Table = {
      */
     shouldRequestOnPageChange(dataCase: any) {
       cy.intercept('POST', '**/list', req => {
-        expect(req.body.limit).to.deep.equal(10);
+        expect(req.body.limit).to.deep.equal(30);
         expect(req.body.page_index).to.deep.equal(0);
         req.continue();
       }).as('listRequest1');
@@ -500,7 +500,7 @@ export const CaseEntity_Variants_SNV_Table = {
       cy.waitWhileLoad(60*1000);
 
       cy.intercept('POST', '**/list', req => {
-        expect(req.body.limit).to.deep.equal(10);
+        expect(req.body.limit).to.deep.equal(30);
         expect(req.body.page_index).to.deep.equal(1);
         req.continue();
       }).as('listRequest2');
@@ -509,7 +509,7 @@ export const CaseEntity_Variants_SNV_Table = {
       cy.waitWhileLoad(60*1000);
 
       cy.intercept('POST', '**/list', req => {
-        expect(req.body.limit).to.deep.equal(10);
+        expect(req.body.limit).to.deep.equal(30);
         expect(req.body.page_index).to.deep.equal(2);
         req.continue();
       }).as('listRequest3');
@@ -518,7 +518,7 @@ export const CaseEntity_Variants_SNV_Table = {
       cy.waitWhileLoad(60*1000);
 
       cy.intercept('POST', '**/list', req => {
-        expect(req.body.limit).to.deep.equal(10);
+        expect(req.body.limit).to.deep.equal(30);
         expect(req.body.page_index).to.deep.equal(1);
         req.continue();
       }).as('listRequest4');
@@ -527,7 +527,7 @@ export const CaseEntity_Variants_SNV_Table = {
       cy.waitWhileLoad(60*1000);
 
       cy.intercept('POST', '**/list', req => {
-        expect(req.body.limit).to.deep.equal(10);
+        expect(req.body.limit).to.deep.equal(30);
         expect(req.body.page_index).to.deep.equal(0);
         req.continue();
       }).as('listRequest5');


### PR DESCRIPTION
# feat: SJRA-1355 Adjust Cypress tests - increase default page size

## 📌 Contexte

Ajustement des tests Cypress suite à l'augmentation de la taille de page par défaut (de 10 à 30) pour les tableaux de variants dans l'entité Case.

## 📝 Modifications

- Mise à jour de `cypress/pom/pages/CaseEntity_Variants_CNV_Table.ts` : la valeur attendue de `req.body.limit` passe de `10` à `30` dans la méthode `shouldRequestOnPageChange` (5 interceptions).
- Mise à jour de `cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts` : même ajustement de `10` à `30` dans la méthode `shouldRequestOnPageChange` (5 interceptions).

## 🧪 Tests

- Les tests Cypress impactés (CaseEntity Variants CNV/SNV - pagination) ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1355](https://d3b.atlassian.net/browse/SJRA-1355)<!-- End JIRA Issues -->


[SJRA-1355]: https://d3b.atlassian.net/browse/SJRA-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ