### PR TITLE
feat: SJRA-1369 Adjust Cypress tests related to recent changes and ad…

### DIFF
--- a/cypress/e2e/CaseEntity/Variants/CNV/Facets/Configuration.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/Facets/Configuration.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_Facets } from 'pom/pages/CaseEntity_Variants_Facets
 describe('Case Entity - Variants - CNV - Facets - Configuration', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'CNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV');
   };
 
   it('Order', () => {

--- a/cypress/e2e/CaseEntity/Variants/CNV/Facets/RequestValidation.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/Facets/RequestValidation.cy.ts
@@ -6,10 +6,10 @@ import { CaseEntity_Variants_Facets } from 'pom/pages/CaseEntity_Variants_Facets
 describe('Case Entity - Variants - CNV - Facets - Request Validation', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'CNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV');
   };
 
-  it('MultiSelect', () => {
+  it('MultiSelect [SJRA-1368]', () => {
     setupTest();
     CaseEntity_Variants_Facets.cnv.validations.shouldRequestOnApply('Variant', 'variant_type');
   });

--- a/cypress/e2e/CaseEntity/Variants/CNV/Table/Columns.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/Table/Columns.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_CNV_Table } from 'pom/pages/CaseEntity_Variants_CNV
 describe('Case Entity - Variants - CNV - Table - Columns', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'CNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV');
   };
 
   it('Default display', () => {

--- a/cypress/e2e/CaseEntity/Variants/CNV/Table/CustomQuery.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/Table/CustomQuery.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_CNV_Table } from 'pom/pages/CaseEntity_Variants_CNV
 describe('Case Entity - Variants - CNV - Table - Custom query', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'CNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV');
   };
 
   it('Save icon', () => {

--- a/cypress/e2e/CaseEntity/Variants/CNV/Table/Hyperlinks.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/Table/Hyperlinks.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_CNV_Table } from 'pom/pages/CaseEntity_Variants_CNV
 describe('Case Entity - Variants - CNV - Table - Hyperlinks', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'CNV', data.cnvGermline.sqon);
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV', data.cnvGermline.sqon);
     CaseEntity_Variants_CNV_Table.actions.showAllColumns();
   };
 

--- a/cypress/e2e/CaseEntity/Variants/CNV/Table/InformationDisplayed.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/Table/InformationDisplayed.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_CNV_Table } from 'pom/pages/CaseEntity_Variants_CNV
 describe('Case Entity - Variants - CNV - Table - Information displayed', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'CNV', data.cnvGermline.sqon);
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV', data.cnvGermline.sqon);
   };
 
   it('Genes', () => {

--- a/cypress/e2e/CaseEntity/Variants/CNV/Table/RequestValidation.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/Table/RequestValidation.cy.ts
@@ -10,7 +10,7 @@ describe('Case Entity - Variants - CNV - Table - Request Validation', () => {
 
   it('Sort', () => {
     setupTest();
-    cy.visitCaseVariantsPage(data.case.case, 'CNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV');
     CaseEntity_Variants_CNV_Table.validations.shouldRequestOnSort('start');
   });
 

--- a/cypress/e2e/CaseEntity/Variants/CNV/Table/Sort.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/Table/Sort.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_CNV_Table } from 'pom/pages/CaseEntity_Variants_CNV
 describe('Case Entity - Variants - CNV - Table - Sort', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'CNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV');
   };
 
   it('Alphanumeric [SJRA-1168]', () => {

--- a/cypress/e2e/CaseEntity/Variants/SNV/Facets/Configuration.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/Facets/Configuration.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_Facets } from 'pom/pages/CaseEntity_Variants_Facets
 describe('Case Entity - Variants - SNV - Facets - Configuration', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV');
   };
 
   it('Order', () => {

--- a/cypress/e2e/CaseEntity/Variants/SNV/Facets/Dictionary.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/Facets/Dictionary.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_Facets } from 'pom/pages/CaseEntity_Variants_Facets
 describe('Case Entity - Variants - SNV - Facets - Dictionary', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV');
   };
 
   it('Non zero values', () => {

--- a/cypress/e2e/CaseEntity/Variants/SNV/Facets/RequestValidation.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/Facets/RequestValidation.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_Facets } from 'pom/pages/CaseEntity_Variants_Facets
 describe('Case Entity - Variants - SNV - Facets - Request Validation', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV');
   };
 
   it('MultiSelect', () => {

--- a/cypress/e2e/CaseEntity/Variants/SNV/IGV/FromTable.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/IGV/FromTable.cy.ts
@@ -7,7 +7,7 @@ import { CaseEntity_Variants_SNV_Table } from 'pom/pages/CaseEntity_Variants_SNV
 describe('Case Entity - Variants - SNV - IGV - From table', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV', data.variantGermline.sqon);
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV', data.variantGermline.sqon);
     CaseEntity_Variants_SNV_Table.actions.selectAction(data.variantGermline, 'Open in IGV');
   };
 

--- a/cypress/e2e/CaseEntity/Variants/SNV/IGV/FromVariantPreview.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/IGV/FromVariantPreview.cy.ts
@@ -8,7 +8,7 @@ import { VariantPreview } from 'pom/pages/VariantPreview';
 describe('Case Entity - Variants - SNV - IGV - From variant preview', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV', data.variantGermline.sqon);
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV', data.variantGermline.sqon);
     CaseEntity_Variants_SNV_Table.actions.selectAction(data.variantGermline, 'Preview');
     VariantPreview.actions.clickOpenIGV();
   };

--- a/cypress/e2e/CaseEntity/Variants/SNV/SavedFilters/Manager.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/SavedFilters/Manager.cy.ts
@@ -7,7 +7,7 @@ import { ManagerFilterModal } from 'pom/pages/ManagerFilterModal';
 describe('Case Entity - Variants - SNV - Saved filters - Manager', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV', data.variantGermline.sqon);
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV', data.variantGermline.sqon);
     CaseEntity_Variants_SavedFilters.snv.actions.clickNewFilterButton();
   };
 

--- a/cypress/e2e/CaseEntity/Variants/SNV/SavedFilters/QueryBuilder.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/SavedFilters/QueryBuilder.cy.ts
@@ -7,7 +7,7 @@ import { ManagerFilterModal } from 'pom/pages/ManagerFilterModal';
 describe('Case Entity - Variants - SNV - Saved filters - Query builder', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV', data.variantGermline.sqon);
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV', data.variantGermline.sqon);
     CaseEntity_Variants_SavedFilters.snv.actions.clickNewFilterButton();
   };
 

--- a/cypress/e2e/CaseEntity/Variants/SNV/Table/Columns.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/Table/Columns.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_SNV_Table } from 'pom/pages/CaseEntity_Variants_SNV
 describe('Case Entity - Variants - SNV - Table - Columns', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV');
   };
 
   it('Default display', () => {

--- a/cypress/e2e/CaseEntity/Variants/SNV/Table/CustomQuery.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/Table/CustomQuery.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_SNV_Table } from 'pom/pages/CaseEntity_Variants_SNV
 describe('Case Entity - Variants - SNV - Table - Custom query', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV', data.variantGermline.sqon);
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV', data.variantGermline.sqon);
   };
 
   it('Save icon', () => {

--- a/cypress/e2e/CaseEntity/Variants/SNV/Table/Hyperlinks.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/Table/Hyperlinks.cy.ts
@@ -7,7 +7,7 @@ import { VariantEntity_Patients } from 'pom/pages/VariantEntity_Patients';
 describe('Case Entity - Variants - SNV - Table - Hyperlinks', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV', data.variantGermline.sqon);
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV', data.variantGermline.sqon);
     CaseEntity_Variants_SNV_Table.actions.showAllColumns();
   };
 

--- a/cypress/e2e/CaseEntity/Variants/SNV/Table/InformationDisplayed.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/Table/InformationDisplayed.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_SNV_Table } from 'pom/pages/CaseEntity_Variants_SNV
 describe('Case Entity - Variants - SNV - Table - Information displayed', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV', data.variantGermline.sqon);
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV', data.variantGermline.sqon);
   };
 
   it('Variant', () => {

--- a/cypress/e2e/CaseEntity/Variants/SNV/Table/RequestValidation.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/Table/RequestValidation.cy.ts
@@ -10,7 +10,7 @@ describe('Case Entity - Variants - SNV - Table - Request Validation', () => {
 
   it('Sort', () => {
     setupTest();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV');
     CaseEntity_Variants_SNV_Table.validations.shouldRequestOnSort('variant');
   });
 

--- a/cypress/e2e/CaseEntity/Variants/SNV/Table/Sort.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/Table/Sort.cy.ts
@@ -6,7 +6,7 @@ import { CaseEntity_Variants_SNV_Table } from 'pom/pages/CaseEntity_Variants_SNV
 describe('Case Entity - Variants - SNV - Table - Sort', () => {
   const setupTest = () => {
     cy.login();
-    cy.visitCaseVariantsPage(data.case.case, 'SNV');
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'SNV');
   };
 
   it('Alphanumeric', () => {

--- a/cypress/pom/pages/CaseEntity_Variants_CNV_Table.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_CNV_Table.ts
@@ -6,7 +6,7 @@ import { getColumnName, getColumnPosition } from '../shared/Utils';
 const selectors = {
   tableCell: (dataCNV: any) => `${CommonSelectors.tableRow()}:contains("${dataCNV.cnv_variant}") ${CommonSelectors.tableCellData}`,
   tab: '[data-cy="variants-tab"]',
-  toggle: '[data-cy="tabs-trigger-cnv"]',
+  toggle: '[data-cy="tabs-trigger-CNV"]',
 };
 
 const tableColumns = [
@@ -480,7 +480,7 @@ export const CaseEntity_Variants_CNV_Table = {
         expect(req.body.page_index).to.deep.equal(0);
         req.continue();
       }).as('listRequest1');
-      cy.visitCaseVariantsPage(dataCase.case, 'CNV');
+      cy.visitCaseVariantsPage(dataCase.case, dataCase.seq.seq_id, 'CNV');
       cy.wait('@listRequest1');
       cy.waitWhileLoad(60 * 1000);
 

--- a/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
@@ -6,7 +6,7 @@ import { getColumnName, getColumnPosition } from '../shared/Utils';
 const selectors = {
   tableCell: (dataVariant: any) => `${CommonSelectors.tableRow()}:contains("${dataVariant.variant}") ${CommonSelectors.tableCellData}`,
   tab: '[data-cy="variants-tab"]',
-  toggle: '[data-cy="tabs-trigger-snv"]',
+  toggle: '[data-cy="tabs-trigger-SNV"]',
 };
 
 const tableColumns = [
@@ -495,7 +495,7 @@ export const CaseEntity_Variants_SNV_Table = {
         expect(req.body.page_index).to.deep.equal(0);
         req.continue();
       }).as('listRequest1');
-      cy.visitCaseVariantsPage(dataCase.case, 'SNV');
+      cy.visitCaseVariantsPage(dataCase.case, dataCase.seq.seq_id, 'SNV');
       cy.wait('@listRequest1');
       cy.waitWhileLoad(60 * 1000);
 

--- a/cypress/pom/shared/Selectors.ts
+++ b/cypress/pom/shared/Selectors.ts
@@ -7,7 +7,7 @@ export const CommonSelectors = {
   animateIn: '[class*="data-[state=open]:animate-in"]',
   checkIcon: '[class*="lucide-check"]',
   circlePlusIcon: '[class*="lucide-circle-plus"]',
-  closeButton: 'button:contains("Close")',
+  closeButton: '[data-cy="CloseButton"]',
   colorIndicator: (color: string) => `[class*="text-indicator-${color}"]`,
   detailsButton: 'button:contains("Details")',
   comboboxButton: 'button[role="combobox"]',

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -446,13 +446,14 @@ Cypress.Commands.add('visitCaseFilesPage', (caseId: string, searchCriteria?: str
 /**
  * Visits the case variants page for a specific case.
  * @param caseId The case ID to visit.
+ * @param seqId The seq ID to visit.
  * @param type The type of variants (SNV | CNV).
  * @param sqon Optional query filter to apply (JSON string).
  */
-Cypress.Commands.add('visitCaseVariantsPage', (caseId: string, type: string, sqon?: string) => {
+Cypress.Commands.add('visitCaseVariantsPage', (caseId: string, seqId: string, type: string, sqon?: string) => {
   if (type === 'SNV') {
     if (sqon == undefined) {
-      cy.visitAndIntercept(`/case/entity/${caseId}?tab=variants`, 'POST', '**/list', 1);
+      cy.visitAndIntercept(`/case/entity/${caseId}?tab=variants&seq_id=${seqId}`, 'POST', '**/list', 1);
     } else {
       cy.intercept('POST', '**/list', interception => {
         const mockBody = { ...interception.body };
@@ -460,11 +461,11 @@ Cypress.Commands.add('visitCaseVariantsPage', (caseId: string, type: string, sqo
         interception.alias = 'postListSNV';
         interception.body = mockBody;
       });
-      cy.visit(`/case/entity/${caseId}?tab=variants`, { failOnStatusCode: false });
+      cy.visit(`/case/entity/${caseId}?tab=variants&seq_id=${seqId}`, { failOnStatusCode: false });
       cy.wait('@postListSNV');
     }
   } else if (type === 'CNV') {
-    cy.visitAndIntercept(`/case/entity/${caseId}?tab=variants`, 'POST', '**/list', 1);
+    cy.visitAndIntercept(`/case/entity/${caseId}?tab=variants&seq_id=${seqId}`, 'POST', '**/list', 1);
 
     if (sqon == undefined) {
       cy.intercept('POST', '**/list').as('postListCNV');

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -42,7 +42,7 @@ declare namespace Cypress {
     visitFilesPage(search_criteria?: string): cy & CyEventEmitter;
     visitCaseDetailsPage(caseID: string): cy & CyEventEmitter;
     visitCaseFilesPage(caseID: string, searchCriteria?: string): cy & CyEventEmitter;
-    visitCaseVariantsPage(caseID: string, type: string, sqon?: string): cy & CyEventEmitter;
+    visitCaseVariantsPage(caseID: string, seqId: string, type: string, sqon?: string): cy & CyEventEmitter;
     visitVariantEvidCondPage(locusID: string): cy & CyEventEmitter;
     visitVariantFrequencyPage(locusID: string): cy & CyEventEmitter;
     visitVariantPatientsPage(locusID: string): cy & CyEventEmitter;

--- a/frontend/components/base/query-builder-v3/saved-filter/manage-filters-dialog.tsx
+++ b/frontend/components/base/query-builder-v3/saved-filter/manage-filters-dialog.tsx
@@ -48,7 +48,7 @@ function SavedFiltersManageDialog({ open, onOpenChange }: { open: boolean; onOpe
         </DialogBody>
         <DialogFooter>
           <DialogClose asChild>
-            <Button>{t('common.close')}</Button>
+            <Button data-cy="CloseButton">{t('common.close')}</Button>
           </DialogClose>
         </DialogFooter>
       </DialogContent>

--- a/frontend/components/base/query-builder/saved-filter/saved-filter-manage-dialog.tsx
+++ b/frontend/components/base/query-builder/saved-filter/saved-filter-manage-dialog.tsx
@@ -50,7 +50,7 @@ function SavedFiltersManageDialog({ open, onOpenChange }: { open: boolean; onOpe
           </DialogBody>
           <DialogFooter>
             <DialogClose asChild>
-              <Button>{dict.savedFilter.manageDialog.close}</Button>
+              <Button data-cy="CloseButton">{dict.savedFilter.manageDialog.close}</Button>
             </DialogClose>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
# feat: SJRA-1369 Adjust Cypress tests related to recent changes and add data-cy

## 📌 Contexte

Ajustement des tests Cypress à la suite de modifications récentes du portail (ajout du paramètre `seq_id` dans l'URL des pages Variants, changement de casse des identifiants d'onglets SNV/CNV) et ajout de sélecteurs `data-cy` pour fiabiliser les tests.

## 📝 Changements

- Ajout du paramètre `seqId` à la commande Cypress `visitCaseVariantsPage` et propagation de `data.case.seq.seq_id` dans tous les tests SNV et CNV.
- Mise à jour de l'URL de visite des pages Variants pour inclure `&seq_id=${seqId}`.
- Correction des sélecteurs des onglets Variants : `tabs-trigger-snv` → `tabs-trigger-SNV` et `tabs-trigger-cnv` → `tabs-trigger-CNV`.
- Remplacement du sélecteur `closeButton` (basé sur le texte `button:contains("Close")`) par un sélecteur `data-cy="CloseButton"`.
- Ajout de l'attribut `data-cy="CloseButton"` sur les boutons de fermeture des dialogues de gestion des filtres sauvegardés (`query-builder` et `query-builder-v3`).
- Ajout du tag Jira `[SJRA-1368]` sur le test `MultiSelect` de `CaseEntity/Variants/CNV/Facets/RequestValidation.cy.ts` (suivi d'un bug en cours).

## 🧪 Tests

- Les tests Cypress impactés ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1369](https://d3b.atlassian.net/browse/SJRA-1369)<!-- End JIRA Issues -->


[SJRA-1368]: https://d3b.atlassian.net/browse/SJRA-1368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ