### PR TITLE
fix(somatic): SJRA-1325 change notation for tumor normal cell

### DIFF
--- a/frontend/components/base/data-table/cells/tumor-normal-frequency-cell.tsx
+++ b/frontend/components/base/data-table/cells/tumor-normal-frequency-cell.tsx
@@ -13,11 +13,10 @@ function TumorNormalFrequencyCell({ pc, pf, locusId }: NumberCellProps) {
     return <EmptyCell />;
   }
 
-  const scientificNotationPC = toExponentialNotation(pc);
   const scientificNotationPF = toExponentialNotation(pf);
   return (
     <AnchorLink size="sm" href={`/variants/entity/${locusId}?tab=patients&cases=OtherCases`} target="_blank">
-      {scientificNotationPC ? scientificNotationPC : pc} ({scientificNotationPF ? scientificNotationPF : pf})
+      {pc} ({scientificNotationPF ? scientificNotationPF : pf})
     </AnchorLink>
   );
 }


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Dans l’API il semble qu’on a juste PC et PF. Donc on mettra PC en nombre entier et PF en notation scientific . ce sera alors quelque chose comme ça 3 (7.50e-1)

## 📝 Changes

- pc(pf scientific notation)
<img width="376" height="547" alt="image" src="https://github.com/user-attachments/assets/9c301b21-bd0a-4443-b18f-9bbb2f14393e" />



## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1325](https://d3b.atlassian.net/browse/SJRA-1325)<!-- End JIRA Issues -->


[SJRA-1325]: https://d3b.atlassian.net/browse/SJRA-1325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ