### PR TITLE
fix(somatic): SJRA-1376 fix tumor normal frequency display

### DIFF
--- a/frontend/apps/case/src/entity/variants/somatic-occurrence/sliders/slider-somatic-occurrence-sheet.tsx
+++ b/frontend/apps/case/src/entity/variants/somatic-occurrence/sliders/slider-somatic-occurrence-sheet.tsx
@@ -296,6 +296,7 @@ export function SomaticOccurrenceSheetContent({
         somatic_pc_tn_wgs={expandResult.data.somatic_pc_tn_wgs}
         somatic_pn_tn_wgs={expandResult.data.somatic_pn_tn_wgs}
         somatic_pf_tn_wgs={expandResult.data.somatic_pf_tn_wgs}
+        locusId={occurrence.locus_id}
       />
     </div>
   );

--- a/frontend/components/base/slider/slider-variant-details-card.tsx
+++ b/frontend/components/base/slider/slider-variant-details-card.tsx
@@ -63,6 +63,9 @@ const SliderVariantDetailsCard = ({
   germline_pc_wgs_not_affected,
   germline_pn_wgs_not_affected,
   germline_pf_wgs_not_affected,
+  somatic_pc_tn_wgs,
+  somatic_pn_tn_wgs,
+  somatic_pf_tn_wgs,
   cadd_phred,
   cadd_score,
   lrt_pred,
@@ -86,6 +89,7 @@ const SliderVariantDetailsCard = ({
   hgvsg,
   gnomad_v3_af,
   locus,
+  locusId,
   hotspot,
 }: SliderVariantDetailsCardProps) => {
   const { t } = useI18n();
@@ -141,6 +145,9 @@ const SliderVariantDetailsCard = ({
           germline_pc_wgs_not_affected={germline_pc_wgs_not_affected}
           germline_pn_wgs_not_affected={germline_pn_wgs_not_affected}
           germline_pf_wgs_not_affected={germline_pf_wgs_not_affected}
+          somatic_pc_tn_wgs={somatic_pc_tn_wgs}
+          somatic_pn_tn_wgs={somatic_pn_tn_wgs}
+          somatic_pf_tn_wgs={somatic_pf_tn_wgs}
           cadd_phred={cadd_phred}
           cadd_score={cadd_score}
           dann_score={dann_score}
@@ -164,6 +171,7 @@ const SliderVariantDetailsCard = ({
           hgvsg={hgvsg}
           gnomad_v3_af={gnomad_v3_af}
           locus={locus}
+          locusId={locusId}
           hotspot={hotspot}
         />
         <ClinicalAssociationCard omim_conditions={omim_conditions} locus_id={locus_id} />
@@ -281,6 +289,7 @@ type PredictionCardProps = SliderVariantType & {
   hgvsg?: string;
   gnomad_v3_af?: number;
   locus?: string;
+  locusId?: string;
   hotspot?: boolean;
 };
 const PredictionCard = ({
@@ -317,6 +326,7 @@ const PredictionCard = ({
   hgvsg,
   gnomad_v3_af,
   locus,
+  locusId,
   hotspot,
 }: PredictionCardProps) => {
   const { t } = useI18n();
@@ -334,7 +344,9 @@ const PredictionCard = ({
         }
       >
         {somatic_pc_tn_wgs && somatic_pn_tn_wgs && somatic_pf_tn_wgs?.toExponential(2) ? (
-          `${somatic_pc_tn_wgs} / ${somatic_pn_tn_wgs} (${somatic_pf_tn_wgs?.toExponential(2)})`
+          <AnchorLink size="sm" href={`/variants/entity/${locusId}?tab=patients&cases=OtherCases`} target="_blank">
+            {somatic_pc_tn_wgs} / {somatic_pn_tn_wgs} ({somatic_pf_tn_wgs?.toExponential(2)})
+          </AnchorLink>
         ) : (
           <EmptyField />
         )}


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Selon le filtre du query builder, il devrait y avoir une valeur pour la fréquence tumor-normal.

## 📝 Changes

- Correctly send data to PredictionCard component
<img width="645" height="577" alt="image" src="https://github.com/user-attachments/assets/c6d932a8-af6e-4295-878b-023d6892d4df" />



## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1376](https://d3b.atlassian.net/browse/SJRA-1376)<!-- End JIRA Issues -->


[SJRA-1376]: https://d3b.atlassian.net/browse/SJRA-1376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ