### PR TITLE
fix(qb): SJRA-1139 sync qb context sqons with user pref

### DIFF
--- a/frontend/components/base/query-builder-v3/hooks/use-query-builder-preference.tsx
+++ b/frontend/components/base/query-builder-v3/hooks/use-query-builder-preference.tsx
@@ -1,11 +1,14 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import useSWR from 'swr';
+import useSWRMutation from 'swr/mutation';
 
 import { UserPreference } from '@/api/api';
 import { ApplicationId } from '@/components/cores/applications-config';
 import { userPreferenceApi } from '@/utils/api';
 
-import { getDefaultQBContext } from './use-query-builder';
+import { ISyntheticSqon } from '../type';
+
+import { getDefaultQBContext, IQBContext } from './use-query-builder';
 
 type FetchUserPreferenceInput = {
   key: string;
@@ -18,6 +21,11 @@ type PostUserPreferenceInput = FetchUserPreferenceInput & {
 type useQueryBuilderGetPreferenceEffectProps = {
   appId: ApplicationId;
   setPreference: (value: any) => void;
+};
+
+type useSqonsQBStateObserverProps = {
+  appId: ApplicationId;
+  sqons: ISyntheticSqon[];
 };
 
 /**
@@ -53,9 +61,51 @@ export function useQueryBuilderGetPreferenceEffect({ appId, setPreference }: use
 
   useEffect(() => {
     if (qbUserPreference.data) {
-      setPreference({ ...getDefaultQBContext(), ...qbUserPreference.data });
+      setPreference({ ...getDefaultQBContext(), ...(qbUserPreference.data.content as Partial<IQBContext>) });
     } else if (qbUserPreference.error) {
       setPreference(getDefaultQBContext());
     }
   }, [qbUserPreference.isLoading]);
+}
+
+/**
+ * Update user-preference of saved filters with a POST request
+ * A debounce of 350 is used to prevent multiple post when use onChange event of data-table
+ */
+export function useSqonsQBUpdatePreferenceEffect({ appId, sqons }: useSqonsQBStateObserverProps) {
+  const qbUserPreference = useSWR(
+    `query-builder-get-${appId}`,
+    () => fetchUserPreference({ key: `query-builder-${appId}` }),
+    {
+      revalidateOnMount: true,
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+    },
+  );
+  const { trigger } = useSWRMutation(`query-builder-post-${appId}`, postUserPreference);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    const handler = setTimeout(() => {
+      trigger({
+        key: `query-builder-${appId}`,
+        userPreference: {
+          content: {
+            ...qbUserPreference.data?.content,
+            sqons,
+          },
+          key: `query-builder-${appId}`,
+        },
+      });
+    }, 350);
+
+    return () => {
+      if (handler) clearTimeout(handler);
+    };
+  }, [sqons]);
 }

--- a/frontend/components/base/query-builder-v3/hooks/use-query-builder-preference.tsx
+++ b/frontend/components/base/query-builder-v3/hooks/use-query-builder-preference.tsx
@@ -83,11 +83,11 @@ export function useSqonsQBUpdatePreferenceEffect({ appId, sqons }: useSqonsQBSta
     },
   );
   const { trigger } = useSWRMutation(`query-builder-post-${appId}`, postUserPreference);
-  const isFirstRender = useRef(true);
+  const hasBeenMountedOnce = useRef(true);
 
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
+    if (hasBeenMountedOnce.current) {
+      hasBeenMountedOnce.current = false;
       return;
     }
 

--- a/frontend/components/base/query-builder-v3/queries-bar-card.tsx
+++ b/frontend/components/base/query-builder-v3/queries-bar-card.tsx
@@ -16,10 +16,16 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/
 import { Button } from '@/components/base/shadcn/button';
 import { Card } from '@/components/base/shadcn/card';
 import { Switch } from '@/components/base/shadcn/switch';
+import { ApplicationId } from '@/components/cores/applications-config';
 import { useI18n } from '@/components/hooks/i18n';
 
+import { useSqonsQBUpdatePreferenceEffect } from './hooks/use-query-builder-preference';
 import QueryBuilderSavedFilters from './saved-filter/query-builder-saved-filters';
 import { BooleanOperators } from './type';
+
+type QueriesBarCardProps = {
+  appId: ApplicationId;
+};
 
 /**
  * Card that display all queries for query-builder
@@ -36,11 +42,17 @@ import { BooleanOperators } from './type';
  * |  [New Query] (*) Label                                                  |
  * └─────────────────────────────────────────────────────────────────────────┘
  */
-function QueriesBarCard() {
+function QueriesBarCard({ appId }: QueriesBarCardProps) {
   const { t } = useI18n();
   const settings = useQBSettings();
   const { sqons } = useQBContext();
   const dispatch = useQBDispatch();
+
+  // Sync sqons changes with user preference
+  useSqonsQBUpdatePreferenceEffect({
+    appId,
+    sqons,
+  });
 
   /**
    * Add and active a new query

--- a/frontend/components/base/query-builder-v3/query-builder.tsx
+++ b/frontend/components/base/query-builder-v3/query-builder.tsx
@@ -61,7 +61,10 @@ function QueryBuilder({ appId, defaultSidebarOpen = false, fetcher, children }: 
 
   return (
     <QBProvider {...qbPreference} aggregations={aggregations} fetcher={fetcher}>
-      <SavedFilterInitializer selectedSavedFilter={savedFilterPreference?.selectedSavedFilter}>
+      <SavedFilterInitializer
+        selectedSavedFilter={savedFilterPreference?.selectedSavedFilter}
+        userPrefSqons={qbPreference?.sqons}
+      >
         <FacetConfigContext value={{ appId, ...facetFetchers }}>
           <SavedFiltersProvider
             savedFilters={savedFilterFetcher.data || []}
@@ -101,7 +104,7 @@ function QueryBuilder({ appId, defaultSidebarOpen = false, fetcher, children }: 
                 </aside>
                 <main className="flex-1 shrink px-3 pb-3 overflow-auto">
                   <div className="py-3 space-y-2">
-                    <QueriesBarCard />
+                    <QueriesBarCard appId={appId} />
                   </div>
                   {children}
                 </main>

--- a/frontend/components/base/query-builder-v3/saved-filter/saved-filter-initializer.tsx
+++ b/frontend/components/base/query-builder-v3/saved-filter/saved-filter-initializer.tsx
@@ -8,25 +8,34 @@ import { ISyntheticSqon } from '../type';
 type SavedFilterSyncWrapperProps = {
   children: React.ReactNode;
   selectedSavedFilter?: SavedFilter;
+  userPrefSqons?: ISyntheticSqon[];
 };
 
 /**
  * Wrapper component that synchronizes selected saved filter with QB context
  * Must be used inside QBProvider
  */
-export function SavedFilterInitializer({ children, selectedSavedFilter }: SavedFilterSyncWrapperProps) {
+export function SavedFilterInitializer({ children, selectedSavedFilter, userPrefSqons }: SavedFilterSyncWrapperProps) {
   const dispatchQB = useQBDispatch();
   const hasInitialized = useRef(false);
 
   useEffect(() => {
-    if (!hasInitialized.current && selectedSavedFilter?.queries) {
+    if (hasInitialized.current) return;
+
+    if (selectedSavedFilter?.queries) {
       dispatchQB({
         type: QBActionType.LOAD_QUERIES,
         payload: selectedSavedFilter.queries as ISyntheticSqon[],
       });
       hasInitialized.current = true;
+    } else if (userPrefSqons?.length) {
+      dispatchQB({
+        type: QBActionType.LOAD_QUERIES,
+        payload: userPrefSqons,
+      });
+      hasInitialized.current = true;
     }
-  }, []); // Empty deps array to run only once
+  }, []);
 
   return <>{children}</>;
 }

--- a/frontend/components/base/query-builder-v3/saved-filter/saved-filter-initializer.tsx
+++ b/frontend/components/base/query-builder-v3/saved-filter/saved-filter-initializer.tsx
@@ -35,7 +35,7 @@ export function SavedFilterInitializer({ children, selectedSavedFilter, userPref
       });
       hasInitialized.current = true;
     }
-  }, []);
+  }, []); // Empty deps array to run only once
 
   return <>{children}</>;
 }


### PR DESCRIPTION
# Fix (qb): Sync qb context sqons with user pref

## 📌 Context

On page load, queries are not loaded if no selected saved filter and existing queries.

## 📝 Changes

- Sync queries with selected saved filter or qb sqons

## 🧪 Tests


https://github.com/user-attachments/assets/cfe6e753-ebf1-4a9c-ad6e-d8ce0138a8a5



## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1139](https://d3b.atlassian.net/browse/SJRA-1139)<!-- End JIRA Issues -->

[SJRA-1139]: https://d3b.atlassian.net/browse/SJRA-1139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ