### PR TITLE
fix(qb): SJRA-1389 qb render two times on reload page

### DIFF
--- a/frontend/apps/case/src/entity/case-entity.tsx
+++ b/frontend/apps/case/src/entity/case-entity.tsx
@@ -148,11 +148,12 @@ export default function App() {
             </TabsContent>
           </Container>
           <TabsContent value={CaseEntityTabs.Variants} className="py-0">
-            {data?.case_type === 'somatic' ? (
-              <SomaticVariantsTab isLoading={isLoading} caseEntity={data} />
-            ) : (
-              <GermlineVariantsTab isLoading={isLoading} caseEntity={data} />
-            )}
+            {data &&
+              (data.case_type === 'somatic' ? (
+                <SomaticVariantsTab isLoading={isLoading} caseEntity={data} />
+              ) : (
+                <GermlineVariantsTab isLoading={isLoading} caseEntity={data} />
+              ))}
           </TabsContent>
           <TabsContent value={CaseEntityTabs.Files} className="p-0 md:p-3">
             <FilesTab />

--- a/frontend/components/base/query-builder-v3/query-builder.tsx
+++ b/frontend/components/base/query-builder-v3/query-builder.tsx
@@ -51,9 +51,13 @@ function QueryBuilder({ appId, defaultSidebarOpen = false, fetcher, children }: 
   useSavedFilterGetPreferenceEffect({ savedFilterType, setPreference: setSavedFilterPreference });
 
   // Fetch saved filters
-  const savedFilterFetcher = useSWR<SavedFilter[]>('fetch-saved-filters', () => fetchSavedFilters(savedFilterType), {
-    revalidateOnFocus: false,
-  });
+  const savedFilterFetcher = useSWR<SavedFilter[]>(
+    `fetch-saved-filters-${savedFilterType}`,
+    () => fetchSavedFilters(savedFilterType),
+    {
+      revalidateOnFocus: false,
+    },
+  );
 
   if (!qbPreference || !savedFilterPreference || savedFilterFetcher.isLoading) {
     return <QueryBuilderSkeleton defaultSidebarOpen={defaultSidebarOpen} aggregations={aggregations} />;


### PR DESCRIPTION
# Fix (qb): two render of component on reload

## 📌 Context

Refresh page render two times the qb

## 📝 Changes

- update check to display somatic or germline tab

## 🧪 Tests

### Before

https://github.com/user-attachments/assets/fbccc09e-f5bd-44aa-87a1-08d6b3958295

### After

https://github.com/user-attachments/assets/50384346-a12b-4b95-bf30-583b72141595

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1389](https://d3b.atlassian.net/browse/SJRA-1389)<!-- End JIRA Issues -->

[SJRA-1389]: https://d3b.atlassian.net/browse/SJRA-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ