### PR TITLE
feat: SJRA-1361 Add My Network table Cypress tests

### DIFF
--- a/cypress/CLAUDE.md
+++ b/cypress/CLAUDE.md
@@ -6,7 +6,6 @@ This file provides guidance to Claude Code when working in the `cypress/` direct
 
 End-to-end (E2E) and API test suite for the Radiant Portal. Tests run against a live QA environment using Cypress with a Page Object Model (POM) pattern.
 
-- **162 tests total**: 66 E2E (UI) + 96 API
 - **QA base URL**: `https://radiant.qa.juno.cqdg.ferlab.bio/`
 - **API base URL**: `https://radiant-api.qa.juno.cqdg.ferlab.bio/`
 - **Auth**: Keycloak at `https://auth.qa.juno.cqdg.ferlab.bio`
@@ -44,7 +43,6 @@ cypress/
 │   ├── Cases/             # Case list table tests
 │   ├── CaseEntity/        # Case detail page (Details, Files, Variants SNV/CNV)
 │   ├── Connexion/         # Login tests
-│   ├── DataQuality/       # Data quality checks
 │   ├── Files/             # Files list tests
 │   └── VariantEntity/     # Variant detail page (EvidCond, Frequency, Patients)
 ├── pom/                   # Page Object Model

--- a/cypress/api/Cases/Search/Paging.cy.ts
+++ b/cypress/api/Cases/Search/Paging.cy.ts
@@ -42,15 +42,18 @@ describe('Cases - Search - Paging', () => {
     }`;
     let firstItemOfAll: any;
 
-    cy.apiCall('POST', `cases/search`, firstBody, Auth.token).then(firstRes => {
-      firstItemOfAll = firstRes.body.list[0].case_id;
-    }).then(() => {
-      cy.apiCall('POST', `cases/search`, secondBody, Auth.token);
-    }).then((secondRes: any) => {
-      expect(secondRes.status).to.eq(200);
-      cy.validateItemCount(secondRes, 10, 'list');
-      expect(secondRes.body.list[0].case_id).to.not.eq(firstItemOfAll);
-    });
+    cy.apiCall('POST', `cases/search`, firstBody, Auth.token)
+      .then(firstRes => {
+        firstItemOfAll = firstRes.body.list[0].case_id;
+      })
+      .then(() => {
+        cy.apiCall('POST', `cases/search`, secondBody, Auth.token);
+      })
+      .then((secondRes: any) => {
+        expect(secondRes.status).to.eq(200);
+        cy.validateItemCount(secondRes, 10, 'list');
+        expect(secondRes.body.list[0].case_id).to.not.eq(firstItemOfAll);
+      });
   });
 
   it('No more items', () => {

--- a/cypress/api/Documents/Search/Paging.cy.ts
+++ b/cypress/api/Documents/Search/Paging.cy.ts
@@ -42,15 +42,18 @@ describe('Documents - Search - Paging', () => {
     }`;
     let firstItemOfAll: any;
 
-    cy.apiCall('POST', `documents/search`, firstBody, Auth.token).then(firstRes => {
-      firstItemOfAll = firstRes.body.list[0].document_id;
-    }).then(() => {
-      cy.apiCall('POST', `documents/search`, secondBody, Auth.token);
-    }).then((secondRes: any) => {
-      expect(secondRes.status).to.eq(200);
-      cy.validateItemCount(secondRes, 10, 'list');
-      expect(secondRes.body.list[0].document_id).to.not.eq(firstItemOfAll);
-    });
+    cy.apiCall('POST', `documents/search`, firstBody, Auth.token)
+      .then(firstRes => {
+        firstItemOfAll = firstRes.body.list[0].document_id;
+      })
+      .then(() => {
+        cy.apiCall('POST', `documents/search`, secondBody, Auth.token);
+      })
+      .then((secondRes: any) => {
+        expect(secondRes.status).to.eq(200);
+        cy.validateItemCount(secondRes, 10, 'list');
+        expect(secondRes.body.list[0].document_id).to.not.eq(firstItemOfAll);
+      });
   });
 
   it('No more items', () => {

--- a/cypress/api/Occurrences/Germline/CNV/List/Paging.cy.ts
+++ b/cypress/api/Occurrences/Germline/CNV/List/Paging.cy.ts
@@ -42,15 +42,18 @@ describe('Occurrences - Germline - CNV - List - Paging', () => {
     }`;
     let firstItemOfAll: any;
 
-    cy.apiCall('POST', `occurrences/germline/cnv/${dataCase.case}/${dataCase.seq.seq_id}/list`, firstBody, Auth.token).then(firstRes => {
-      firstItemOfAll = firstRes.body[0].name;
-    }).then(() => {
-      cy.apiCall('POST', `occurrences/germline/cnv/${dataCase.case}/${dataCase.seq.seq_id}/list`, secondBody, Auth.token);
-    }).then((secondRes: any) => {
-      expect(secondRes.status).to.eq(200);
-      cy.validateItemCount(secondRes, 10);
-      expect(secondRes.body[0].name).to.not.eq(firstItemOfAll);
-    });
+    cy.apiCall('POST', `occurrences/germline/cnv/${dataCase.case}/${dataCase.seq.seq_id}/list`, firstBody, Auth.token)
+      .then(firstRes => {
+        firstItemOfAll = firstRes.body[0].name;
+      })
+      .then(() => {
+        cy.apiCall('POST', `occurrences/germline/cnv/${dataCase.case}/${dataCase.seq.seq_id}/list`, secondBody, Auth.token);
+      })
+      .then((secondRes: any) => {
+        expect(secondRes.status).to.eq(200);
+        cy.validateItemCount(secondRes, 10);
+        expect(secondRes.body[0].name).to.not.eq(firstItemOfAll);
+      });
   });
 
   it('No more items', () => {

--- a/cypress/api/Occurrences/Germline/SNV/Count/Frequency.cy.ts
+++ b/cypress/api/Occurrences/Germline/SNV/Count/Frequency.cy.ts
@@ -41,7 +41,7 @@ describe('Occurrences - Germline - SNV - Count - Frequency', () => {
             expect(response.body.count.toString()).to.match(facetData.count);
           } else {
             expect(response.body.count).to.eq(facetData.count);
-          };
+          }
         });
       });
     });

--- a/cypress/api/Occurrences/Germline/SNV/List/Paging.cy.ts
+++ b/cypress/api/Occurrences/Germline/SNV/List/Paging.cy.ts
@@ -42,15 +42,18 @@ describe('Occurrences - Germline - SNV - List - Paging', () => {
     }`;
     let firstItemOfAll: any;
 
-    cy.apiCall('POST', `occurrences/germline/snv/${dataCase.case}/${dataCase.seq.seq_id}/list`, firstBody, Auth.token).then(firstRes => {
-      firstItemOfAll = firstRes.body[0].locus;
-    }).then(() => {
-      cy.apiCall('POST', `occurrences/germline/snv/${dataCase.case}/${dataCase.seq.seq_id}/list`, secondBody, Auth.token);
-    }).then((secondRes: any) => {
-      expect(secondRes.status).to.eq(200);
-      cy.validateItemCount(secondRes, 10);
-      expect(secondRes.body[0].locus).to.not.eq(firstItemOfAll);
-    });
+    cy.apiCall('POST', `occurrences/germline/snv/${dataCase.case}/${dataCase.seq.seq_id}/list`, firstBody, Auth.token)
+      .then(firstRes => {
+        firstItemOfAll = firstRes.body[0].locus;
+      })
+      .then(() => {
+        cy.apiCall('POST', `occurrences/germline/snv/${dataCase.case}/${dataCase.seq.seq_id}/list`, secondBody, Auth.token);
+      })
+      .then((secondRes: any) => {
+        expect(secondRes.status).to.eq(200);
+        cy.validateItemCount(secondRes, 10);
+        expect(secondRes.body[0].locus).to.not.eq(firstItemOfAll);
+      });
   });
 
   it('No more items', () => {

--- a/cypress/e2e/CaseEntity/Variants/CNV/Table/RequestValidation.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/Table/RequestValidation.cy.ts
@@ -13,7 +13,7 @@ describe('Case Entity - Variants - CNV - Table - Request Validation', () => {
     cy.visitCaseVariantsPage(data.case.case, 'CNV');
     CaseEntity_Variants_CNV_Table.validations.shouldRequestOnSort('start');
   });
-  
+
   it('Paging', () => {
     setupTest();
     CaseEntity_Variants_CNV_Table.validations.shouldRequestOnPageChange(data.case);

--- a/cypress/e2e/CaseEntity/Variants/SNV/SavedFilters/QueryBuilder.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/SavedFilters/QueryBuilder.cy.ts
@@ -22,7 +22,7 @@ describe('Case Entity - Variants - SNV - Saved filters - Query builder', () => {
 
     ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F0');
     ManagerFilterModal.actions.closeManager();
-    
+
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('plus', false /*isDisable*/, false /*isDirty*/);
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('duplicate', false /*isDisable*/, false /*isDirty*/);

--- a/cypress/e2e/Cases/RequestValidation.cy.ts
+++ b/cypress/e2e/Cases/RequestValidation.cy.ts
@@ -24,7 +24,7 @@ describe('Cases - Request Validation', () => {
     cy.visitCasesPage();
     CasesTable.validations.shouldRequestOnSort('case');
   });
-      
+
   it('Paging', () => {
     setupTest();
     CasesTable.validations.shouldRequestOnPageChange();

--- a/cypress/e2e/Files/RequestValidation.cy.ts
+++ b/cypress/e2e/Files/RequestValidation.cy.ts
@@ -12,7 +12,7 @@ describe('Files - Request Validation', () => {
     cy.visitFilesPage();
     FilesTable.validations.shouldRequestOnSort('name');
   });
-    
+
   it('Paging', () => {
     setupTest();
     FilesTable.validations.shouldRequestOnPageChange();

--- a/cypress/e2e/VariantEntity/Frequency/MyNetwork_Columns.cy.ts
+++ b/cypress/e2e/VariantEntity/Frequency/MyNetwork_Columns.cy.ts
@@ -1,0 +1,41 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { VariantEntity_Frequency } from 'pom/pages/VariantEntity_Frequency';
+
+describe('VariantEntity - Frequency - MyNetwork - Columns', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitVariantFrequencyPage(data.variantGermline.locus_id);
+  };
+
+  it('Default display', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldMatchDefaultColumnVisibility();
+  });
+
+  it('Order', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowAllColumns();
+  });
+
+  it('Pin', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowPinnableColumns();
+  });
+
+  it('Default pin state', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldMatchDefaultPinnedColumns();
+  });
+
+  it('Sort', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowSortableColumns();
+  });
+
+  it('Tooltip', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowColumnTooltips();
+  });
+});

--- a/cypress/e2e/VariantEntity/Frequency/MyNetwork_Hyperlinks.cy.ts
+++ b/cypress/e2e/VariantEntity/Frequency/MyNetwork_Hyperlinks.cy.ts
@@ -1,0 +1,16 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { VariantEntity_Frequency } from 'pom/pages/VariantEntity_Frequency';
+
+describe('VariantEntity - Frequency - MyNetwork - Hyperlinks', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitVariantFrequencyPage(data.variantGermline.locus_id);
+  };
+
+  it('Primary Condition', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldHaveTableCellLink(data.variantGermline.myNetwork, 'primary_condition');
+  });
+});

--- a/cypress/e2e/VariantEntity/Frequency/MyNetwork_InformationDisplayed.cy.ts
+++ b/cypress/e2e/VariantEntity/Frequency/MyNetwork_InformationDisplayed.cy.ts
@@ -1,0 +1,46 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { VariantEntity_Frequency } from 'pom/pages/VariantEntity_Frequency';
+
+describe('VariantEntity - Frequency - MyNetwork - Information displayed', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitVariantFrequencyPage(data.variantGermline.locus_id);
+  };
+
+  it('Primary Condition', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowColumnContent('primary_condition', data.variantGermline.myNetwork);
+  });
+
+  it('Frequency (All Patients)', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowColumnContent('freq_all', data.variantGermline.myNetwork);
+  });
+
+  it('Homozygotes (All Patients)', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowColumnContent('homo_all', data.variantGermline.myNetwork);
+  });
+
+  it('Frequency (Affected Patients)', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowColumnContent('freq_affected', data.variantGermline.myNetwork);
+  });
+
+  it('Homozygotes (Affected Patients)', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowColumnContent('homo_affected', data.variantGermline.myNetwork);
+  });
+
+  it('Frequency (Non-Affected Patients)', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowColumnContent('freq_non_affected', data.variantGermline.myNetwork);
+  });
+
+  it('Homozygotes (Non-Affected Patients)', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldShowColumnContent('homo_non_affected', data.variantGermline.myNetwork);
+  });
+});

--- a/cypress/e2e/VariantEntity/Frequency/PublicCohorts_InformationDisplayed.cy.ts
+++ b/cypress/e2e/VariantEntity/Frequency/PublicCohorts_InformationDisplayed.cy.ts
@@ -8,7 +8,7 @@ describe('VariantEntity - Frequency - PublicCohorts - Information displayed', ()
     cy.login();
     cy.visitVariantFrequencyPage(data.variantGermline.locus_id);
   };
-  
+
   it('Cohort', () => {
     setupTest();
     VariantEntity_Frequency.publicCohorts.validations.shouldShowColumnContent('cohort', data.variantGermline.publicCohorts);

--- a/cypress/pom/pages/CaseEntity_Details.ts
+++ b/cypress/pom/pages/CaseEntity_Details.ts
@@ -412,46 +412,46 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
 
 const bioinformaticsColumnContentHandler = (columnID: string, data: any, position: number) => {
   const tableId = selectors.bioinformaticsCard.tableId;
-    switch (columnID) {
-      case 'patient':
-        cy.validateTableFirstRowContent(data[columnID], position, tableId);
-        cy.validateTableFirstRowClass(CommonSelectors.tagBlank, position);
-        break;
-      case 'type':
-        cy.validateTableFirstRowContent(data[columnID], position, tableId);
-        cy.validateTableFirstRowClass(CommonSelectors.tagLevel('secondary'), position, tableId);
-        break;
-      default:
-        cy.validateTableFirstRowContent(data[columnID], position, tableId);
-        break;
-    }
+  switch (columnID) {
+    case 'patient':
+      cy.validateTableFirstRowContent(data[columnID], position, tableId);
+      cy.validateTableFirstRowClass(CommonSelectors.tagBlank, position);
+      break;
+    case 'type':
+      cy.validateTableFirstRowContent(data[columnID], position, tableId);
+      cy.validateTableFirstRowClass(CommonSelectors.tagLevel('secondary'), position, tableId);
+      break;
+    default:
+      cy.validateTableFirstRowContent(data[columnID], position, tableId);
+      break;
+  }
 };
 
 const sequencingColumnContentHandler = (columnID: string, data: any, position: number) => {
   const tableId = selectors.sequencingCard.tableId;
-    switch (columnID) {
-      case 'relationship':
-      case 'histology':
-        cy.validateTableFirstRowContent(data[columnID], position, tableId);
-        cy.validateTableFirstRowClass(CommonSelectors.tagBlank, position);
-        break;
-      case 'sample_type':
-      case 'exp_strat':
-        cy.validateTableFirstRowContent(data[columnID], position, tableId);
-        cy.validateTableFirstRowClass(CommonSelectors.tagLevel('secondary'), position, tableId);
-        break;
-      case 'seq_status':
-        cy.validateTableFirstRowContent(data[columnID], position, tableId);
-        cy.validateTableFirstRowClass(CommonSelectors.statusIcon(getStatusIcon(data[columnID])), position, tableId);
-        cy.validateTableFirstRowClass(CommonSelectors.tag(getStatusColor(data[columnID])), position, tableId);
-        break;
-      case 'actions':
-        cy.validateTableFirstRowClass(CommonSelectors.detailsButton, position, tableId);
-        break;
-      default:
-        cy.validateTableFirstRowContent(data[columnID], position, tableId);
-        break;
-    }
+  switch (columnID) {
+    case 'relationship':
+    case 'histology':
+      cy.validateTableFirstRowContent(data[columnID], position, tableId);
+      cy.validateTableFirstRowClass(CommonSelectors.tagBlank, position);
+      break;
+    case 'sample_type':
+    case 'exp_strat':
+      cy.validateTableFirstRowContent(data[columnID], position, tableId);
+      cy.validateTableFirstRowClass(CommonSelectors.tagLevel('secondary'), position, tableId);
+      break;
+    case 'seq_status':
+      cy.validateTableFirstRowContent(data[columnID], position, tableId);
+      cy.validateTableFirstRowClass(CommonSelectors.statusIcon(getStatusIcon(data[columnID])), position, tableId);
+      cy.validateTableFirstRowClass(CommonSelectors.tag(getStatusColor(data[columnID])), position, tableId);
+      break;
+    case 'actions':
+      cy.validateTableFirstRowClass(CommonSelectors.detailsButton, position, tableId);
+      break;
+    default:
+      cy.validateTableFirstRowContent(data[columnID], position, tableId);
+      break;
+  }
 };
 
 export const CaseEntity_Details = {
@@ -472,14 +472,13 @@ export const CaseEntity_Details = {
     },
   },
 
-
   bioinformaticsCard: {
     actions: (() => {
       const baseActions = generateTableActionsFunctions(selectors.bioinformaticsCard.tableId, tableColumns.bioinformaticsCard);
       return {
         ...baseActions,
         clickDetailsButton(data: any) {
-          baseActions.clickDetailsButton(data, (data) => selectors.bioinformaticsCard.tableCell(data));
+          baseActions.clickDetailsButton(data, data => selectors.bioinformaticsCard.tableCell(data));
         },
       };
     })(),
@@ -503,7 +502,7 @@ export const CaseEntity_Details = {
       return {
         ...baseActions,
         clickDetailsButton(data: any) {
-          baseActions.clickDetailsButton(data, (data) => selectors.sequencingCard.tableCell(data));
+          baseActions.clickDetailsButton(data, data => selectors.sequencingCard.tableCell(data));
         },
       };
     })(),

--- a/cypress/pom/pages/CaseEntity_Files.ts
+++ b/cypress/pom/pages/CaseEntity_Files.ts
@@ -172,7 +172,7 @@ export const CaseEntity_Files = {
      */
     filterFormat(dataValue: string) {
       cy.get(`button:has(${CommonSelectors.circlePlusIcon}):contains("${CommonTexts.en.format}")`).clickAndWait({ force: true });
-      cy.get(`[data-value="${dataValue}"] button[role="checkbox"]`).click({ force:true });
+      cy.get(`[data-value="${dataValue}"] button[role="checkbox"]`).click({ force: true });
     },
     /**
      * Hides a specific column in the table.
@@ -501,7 +501,7 @@ export const CaseEntity_Files = {
                         throw new Error(`Error: "${biggest}" should be equal to "${smallest}" (unique values expected)`);
                       }
                     } else if (!isReverseSorting && biggest.localeCompare(smallest) <= 0) {
-                        throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
+                      throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
                     } else if (isReverseSorting && biggest.localeCompare(smallest) >= 0) {
                       throw new Error(`Error: "${biggest}" should be < "${smallest}"`);
                     }

--- a/cypress/pom/pages/CaseEntity_Variants_CNV_Table.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_CNV_Table.ts
@@ -217,7 +217,7 @@ export const CaseEntity_Variants_CNV_Table = {
      * @param buttonName The button name to click (First | Last | Previous | Next | Select)
      */
     clickPaginationButton(buttonName: string) {
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
       cy.get(CommonSelectors.paginationButton(buttonName)).clickAndWait({ force: true });
     },
     /**
@@ -482,7 +482,7 @@ export const CaseEntity_Variants_CNV_Table = {
       }).as('listRequest1');
       cy.visitCaseVariantsPage(dataCase.case, 'CNV');
       cy.wait('@listRequest1');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/list', req => {
         expect(req.body.limit).to.deep.equal(30);
@@ -491,7 +491,7 @@ export const CaseEntity_Variants_CNV_Table = {
       }).as('listRequest2');
       CaseEntity_Variants_CNV_Table.actions.clickPaginationButton('Next');
       cy.wait('@listRequest2');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/list', req => {
         expect(req.body.limit).to.deep.equal(30);
@@ -500,7 +500,7 @@ export const CaseEntity_Variants_CNV_Table = {
       }).as('listRequest3');
       CaseEntity_Variants_CNV_Table.actions.clickPaginationButton('Next');
       cy.wait('@listRequest3');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/list', req => {
         expect(req.body.limit).to.deep.equal(30);
@@ -509,7 +509,7 @@ export const CaseEntity_Variants_CNV_Table = {
       }).as('listRequest4');
       CaseEntity_Variants_CNV_Table.actions.clickPaginationButton('Previous');
       cy.wait('@listRequest4');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/list', req => {
         expect(req.body.limit).to.deep.equal(30);
@@ -656,7 +656,7 @@ export const CaseEntity_Variants_CNV_Table = {
                         throw new Error(`Error: "${biggest}" should be equal to "${smallest}" (unique values expected)`);
                       }
                     } else if (!isReverseSorting && biggest.localeCompare(smallest) <= 0) {
-                        throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
+                      throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
                     } else if (isReverseSorting && biggest.localeCompare(smallest) >= 0) {
                       throw new Error(`Error: "${biggest}" should be < "${smallest}"`);
                     }

--- a/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
@@ -217,7 +217,7 @@ export const CaseEntity_Variants_SNV_Table = {
      * @param buttonName The button name to click (First | Last | Previous | Next | Select)
      */
     clickPaginationButton(buttonName: string) {
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
       cy.get(CommonSelectors.paginationButton(buttonName)).clickAndWait({ force: true });
     },
     /**
@@ -497,7 +497,7 @@ export const CaseEntity_Variants_SNV_Table = {
       }).as('listRequest1');
       cy.visitCaseVariantsPage(dataCase.case, 'SNV');
       cy.wait('@listRequest1');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/list', req => {
         expect(req.body.limit).to.deep.equal(30);
@@ -506,7 +506,7 @@ export const CaseEntity_Variants_SNV_Table = {
       }).as('listRequest2');
       CaseEntity_Variants_SNV_Table.actions.clickPaginationButton('Next');
       cy.wait('@listRequest2');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/list', req => {
         expect(req.body.limit).to.deep.equal(30);
@@ -515,7 +515,7 @@ export const CaseEntity_Variants_SNV_Table = {
       }).as('listRequest3');
       CaseEntity_Variants_SNV_Table.actions.clickPaginationButton('Next');
       cy.wait('@listRequest3');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/list', req => {
         expect(req.body.limit).to.deep.equal(30);
@@ -524,7 +524,7 @@ export const CaseEntity_Variants_SNV_Table = {
       }).as('listRequest4');
       CaseEntity_Variants_SNV_Table.actions.clickPaginationButton('Previous');
       cy.wait('@listRequest4');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/list', req => {
         expect(req.body.limit).to.deep.equal(30);
@@ -721,7 +721,7 @@ export const CaseEntity_Variants_SNV_Table = {
                         throw new Error(`Error: "${biggest}" should be equal to "${smallest}" (unique values expected)`);
                       }
                     } else if (!isReverseSorting && biggest.localeCompare(smallest) <= 0) {
-                        throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
+                      throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
                     } else if (isReverseSorting && biggest.localeCompare(smallest) >= 0) {
                       throw new Error(`Error: "${biggest}" should be < "${smallest}"`);
                     }

--- a/cypress/pom/pages/CasesTable.ts
+++ b/cypress/pom/pages/CasesTable.ts
@@ -194,7 +194,7 @@ export const CasesTable = {
      * @param buttonName The button name to click (First | Last | Previous | Next | Select)
      */
     clickPaginationButton(buttonName: string) {
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
       cy.get(CommonSelectors.paginationButton(buttonName)).clickAndWait({ force: true });
     },
     /**
@@ -429,7 +429,7 @@ export const CasesTable = {
       }).as('searchRequest1');
       cy.visitCasesPage();
       cy.wait('@searchRequest1');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/search', req => {
         expect(req.body.limit).to.deep.equal(20);
@@ -438,7 +438,7 @@ export const CasesTable = {
       }).as('searchRequest2');
       CasesTable.actions.clickPaginationButton('Next');
       cy.wait('@searchRequest2');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/search', req => {
         expect(req.body.limit).to.deep.equal(20);
@@ -447,7 +447,7 @@ export const CasesTable = {
       }).as('searchRequest3');
       CasesTable.actions.clickPaginationButton('Previous');
       cy.wait('@searchRequest3');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/search', req => {
         expect(req.body.limit).to.deep.equal(20);
@@ -456,7 +456,7 @@ export const CasesTable = {
       }).as('searchRequest4');
       CasesTable.actions.clickPaginationButton('Next');
       cy.wait('@searchRequest4');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/search', req => {
         expect(req.body.limit).to.deep.equal(20);
@@ -655,7 +655,7 @@ export const CasesTable = {
                         throw new Error(`Error: "${biggest}" should be equal to "${smallest}" (unique values expected)`);
                       }
                     } else if (!isReverseSorting && biggest.localeCompare(smallest) <= 0) {
-                        throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
+                      throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
                     } else if (isReverseSorting && biggest.localeCompare(smallest) >= 0) {
                       throw new Error(`Error: "${biggest}" should be < "${smallest}"`);
                     }

--- a/cypress/pom/pages/FilesTable.ts
+++ b/cypress/pom/pages/FilesTable.ts
@@ -171,7 +171,7 @@ export const FilesTable = {
      * @param buttonName The button name to click (First | Last | Previous | Next | Select)
      */
     clickPaginationButton(buttonName: string) {
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
       cy.get(CommonSelectors.paginationButton(buttonName)).clickAndWait({ force: true });
     },
     /**
@@ -384,7 +384,7 @@ export const FilesTable = {
       }).as('searchRequest1');
       cy.visitFilesPage();
       cy.wait('@searchRequest1');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/search', req => {
         expect(req.body.limit).to.deep.equal(20);
@@ -393,7 +393,7 @@ export const FilesTable = {
       }).as('searchRequest2');
       FilesTable.actions.clickPaginationButton('Next');
       cy.wait('@searchRequest2');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/search', req => {
         expect(req.body.limit).to.deep.equal(20);
@@ -402,7 +402,7 @@ export const FilesTable = {
       }).as('searchRequest3');
       FilesTable.actions.clickPaginationButton('Next');
       cy.wait('@searchRequest3');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/search', req => {
         expect(req.body.limit).to.deep.equal(20);
@@ -411,7 +411,7 @@ export const FilesTable = {
       }).as('searchRequest4');
       FilesTable.actions.clickPaginationButton('Previous');
       cy.wait('@searchRequest4');
-      cy.waitWhileLoad(60*1000);
+      cy.waitWhileLoad(60 * 1000);
 
       cy.intercept('POST', '**/search', req => {
         expect(req.body.limit).to.deep.equal(20);

--- a/cypress/pom/pages/OverlappingGenesModal.ts
+++ b/cypress/pom/pages/OverlappingGenesModal.ts
@@ -1,12 +1,10 @@
 /// <reference types="cypress"/>
 import { CommonSelectors } from 'pom/shared/Selectors';
 
-const selectors = {
-};
+const selectors = {};
 
 export const OverlappingGenesModal = {
   actions: {},
 
-  validations: {
-  },
+  validations: {},
 };

--- a/cypress/pom/pages/VariantEntity_EvidCond.ts
+++ b/cypress/pom/pages/VariantEntity_EvidCond.ts
@@ -403,7 +403,7 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
    * @param hasUniqueValues The data of the column to sort has unique values.
    * @param isReverseSorting The first sort of the column is Ascending (compare to Descending by default).
    */
-    shouldSortColumn(columnID: string, hasUniqueValues: boolean, isReverseSorting: boolean, sortAction: () => void) {
+  shouldSortColumn(columnID: string, hasUniqueValues: boolean, isReverseSorting: boolean, sortAction: () => void) {
     cy.then(() =>
       getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
         if (position !== -1) {
@@ -429,7 +429,7 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
                       throw new Error(`Error: "${biggest}" should be equal to "${smallest}" (unique values expected)`);
                     }
                   } else if (!isReverseSorting && biggest.localeCompare(smallest) <= 0) {
-                      throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
+                    throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
                   } else if (isReverseSorting && biggest.localeCompare(smallest) >= 0) {
                     throw new Error(`Error: "${biggest}" should be < "${smallest}"`);
                   }

--- a/cypress/pom/pages/VariantEntity_Frequency.ts
+++ b/cypress/pom/pages/VariantEntity_Frequency.ts
@@ -8,6 +8,10 @@ const selectors = {
   publicCohorts: {
     tableId: '[data-cy="public-cohorts-table"]',
   },
+  myNetwork: {
+    tableId: '[id="primary_condition_tab"]',
+    tableHeadRow: 'tr:eq(1)',
+  },
 };
 
 const tableColumns = {
@@ -68,16 +72,101 @@ const tableColumns = {
       tooltip: 'Allele Frequency',
     },
   ],
-}
+  myNetwork: [
+    {
+      id: 'primary_condition',
+      name: 'Primary Condition',
+      apiField: 'split_value_code',
+      isVisibleByDefault: true,
+      pinByDefault: null,
+      isSortable: true,
+      isPinnable: true,
+      position: 0,
+      tooltip: null,
+    },
+    {
+      id: 'freq_all',
+      name: '', // Frequency (headers à 2 niveaux avec labels dupliqués)
+      apiField: 'frequencies.pc_all',
+      isVisibleByDefault: true,
+      pinByDefault: null,
+      isSortable: true,
+      isPinnable: true,
+      position: 1,
+      tooltip: null,
+    },
+    {
+      id: 'homo_all',
+      name: '', // Homozygotes (headers à 2 niveaux avec labels dupliqués)
+      apiField: 'frequencies.hom_all',
+      isVisibleByDefault: true,
+      pinByDefault: null,
+      isSortable: true,
+      isPinnable: true,
+      position: 2,
+      tooltip: null,
+    },
+    {
+      id: 'freq_affected',
+      name: '', // Frequency (headers à 2 niveaux avec labels dupliqués)
+      apiField: 'frequencies.pc_affected',
+      isVisibleByDefault: true,
+      pinByDefault: null,
+      isSortable: true,
+      isPinnable: true,
+      position: 3,
+      tooltip: null,
+    },
+    {
+      id: 'homo_affected',
+      name: '', // Homozygotes (headers à 2 niveaux avec labels dupliqués)
+      apiField: 'frequencies.hom_affected',
+      isVisibleByDefault: true,
+      pinByDefault: null,
+      isSortable: true,
+      isPinnable: true,
+      position: 4,
+      tooltip: null,
+    },
+    {
+      id: 'freq_non_affected',
+      name: '', // Frequency (headers à 2 niveaux avec labels dupliqués)
+      apiField: 'frequencies.pc_non_affected',
+      isVisibleByDefault: true,
+      pinByDefault: null,
+      isSortable: true,
+      isPinnable: true,
+      position: 5,
+      tooltip: null,
+    },
+    {
+      id: 'homo_non_affected',
+      name: '', // Homozygotes (headers à 2 niveaux avec labels dupliqués)
+      apiField: 'frequencies.hom_non_affected',
+      isVisibleByDefault: true,
+      pinByDefault: null,
+      isSortable: true,
+      isPinnable: true,
+      position: 6,
+      tooltip: null,
+    },
+  ],
+};
 
-const generateTableActionsFunctions = (tableId: string, columns: any[]) => ({
+/**
+ * Generates the set of table action functions (pin, sort, unpin) for a given table.
+ * @param tableId The table selector.
+ * @param columns The array of column objects.
+ * @param headRowSelector Optional selector to scope header lookups to a specific row (e.g. `'tr:eq(1)'`) for tables with multi-level headers.
+ */
+const generateTableActionsFunctions = (tableId: string, columns: any[], headRowSelector?: string) => ({
   /**
    * Pins a column in the table by its ID.
    * @param columnID The ID of the column to pin.
    */
   pinColumn(columnID: string) {
     cy.then(() =>
-      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
         cy.pinColumn(position, tableId);
       })
     );
@@ -88,7 +177,7 @@ const generateTableActionsFunctions = (tableId: string, columns: any[]) => ({
    */
   sortColumn(columnID: string) {
     cy.then(() =>
-      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
         if (position !== -1) {
           cy.sortTableAndWait(position, tableId);
         } else {
@@ -103,14 +192,21 @@ const generateTableActionsFunctions = (tableId: string, columns: any[]) => ({
    */
   unpinColumn(columnID: string) {
     cy.then(() =>
-      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
         cy.unpinColumn(position, tableId);
       })
     );
   },
 });
 
-const generateTableValidationsFunctions = (tableId: string, columns: any[], customColumnContent?: (columnID: string, data: any, position: number) => void) => ({
+/**
+ * Generates the set of table validation functions (visibility, pin, sort, column content, etc.) for a given table.
+ * @param tableId The table selector.
+ * @param columns The array of column objects.
+ * @param customColumnContent Optional handler to customize how each column's content is validated.
+ * @param headRowSelector Optional selector to scope header lookups to a specific row (e.g. `'tr:eq(1)'`) for tables with multi-level headers.
+ */
+const generateTableValidationsFunctions = (tableId: string, columns: any[], customColumnContent?: (columnID: string, data: any, position: number) => void, headRowSelector?: string) => ({
   /**
    * Validates the value of the first row for a given column.
    * @param value The expected value (string or RegExp).
@@ -118,7 +214,7 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
    */
   shouldHaveFirstRowValue(value: string | RegExp, columnID: string) {
     cy.then(() =>
-      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
         cy.validateTableFirstRowContent(value, position);
       })
     );
@@ -130,7 +226,7 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
    */
   shouldHaveTableCellLink(dataVariant: any, columnID: string) {
     cy.then(() =>
-      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
         if (position !== -1) {
           cy.get(CommonSelectors.tableRow(tableId)).eq(0).find(CommonSelectors.tableCellData).eq(position).find(CommonSelectors.link).should('have.attr', 'href', getUrlLink(columnID, dataVariant));
         } else {
@@ -174,11 +270,12 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
    * Validates that all columns are displayed in the correct order in the table.
    */
   shouldShowAllColumns() {
+    const baseSelector = headRowSelector ? `${CommonSelectors.tableHead(tableId)} ${headRowSelector} ${CommonSelectors.tableCellHead}` : `${CommonSelectors.tableHead(tableId)} ${CommonSelectors.tableCellHead}`;
     columns.forEach(column => {
       if (column.name.startsWith('[')) {
-        cy.get(CommonSelectors.tableHeadCell(tableId)).eq(column.position).find(column.name).should('exist');
+        cy.get(baseSelector).eq(column.position).find(column.name).should('exist');
       } else {
-        cy.get(CommonSelectors.tableHeadCell(tableId)).eq(column.position).contains(stringToRegExp(column.name, true /*exact*/)).should('exist');
+        cy.get(baseSelector).eq(column.position).contains(stringToRegExp(column.name, true /*exact*/)).should('exist');
       }
     });
   },
@@ -188,7 +285,7 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
    * @param data The data object containing the expected values.
    */
   shouldShowColumnContent(columnID: string, data: any) {
-    getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+    getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
       if (position !== -1) {
         if (customColumnContent) {
           customColumnContent(columnID, data, position);
@@ -225,7 +322,8 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
       cy.then(() =>
         getColumnPosition(CommonSelectors.tableHead(tableId), columns, column.id).then(position => {
           if (position !== -1) {
-            cy.get(CommonSelectors.tableHeadCell(tableId)).eq(position).shouldBePinnable(column.isPinnable);
+            const baseSelector = headRowSelector ? `${CommonSelectors.tableHead(tableId)} ${headRowSelector} ${CommonSelectors.tableCellHead}` : `${CommonSelectors.tableHead(tableId)} ${CommonSelectors.tableCellHead}`;
+            cy.get(baseSelector).eq(position).shouldBePinnable(column.isPinnable);
           } else {
             cy.handleColumnNotFound(column.id);
           }
@@ -239,7 +337,7 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
    */
   shouldPinnedColumn(columnID: string) {
     cy.then(() =>
-      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
         cy.get(CommonSelectors.tableHeadCell(tableId)).eq(position).shouldBePinned('left');
       })
     );
@@ -252,7 +350,8 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
       cy.then(() =>
         getColumnPosition(CommonSelectors.tableHead(tableId), columns, column.id).then(position => {
           if (position !== -1) {
-            cy.get(CommonSelectors.tableHeadCell(tableId)).eq(position).shouldBeSortable(column.isSortable);
+            const baseSelector = headRowSelector ? `${CommonSelectors.tableHead(tableId)} ${headRowSelector} ${CommonSelectors.tableCellHead}` : `${CommonSelectors.tableHead(tableId)} ${CommonSelectors.tableCellHead}`;
+            cy.get(baseSelector).eq(position).shouldBeSortable(column.isSortable);
           } else {
             cy.handleColumnNotFound(column.id);
           }
@@ -266,7 +365,7 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
    */
   shouldUnpinnedColumn(columnID: string) {
     cy.then(() =>
-      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
         cy.get(CommonSelectors.tableHeadCell(tableId)).eq(position).shouldBePinned(null);
       })
     );
@@ -279,7 +378,7 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
    */
   shouldSortColumn(columnID: string, hasUniqueValues: boolean, isReverseSorting: boolean, sortAction: () => void) {
     cy.then(() =>
-      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
         if (position !== -1) {
           sortAction();
           cy.get(CommonSelectors.tableRow(tableId))
@@ -303,7 +402,8 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
                       throw new Error(`Error: "${biggest}" should be equal to "${smallest}" (unique values expected)`);
                     }
                   } else if (!isReverseSorting && biggest.localeCompare(smallest) <= 0) {
-                      throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
+                    throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
+                    throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
                   } else if (isReverseSorting && biggest.localeCompare(smallest) >= 0) {
                     throw new Error(`Error: "${biggest}" should be < "${smallest}"`);
                   }
@@ -320,6 +420,18 @@ const publicCohortsColumnContentHandler = (columnID: string, datapublicCohorts: 
   switch (columnID) {
     default:
       cy.validateTableFirstRowContent(datapublicCohorts[columnID], position, tableId);
+      break;
+  }
+};
+
+const myNetworkColumnContentHandler = (columnID: string, dataMyNetwork: any, position: number) => {
+  const tableId = selectors.myNetwork.tableId;
+  switch (columnID) {
+    case 'primary_condition':
+      cy.validateTableFirstRowContent(dataMyNetwork.primary_condition_name, position);
+      break;
+    default:
+      cy.validateTableFirstRowContent(dataMyNetwork[columnID], position, tableId);
       break;
   }
 };
@@ -351,7 +463,24 @@ export const VariantEntity_Frequency = {
         shouldShowColumnContent(columnID: string, data: any) {
           baseValidations.shouldShowColumnContent(columnID, data);
         },
-        shouldSortColumn(columnID: string, hasUniqueValues: boolean, isReverseSorting:boolean) {
+        shouldSortColumn(columnID: string, hasUniqueValues: boolean, isReverseSorting: boolean) {
+          baseValidations.shouldSortColumn(columnID, hasUniqueValues, isReverseSorting, () => actions.sortColumn(columnID));
+        },
+      };
+    })(),
+  },
+
+  myNetwork: {
+    actions: generateTableActionsFunctions(selectors.myNetwork.tableId, tableColumns.myNetwork, selectors.myNetwork.tableHeadRow),
+    validations: (() => {
+      const actions = generateTableActionsFunctions(selectors.myNetwork.tableId, tableColumns.myNetwork, selectors.myNetwork.tableHeadRow);
+      const baseValidations = generateTableValidationsFunctions(selectors.myNetwork.tableId, tableColumns.myNetwork, myNetworkColumnContentHandler, selectors.myNetwork.tableHeadRow);
+      return {
+        ...baseValidations,
+        shouldShowColumnContent(columnID: string, data: any) {
+          baseValidations.shouldShowColumnContent(columnID, data);
+        },
+        shouldSortColumn(columnID: string, hasUniqueValues: boolean, isReverseSorting: boolean) {
           baseValidations.shouldSortColumn(columnID, hasUniqueValues, isReverseSorting, () => actions.sortColumn(columnID));
         },
       };

--- a/cypress/pom/pages/VariantEntity_Patients.ts
+++ b/cypress/pom/pages/VariantEntity_Patients.ts
@@ -373,7 +373,7 @@ const generateTableActionsFunctions = (tableId: string, columns: any[]) => ({
    * Shows all columns in the table.
    */
   showAllColumns() {
-    columns.forEach((column) => {
+    columns.forEach(column => {
       if (!column.isVisibleByDefault) {
         cy.showColumn(stringToRegExp(column.name, true /*exact*/));
       }

--- a/cypress/pom/shared/Data.ts
+++ b/cypress/pom/shared/Data.ts
@@ -111,6 +111,16 @@ export const data = {
       homo: '0',
       freq: '1.54e-3',
     },
+    myNetwork: {
+      primary_condition_name: 'cerebral ventricle cancer',
+      primary_condition_id: 'MONDO:0002682',
+      freq_all: '0/1',
+      homo_all: '0',
+      freq_affected: '0/1',
+      homo_affected: '0',
+      freq_non_affected: '-',
+      homo_non_affected: '-',
+    },
     interpreted: {
       case: '1',
       relationship: 'proband',

--- a/cypress/pom/shared/Utils.ts
+++ b/cypress/pom/shared/Utils.ts
@@ -43,11 +43,13 @@ export const getColumnName = (columns: any, columnID: string) => {
  * @param tableHead The table head.
  * @param columns The array of column objects.
  * @param columnID The ID of the column.
+ * @param headRowSelector Optional selector to scope the lookup to a specific header row (e.g. `'tr:eq(1)'`) for tables with multi-level headers.
  * @returns A Cypress chain containing the column position (0-based) or -1 if not found
  */
-export const getColumnPosition = (tableHead: string, columns: any, columnID: string) => {
+export const getColumnPosition = (tableHead: string, columns: any, columnID: string, headRowSelector?: string) => {
   const columnName = getColumnName(columns, columnID);
-  return cy.get(`${tableHead} ${CommonSelectors.tableCellHead}`).then($cells => {
+  const baseSelector = headRowSelector ? `${tableHead} ${headRowSelector} ${CommonSelectors.tableCellHead}` : `${tableHead} ${CommonSelectors.tableCellHead}`;
+  return cy.get(baseSelector).then($cells => {
     $cells.css('width', '125px'); // Widen columns for full name access
     let position;
     if (columnName.startsWith('[')) {

--- a/cypress/support/apiCommands.ts
+++ b/cypress/support/apiCommands.ts
@@ -22,21 +22,23 @@ Cypress.Commands.add('apiCall', (method: string, query: string, body: string, to
   }
 
   const makeRequest = (attemptsLeft: number): Cypress.Chainable => {
-    return cy.request({
-      method: method,
-      url: `${apiUrl}${query}`,
-      headers: { Authorization: `Bearer ${token}` },
-      body: body,
-      failOnStatusCode: false,
-      timeout: 60000,
-    }).then(res => {
-      if (res.status === 500 && attemptsLeft > 0) {
-        cy.log(`Retrying API call, remaining retries: ${attemptsLeft - 1}`);
-        return makeRequest(attemptsLeft - 1);
-      } else {
-        return res;
-      }
-    });
+    return cy
+      .request({
+        method: method,
+        url: `${apiUrl}${query}`,
+        headers: { Authorization: `Bearer ${token}` },
+        body: body,
+        failOnStatusCode: false,
+        timeout: 60000,
+      })
+      .then(res => {
+        if (res.status === 500 && attemptsLeft > 0) {
+          cy.log(`Retrying API call, remaining retries: ${attemptsLeft - 1}`);
+          return makeRequest(attemptsLeft - 1);
+        } else {
+          return res;
+        }
+      });
   };
 
   return makeRequest(retries);
@@ -104,8 +106,7 @@ Cypress.Commands.add('validateAcceptedBatchResponse', (response: any, batch_type
 Cypress.Commands.add('validateItemCount', (response: any, count: number, field?: string) => {
   if (field == undefined) {
     expect(response.body).to.have.lengthOf(count);
-  }
-  else {
+  } else {
     expect(response.body[field]).to.have.lengthOf(count);
   }
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -231,7 +231,7 @@ Cypress.Commands.add('shouldHaveTooltip', { prevSubject: 'element' }, (subject, 
  * Shows a column in the table by checking it in the column selector.
  * @param column The column name to show.
  */
-Cypress.Commands.add('showColumn', (column: string|RegExp) => {
+Cypress.Commands.add('showColumn', (column: string | RegExp) => {
   cy.get(CommonSelectors.settingsIcon).clickAndWait({ force: true });
   getSettingsCheckbox(column).click({ force: true });
   cy.get(CommonSelectors.logo).clickAndWait({ force: true }); // Close the popper

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -29,7 +29,7 @@ declare namespace Cypress {
     shouldBePinned(position: 'left' | 'right' | null): Chainable<JQuery<HTMLElement>>;
     shouldBeSortable(isSortable: boolean): Chainable<Element>;
     shouldHaveTooltip(column: any): cy & CyEventEmitter;
-    showColumn(column: string|RegExp): cy & CyEventEmitter;
+    showColumn(column: string | RegExp): cy & CyEventEmitter;
     sortTableAndIntercept(position: number, routeMatcher: string, nbCalls: number, tableId: string = ''): cy & CyEventEmitter;
     sortTableAndWait(position: number, tableId: string = ''): cy & CyEventEmitter;
     unpinColumn(position: number, tableId: string = ''): cy & CyEventEmitter;

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2018",
     "lib": ["es2018", "dom"],
     "types": ["cypress", "node"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
# feat: SJRA-1361 Add My Network table Cypress tests

## 📌 Contexte

Ajout de la couverture Cypress E2E pour la table **My Network** de la page Variant Entity - Frequency. Cette table possède des en-têtes sur deux niveaux, ce qui a nécessité une adaptation des fonctions utilitaires partagées afin de cibler une ligne d'en-tête spécifique lors de la recherche des colonnes.

## 📝 Changements

- Ajout de 3 nouveaux fichiers de tests E2E pour la table My Network :
  - `MyNetwork_Columns.cy.ts` : affichage par défaut, ordre, pin, état par défaut du pin, tri, tooltip.
  - `MyNetwork_Hyperlinks.cy.ts` : validation du lien sur la colonne `primary_condition`.
  - `MyNetwork_InformationDisplayed.cy.ts` : validation du contenu affiché dans chaque colonne.
- Mise à jour de [VariantEntity_Frequency.ts](cypress/pom/pages/VariantEntity_Frequency.ts) :
  - Ajout des sélecteurs et de la définition des colonnes pour la table `myNetwork`.
  - Ajout du handler `myNetworkColumnContentHandler` pour gérer la colonne `primary_condition` (affiche `primary_condition_name`).
  - Exposition des `actions` et `validations` de `myNetwork`.
- Support des tables avec en-têtes multi-niveaux :
  - Ajout d'un paramètre optionnel `headRowSelector` dans `generateTableActionsFunctions`, `generateTableValidationsFunctions` et [getColumnPosition](cypress/pom/shared/Utils.ts) pour restreindre la recherche des colonnes à une ligne d'en-tête spécifique (ex. `tr:eq(1)`).
- Ajout des données de référence `myNetwork` dans [Data.ts](cypress/pom/shared/Data.ts).
- Modification du [tsconfig.json](cypress/tsconfig.json) : `moduleResolution` passe de `node` à `bundler`.
- Nettoyage de [cypress/CLAUDE.md](cypress/CLAUDE.md) : retrait du total des tests et du dossier `DataQuality` obsolète.
- Reformatage Prettier de plusieurs fichiers (POM, commandes, tests API). Aucun changement fonctionnel.

## 🧪 Tests

- Les tests impactés ont été exécutés localement et passent avec succès.
- Nouveaux tests E2E ajoutés (14 au total) dans `cypress/e2e/VariantEntity/Frequency/` :
  - `MyNetwork_Columns.cy.ts` (6 tests)
  - `MyNetwork_Hyperlinks.cy.ts` (1 test)
  - `MyNetwork_InformationDisplayed.cy.ts` (7 tests)

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1361](https://d3b.atlassian.net/browse/SJRA-1361)<!-- End JIRA Issues -->

[SJRA-1361]: https://d3b.atlassian.net/browse/SJRA-1361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ