### PR TITLE
feat: SJRA-1370 Adjust Cypress tests related to recent changes

### DIFF
--- a/cypress/pom/pages/CaseEntity_Variants_Facets.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_Facets.ts
@@ -438,7 +438,7 @@ export const tableCNVFacets = [
         position: 0,
         tooltip: null,
         defaultOperator: null,
-        hasDictionary: false,
+        hasDictionary: true,
       },
       {
         id: 'copy_number',
@@ -465,7 +465,7 @@ export const tableCNVFacets = [
         position: 3,
         tooltip: null,
         defaultOperator: null,
-        hasDictionary: false,
+        hasDictionary: true,
       },
       {
         id: 'start',


### PR DESCRIPTION
# feat: SJRA-1370 Adjust Cypress tests related to recent changes

## 📌 Contexte

Ajustement des tests Cypress suite à des modifications récentes concernant les facettes CNV de l'entité Cas. Les champs `name` et `start` disposent maintenant d'un dictionnaire.

## 📝 Changements

- Mise à jour de `cypress/pom/pages/CaseEntity_Variants_Facets.ts` : passage de `hasDictionary: false` à `hasDictionary: true` pour les facettes `name` et `start` de la table CNV.

## 🧪 Tests

- Les tests Cypress impactés ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1370](https://d3b.atlassian.net/browse/SJRA-1370)<!-- End JIRA Issues -->


[SJRA-1370]: https://d3b.atlassian.net/browse/SJRA-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ