### PR TITLE
feat(switch): SJRA-1363 rework component update sizes

### DIFF
--- a/frontend/components/base/query-builder-v3/facets/multiselect-facet.tsx
+++ b/frontend/components/base/query-builder-v3/facets/multiselect-facet.tsx
@@ -310,7 +310,7 @@ export function MultiSelectFacet({ field, maxVisibleItems = 5 }: MultiFacetProps
               <Switch
                 id="with-dictionary-switch"
                 checked={isDictionaryEnabled}
-                size="xs"
+                size="sm"
                 onCheckedChange={handleOnDictionaryChecked}
               />
             </>

--- a/frontend/components/base/query-builder-v3/queries-bar-card.tsx
+++ b/frontend/components/base/query-builder-v3/queries-bar-card.tsx
@@ -165,7 +165,7 @@ function QueriesBarCard({ appId }: QueriesBarCardProps) {
 
                     {/* Toggle labelsEnabled Settings */}
                     <div className="flex items-center gap-1.5">
-                      <Switch size="xs" checked={settings.labelsEnabled} onCheckedChange={handleLabelsCheckedChange} />
+                      <Switch size="sm" checked={settings.labelsEnabled} onCheckedChange={handleLabelsCheckedChange} />
                       {t('common.toolbar.labels')}
                     </div>
                   </>

--- a/frontend/components/base/query-builder/query-toolbar/query-toolbar-labels-action.tsx
+++ b/frontend/components/base/query-builder/query-toolbar/query-toolbar-labels-action.tsx
@@ -9,7 +9,7 @@ function QueryToolbarLabelsAction() {
   if (!queryBuilder.canCombine() && enableShowHideLabels) {
     return (
       <div className="flex items-center gap-1.5">
-        <Switch size="xs" checked={showLabels} onCheckedChange={toggleLabels} /> {dict.toolbar.labels}
+        <Switch size="sm" checked={showLabels} onCheckedChange={toggleLabels} /> {dict.toolbar.labels}
       </div>
     );
   }

--- a/frontend/components/base/query-filters/multiselect-filter.tsx
+++ b/frontend/components/base/query-filters/multiselect-filter.tsx
@@ -572,7 +572,7 @@ export function MultiSelectFilter({ field, maxVisibleItems = 5 }: IProps) {
               <Switch
                 id="with-dictionary-switch"
                 checked={withDictionaryToggle}
-                size="xs"
+                size="sm"
                 onCheckedChange={() => setWithDictionaryToggle(!withDictionaryToggle)}
               />
             </>

--- a/frontend/components/base/shadcn/switch.tsx
+++ b/frontend/components/base/shadcn/switch.tsx
@@ -4,31 +4,19 @@ import { tv, VariantProps } from 'tailwind-variants';
 
 const switchVariants = tv({
   slots: {
-    base: 'peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors shadow-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring  focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+    base: 'peer inline-flex shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors shadow-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring  focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
     thumb:
       'pointer-events-none block rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=unchecked]:translate-x-0',
   },
   variants: {
     size: {
       default: {
-        base: 'h-5 w-9',
-        thumb: 'size-4 data-[state=checked]:translate-x-4',
-      },
-      xs: {
-        base: 'h-4 w-7',
-        thumb: 'size-3 data-[state=checked]:translate-x-3',
+        base: 'h-5 w-8',
+        thumb: 'size-4 data-[state=checked]:translate-x-3',
       },
       sm: {
-        base: 'h-5 w-9',
-        thumb: 'size-4 data-[state=checked]:translate-x-4',
-      },
-      md: {
-        base: 'h-6 w-11',
-        thumb: 'size-5 data-[state=checked]:translate-x-5',
-      },
-      lg: {
-        base: 'h-7 w-12',
-        thumb: 'size-6 data-[state=checked]:translate-x-5',
+        base: 'h-3.5 w-6',
+        thumb: 'size-3 data-[state=checked]:translate-x-2.5',
       },
     },
   },

--- a/frontend/components/stories/inputs/switch.stories.tsx
+++ b/frontend/components/stories/inputs/switch.stories.tsx
@@ -18,25 +18,21 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  render: () => {
-    const [checked, setChecked] = useState(false);
-
-    return <Switch checked={checked} onCheckedChange={setChecked} />;
-  },
-};
-
 export const Sizes: Story = {
   render: () => {
-    const [checked, setChecked] = useState(false);
+    const [checkedDefault, setCheckedDefault] = useState(false);
+    const [checkedSm, setCheckedSm] = useState(false);
 
     return (
-      <div className="flex gap-2">
-        <Switch size="default" checked={checked} onCheckedChange={setChecked} />
-        <Switch size="xs" checked={checked} onCheckedChange={setChecked} />
-        <Switch size="sm" checked={checked} onCheckedChange={setChecked} />
-        <Switch size="md" checked={checked} onCheckedChange={setChecked} />
-        <Switch size="lg" checked={checked} onCheckedChange={setChecked} />
+      <div className="flex flex-col gap-2">
+        <div className="flex gap-2 items-center">
+          <span className="">Default</span>
+          <Switch size="default" checked={checkedDefault} onCheckedChange={setCheckedDefault} />
+        </div>
+        <div className="flex gap-2 items-center">
+          <span className="">Small</span>
+          <Switch size="sm" checked={checkedSm} onCheckedChange={setCheckedSm} />
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
# Feat(switch): Rework component update sizes

## 📌 Context

Align Switch component with Figma + shadcn

## 📝 Changes

- rework style and size component
- update storybook
- update size where it's used

## 🧪 Tests

### Before

<img width="665" height="271" alt="Capture d’écran, le 2026-04-27 à 09 57 06" src="https://github.com/user-attachments/assets/615f7a62-7602-4e68-9910-09b9d9ede511" />

### After

https://github.com/user-attachments/assets/3936a016-14e9-4851-9a7c-f21b70d5f0e6

#### impacted screen

<img width="665" height="271" alt="Capture d’écran, le 2026-04-27 à 10 01 43" src="https://github.com/user-attachments/assets/d1b869f5-fd6f-49f8-a011-96601f25db01" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1363](https://d3b.atlassian.net/browse/SJRA-1363)<!-- End JIRA Issues -->

[SJRA-1363]: https://d3b.atlassian.net/browse/SJRA-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ