### PR TITLE
feat(somatic): SJRA-1351 add read only interpretation in variant slider

### DIFF
--- a/frontend/components/base/badges/classification-badge.tsx
+++ b/frontend/components/base/badges/classification-badge.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@/components/hooks/i18n';
 interface ClassificationBadgeProps extends BadgeProps {
   value: string | null; // TODO: Should be replace with enum with API exposes one
   abbreviated?: boolean;
+  isSomatic?: boolean;
 }
 
 export const ClassificationValueMap: Record<string, BadgeProps['variant']> = {
@@ -13,11 +14,13 @@ export const ClassificationValueMap: Record<string, BadgeProps['variant']> = {
   association_not_found: 'neutral',
   uncertain_significance: 'yellow',
   likely_benign: 'lime',
+  likely_oncogenic: 'violet',
   likely_pathogenic: 'orange',
   low_penetrance: 'neutral',
   risk_factor: 'neutral',
   association: 'neutral',
   uncertain_risk_allele: 'neutral',
+  oncogenic: 'red',
   pathogenic: 'red',
   protective: 'neutral',
   conflicting_classifications_of_pathogenicity: 'orange',
@@ -40,11 +43,19 @@ export const AcmgAmpClassificationMap: Record<string, string> = {
   'LA6675-8': 'benign',
 };
 
+export const SomaticAcmgAmpClassificationMap: Record<string, string> = {
+  'LA6668-3': 'oncogenic',
+  'LA26332-9': 'likely_oncogenic',
+  'LA26333-7': 'uncertain_significance',
+  'LA26334-5': 'likely_benign',
+  'LA6675-8': 'benign',
+};
+
 /**
  * API can return non-snake-case key. We needs to map
  * the non-snake-case value to the correct classification value
  */
-function getClassificationValue(value: string): { color: BadgeProps['variant']; key: string } {
+function getClassificationValue(value: string, isSomatic: boolean): { color: BadgeProps['variant']; key: string } {
   const color = ClassificationValueMap[value];
 
   // value is in snake_case
@@ -52,7 +63,10 @@ function getClassificationValue(value: string): { color: BadgeProps['variant']; 
     return { color, key: value };
   }
 
-  const acmgamp = AcmgAmpClassificationMap[value.toUpperCase()];
+  const acmgamp = isSomatic
+    ? SomaticAcmgAmpClassificationMap[value.toUpperCase()]
+    : AcmgAmpClassificationMap[value.toUpperCase()];
+
   if (acmgamp) {
     return {
       color: ClassificationValueMap[acmgamp],
@@ -82,9 +96,9 @@ function getClassificationValue(value: string): { color: BadgeProps['variant']; 
   };
 }
 
-function ClassificationBadge({ value, abbreviated, ...props }: ClassificationBadgeProps) {
+function ClassificationBadge({ value, abbreviated, isSomatic = false, ...props }: ClassificationBadgeProps) {
   const { t } = useI18n();
-  const result = getClassificationValue((value ?? '').toLowerCase());
+  const result = getClassificationValue((value ?? '').toLowerCase(), isSomatic);
 
   return (
     <ConditionalWrapper

--- a/frontend/components/base/slider/germline-slider-interpretation-details-card.tsx
+++ b/frontend/components/base/slider/germline-slider-interpretation-details-card.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { CalendarIcon, ClipboardList, LibraryBig, StethoscopeIcon } from 'lucide-react';
-
 import useSWR from 'swr';
+
 import { InterpretationGermline } from '@/api/api';
 import ClassificationBadge from '@/components/base/badges/classification-badge';
 import TransmissionModeBadge from '@/components/base/badges/transmission-mode-badge';
@@ -16,12 +16,12 @@ import { Badge } from '@/components/base/shadcn/badge';
 import { Button } from '@/components/base/shadcn/button';
 import { Separator } from '@/components/base/shadcn/separator';
 import { Skeleton } from '@/components/base/shadcn/skeleton';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/shadcn/tooltip';
 import { DescriptionSection } from '@/components/base/slider/description';
 import SliderCard from '@/components/base/slider/slider-card';
 import TranscriptIdLink from '@/components/base/variant/transcript-id-link';
 import { getOmimOrgUrl } from '@/components/base/variant/utils';
 import { useI18n } from '@/components/hooks/i18n';
-import { Tooltip, TooltipContent, TooltipTrigger } from 'components/base/shadcn/tooltip';
 import { interpretationApi } from '@/utils/api';
 
 type GermlineSliderInterpretationDetailsCardProps = {

--- a/frontend/components/base/slider/germline-slider-interpretation-details-card.tsx
+++ b/frontend/components/base/slider/germline-slider-interpretation-details-card.tsx
@@ -107,7 +107,7 @@ function GermlineSliderInterpretationDetailsCard({
         <div className="size-full">
           <div className="flex flex-col flex-wrap gap-4 items-start p-3 w-full">
             <div className="flex grow w-full">
-              <div className="flex gap-6">
+              <div className="flex gap-6 w-full">
                 <DescriptionSection title={t('preview_sheet.interpretation_details.fields.gene')} fullWidth={false}>
                   {symbol ? (
                     <AnchorLink

--- a/frontend/components/base/slider/somatic-slider-interpretation-details-card.tsx
+++ b/frontend/components/base/slider/somatic-slider-interpretation-details-card.tsx
@@ -170,7 +170,9 @@ function SomaticSliderInterpretationDetailsCard({
               <DescriptionSection title={t('preview_sheet.interpretation_details.fields.clinical_utility')}>
                 {interpretation.data?.clinical_utility ? (
                   <Badge>
-                    {t(`preview_sheet.interpretation_details.clinical_utility.${interpretation.data.clinical_utility}`)}
+                    {t(
+                      `variant.interpretation_form.somatic.clinical_utility_options.${interpretation.data.clinical_utility}`,
+                    )}
                   </Badge>
                 ) : (
                   <EmptyField />

--- a/frontend/components/base/slider/somatic-slider-interpretation-details-card.tsx
+++ b/frontend/components/base/slider/somatic-slider-interpretation-details-card.tsx
@@ -106,7 +106,7 @@ function SomaticSliderInterpretationDetailsCard({
         <div className="size-full">
           <div className="flex flex-col flex-wrap gap-4 items-start p-3 w-full">
             <div className="flex grow w-full">
-              <div className="flex gap-6">
+              <div className="flex gap-6 w-full">
                 <DescriptionSection title={t('preview_sheet.interpretation_details.fields.gene')} fullWidth={false}>
                   {symbol ? (
                     <AnchorLink
@@ -143,17 +143,16 @@ function SomaticSliderInterpretationDetailsCard({
                 </div>
               </div>
             </div>
-            {/* TODO: waiting back fix to display the real tumoral type */}
-            {interpretation.data?.tumoral_type && (
+            {interpretation.data?.tumoral_name && interpretation.data?.tumoral_name && (
               <DescriptionSection title={t('preview_sheet.interpretation_details.fields.tumoral_type')}>
                 <div className="flex gap-2">
                   <AnchorLink
-                    href={`http://purl.obolibrary.org/obo/MONDO_${interpretation.data?.tumoral_type.replace('MONDO:', '')}`}
+                    href={`http://purl.obolibrary.org/obo/MONDO_${interpretation.data?.tumoral_type?.replace('MONDO:', '')}`}
                     target="_blank"
                     rel="noreferrer"
                     size="sm"
                   >
-                    {interpretation.data?.tumoral_type}
+                    {interpretation.data?.tumoral_name}
                   </AnchorLink>
                 </div>
               </DescriptionSection>

--- a/frontend/components/base/slider/somatic-slider-interpretation-details-card.tsx
+++ b/frontend/components/base/slider/somatic-slider-interpretation-details-card.tsx
@@ -1,26 +1,27 @@
 import { useEffect, useState } from 'react';
 import { CalendarIcon, ClipboardList, LibraryBig, StethoscopeIcon } from 'lucide-react';
-
 import useSWR from 'swr';
+
 import { InterpretationSomatic } from '@/api/api';
-import ClassificationBadge from '@/components/base/badges/classification-badge';
-import TransmissionModeBadge from '@/components/base/badges/transmission-mode-badge';
 import RichTextViewer from '@/components/base/data-entry/rich-text-editor/rich-text-viewer';
 import DateTime from '@/components/base/date/datetime';
 import EmptyField from '@/components/base/information/empty-field';
 import AnchorLink from '@/components/base/navigation/anchor-link';
-import PhenotypeConditionLink from '@/components/base/navigation/phenotypes/phenotype-condition-link';
 import PubmedListDialog from '@/components/base/pubmed/pubmed-list-dialog';
 import { Button } from '@/components/base/shadcn/button';
 import { Separator } from '@/components/base/shadcn/separator';
 import { Skeleton } from '@/components/base/shadcn/skeleton';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/shadcn/tooltip';
 import { DescriptionSection } from '@/components/base/slider/description';
 import SliderCard from '@/components/base/slider/slider-card';
 import TranscriptIdLink from '@/components/base/variant/transcript-id-link';
 import { getOmimOrgUrl } from '@/components/base/variant/utils';
 import { useI18n } from '@/components/hooks/i18n';
-import { Tooltip, TooltipContent, TooltipTrigger } from 'components/base/shadcn/tooltip';
 import { interpretationApi } from '@/utils/api';
+
+import ClassificationBadge from '../badges/classification-badge';
+import { getOncogenicityClassificationCriteriaColor } from '../classifications/oncogenicity';
+import { Badge } from '../shadcn/badge';
 
 type SliderInterpretationDetailsCardProps = {
   seqId: number;
@@ -136,6 +137,46 @@ function SomaticSliderInterpretationDetailsCard({
                   )}
                 </DescriptionSection>
               </div>
+              <div className="flex justify-end w-full">
+                <div>
+                  <ClassificationBadge value={interpretation.data?.oncogenicity ?? ''} isSomatic={true} size="lg" />
+                </div>
+              </div>
+            </div>
+            {/* TODO: waiting back fix to display the real tumoral type */}
+            {interpretation.data?.tumoral_type && (
+              <DescriptionSection title={t('preview_sheet.interpretation_details.fields.tumoral_type')}>
+                <div className="flex gap-2">
+                  <AnchorLink
+                    href={`http://purl.obolibrary.org/obo/MONDO_${interpretation.data?.tumoral_type.replace('MONDO:', '')}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    size="sm"
+                  >
+                    {interpretation.data?.tumoral_type}
+                  </AnchorLink>
+                </div>
+              </DescriptionSection>
+            )}
+            <div className="flex w-full">
+              <DescriptionSection title={t('preview_sheet.interpretation_details.fields.classification_criteria')}>
+                <div className="space-x-1">
+                  {(interpretation.data?.oncogenicity_classification_criterias ?? []).map((criteria: string) => (
+                    <Badge key={criteria} variant={getOncogenicityClassificationCriteriaColor(criteria)}>
+                      {criteria}
+                    </Badge>
+                  ))}
+                </div>
+              </DescriptionSection>
+              <DescriptionSection title={t('preview_sheet.interpretation_details.fields.clinical_utility')}>
+                {interpretation.data?.clinical_utility ? (
+                  <Badge>
+                    {t(`preview_sheet.interpretation_details.clinical_utility.${interpretation.data.clinical_utility}`)}
+                  </Badge>
+                ) : (
+                  <EmptyField />
+                )}
+              </DescriptionSection>
             </div>
             <Separator />
             <div className="flex gap-6 text-sm text-muted-foreground font-sans">

--- a/frontend/translations/common/en.json
+++ b/frontend/translations/common/en.json
@@ -57,6 +57,9 @@
       "likely_benign": "Likely Benign",
       "likely_benign.abbrev": "LB",
       "likely_benign.tooltip": "Likely Benign",
+      "likely_oncogenic": "Likely Oncogenic",
+      "likely_oncogenic.abbrev": "LO",
+      "likely_oncogenic.tooltip": "Likely Oncogenic",
       "likely_pathogenic": "Likely Patho.",
       "likely_pathogenic.abbrev": "LP",
       "likely_pathogenic.tooltip": "Likely Pathogenic",
@@ -75,6 +78,9 @@
       "no_data": "No Data",
       "no_data.abbrev": "ND",
       "no_data.tooltip": "No Data",
+      "oncogenic": "Oncogenic",
+      "oncogenic.abbrev": "O",
+      "oncogenic.tooltip": "Oncogenic",
       "pathogenic": "Pathogenic",
       "pathogenic.abbrev": "P",
       "pathogenic.tooltip": "Pathogenic",
@@ -1125,10 +1131,19 @@
         "classification": "Classification",
         "primary_condition": "Primary Condition",
         "classification_criteria": "Classification criteria",
+        "clinical_utility": "Clinical utility",
         "interpretation": "Interpretation",
         "references": "{{count}} references",
+        "tumoral_type": "Tumor Type",
         "updated_at_tooltip": "Last interpretation date",
         "updated_by_name_tooltip": "Authored by"
+      },
+      "clinical_utility": {
+        "category_ia": "Tier IA",
+        "category_ib": "Tier IB",
+        "category_iic": "Tier IIC",
+        "category_iid": "Tier IID",
+        "category_iii": "Tier III"
       }
     },
     "variant_details": {

--- a/frontend/translations/common/en.json
+++ b/frontend/translations/common/en.json
@@ -1137,13 +1137,6 @@
         "tumoral_type": "Tumor Type",
         "updated_at_tooltip": "Last interpretation date",
         "updated_by_name_tooltip": "Authored by"
-      },
-      "clinical_utility": {
-        "category_ia": "Tier IA",
-        "category_ib": "Tier IB",
-        "category_iic": "Tier IIC",
-        "category_iid": "Tier IID",
-        "category_iii": "Tier III"
       }
     },
     "variant_details": {

--- a/frontend/translations/common/fr.json
+++ b/frontend/translations/common/fr.json
@@ -1141,13 +1141,6 @@
         "tumoral_type": "Type tumoral",
         "updated_at_tooltip": "Dernière date d'interprétation",
         "updated_by_name_tooltip": "Rédigé par"
-      },
-      "clinical_utility": {
-        "category_ia": "Tier IA",
-        "category_ib": "Tier IB",
-        "category_iic": "Tier IIC",
-        "category_iid": "Tier IID",
-        "category_iii": "Tier III"
       }
     },
     "variant_details": {

--- a/frontend/translations/common/fr.json
+++ b/frontend/translations/common/fr.json
@@ -57,6 +57,9 @@
       "likely_benign": "Probablement bénigne",
       "likely_benign.abbrev": "LB",
       "likely_benign.tooltip": "Probablement bénigne",
+      "likely_oncogenic": "Prob. oncogénique",
+      "likely_oncogenic.abbrev": "LO",
+      "likely_oncogenic.tooltip": "Probablement oncogénique",
       "likely_pathogenic": "Probablement pathogénique",
       "likely_pathogenic.abbrev": "LP",
       "likely_pathogenic.tooltip": "Probablement pathogénique",
@@ -75,6 +78,9 @@
       "no_data": "Aucune donnée",
       "no_data.abbrev": "ND",
       "no_data.tooltip": "Aucune donnée",
+      "oncogenic": "Oncogénique",
+      "oncogenic.abbrev": "O",
+      "oncogenic.tooltip": "Oncogénique",
       "pathogenic": "Pathogénique",
       "pathogenic.abbrev": "P",
       "pathogenic.tooltip": "Pathogénique",
@@ -1129,10 +1135,19 @@
         "classification": "Classification",
         "primary_condition": "Condition principale",
         "classification_criteria": "Critères de classification",
+        "clinical_utility": "Utilité clinique",
         "interpretation": "Interprétation",
         "references": "{{count}} références",
+        "tumoral_type": "Type tumoral",
         "updated_at_tooltip": "Dernière date d'interprétation",
         "updated_by_name_tooltip": "Rédigé par"
+      },
+      "clinical_utility": {
+        "category_ia": "Tier IA",
+        "category_ib": "Tier IB",
+        "category_iic": "Tier IIC",
+        "category_iid": "Tier IID",
+        "category_iii": "Tier III"
       }
     },
     "variant_details": {


### PR DESCRIPTION
# Feat (somatic): Add read only interpretation in variant slider

## 📌 Context

Add interpretation un variant somatic slider.

## 📝 Changes

- add interpretation info in somatic slider

## 🧪 Tests

<img width="665" height="473" alt="Capture d’écran, le 2026-04-27 à 10 22 02" src="https://github.com/user-attachments/assets/a99ea0e2-7e17-4c89-ad5e-2b1ec72cf09d" />

<img width="665" height="496" alt="Capture d’écran, le 2026-04-27 à 10 23 03" src="https://github.com/user-attachments/assets/870ccb61-1d08-4e31-86bf-33f4e677bd15" />

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1351](https://d3b.atlassian.net/browse/SJRA-1351)<!-- End JIRA Issues -->

[SJRA-1351]: https://d3b.atlassian.net/browse/SJRA-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ