### PR TITLE
fix(somatic): SJRA-1375 make gnomad only display on germline

### DIFF
--- a/frontend/components/base/slider/slider-variant-details-card.tsx
+++ b/frontend/components/base/slider/slider-variant-details-card.tsx
@@ -20,7 +20,6 @@ import { getDbSnpUrl, getEnsemblUrl, getOmimOrgUrl } from '@/components/base/var
 import { useI18n } from '@/components/hooks/i18n';
 import { toExponentialNotation, toExponentialNotationAtThreshold } from '@/components/lib/number-format';
 import { cn } from '@/components/lib/utils';
-import Empty from '../empty';
 
 const MAX_CLINICAL_ASSOCIATION = 3;
 
@@ -324,8 +323,8 @@ const PredictionCard = ({
 
   // Frequencies differ from somatic to germline
   const frequencies = [];
-
   if (type == 'somatic') {
+    // Tumor-Normal
     frequencies.push(
       <DescriptionRow
         label={
@@ -342,6 +341,7 @@ const PredictionCard = ({
       </DescriptionRow>,
     );
   } else {
+    // Germline Affected
     frequencies.push(
       <DescriptionRow
         label={
@@ -362,6 +362,10 @@ const PredictionCard = ({
           <EmptyField />
         )}
       </DescriptionRow>,
+    );
+
+    // Germline Non Affected
+    frequencies.push(
       <DescriptionRow
         label={
           <Tooltip>
@@ -379,6 +383,23 @@ const PredictionCard = ({
         germline_pn_wgs_not_affected &&
         germline_pf_wgs_not_affected?.toExponential(2) ? (
           `${germline_pc_wgs_not_affected} / ${germline_pn_wgs_not_affected} (${germline_pf_wgs_not_affected?.toExponential(2)})`
+        ) : (
+          <EmptyField />
+        )}
+      </DescriptionRow>,
+    );
+
+    // GnomAD
+    frequencies.push(
+      <DescriptionRow label={t('preview_sheet.variant_details.sections.frequencies.gnomad')}>
+        {gnomad_v3_af ? (
+          <AnchorLink
+            size="sm"
+            href={`https://gnomad.broadinstitute.org/variant/${locus}?dataset=gnomad_r3`}
+            target="_blank"
+          >
+            {toExponentialNotation(gnomad_v3_af)}
+          </AnchorLink>
         ) : (
           <EmptyField />
         )}
@@ -577,19 +598,6 @@ const PredictionCard = ({
       <div className="flex flex-1 flex-col gap-4">
         <DescriptionSection title={t('preview_sheet.variant_details.sections.frequencies.title')}>
           {frequencies.map(element => element)}
-          <DescriptionRow label={t('preview_sheet.variant_details.sections.frequencies.gnomad')}>
-            {gnomad_v3_af ? (
-              <AnchorLink
-                size="sm"
-                href={`https://gnomad.broadinstitute.org/variant/${locus}?dataset=gnomad_r3`}
-                target="_blank"
-              >
-                {toExponentialNotation(gnomad_v3_af)}
-              </AnchorLink>
-            ) : (
-              <EmptyField />
-            )}
-          </DescriptionRow>
         </DescriptionSection>
         <DescriptionSection title={t('preview_sheet.variant_details.sections.functional_scores.title')}>
           <ExpandableList


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Pour gnomAD, il ne devrait pas être dans le slider en tant que tel. Il devrait juste être présent pour le germline

## 📝 Changes

- Make gnomAD only display on germline
<img width="617" height="606" alt="image" src="https://github.com/user-attachments/assets/4e8a3a5f-ec29-46fb-85a8-447d40189cfe" />
<img width="651" height="680" alt="image" src="https://github.com/user-attachments/assets/739118e3-78bc-4a3e-ad57-fae2b55c38c2" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1375](https://d3b.atlassian.net/browse/SJRA-1375)<!-- End JIRA Issues -->


[SJRA-1375]: https://d3b.atlassian.net/browse/SJRA-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ