### PR TITLE
feat(igv): SJRA-1329 disabled igv when files are unavailables

### DIFF
--- a/frontend/apps/case/src/entity/variants/germline-occurrence/sliders/slider-germline-occurrence-sheet.tsx
+++ b/frontend/apps/case/src/entity/variants/germline-occurrence/sliders/slider-germline-occurrence-sheet.tsx
@@ -183,7 +183,7 @@ function GermlineOccurrenceSheetContent({
           mother_calls={expandResult.data.mother_calls}
           ad_alt={expandResult.data.ad_alt}
           ad_total={expandResult.data.ad_total}
-          enableIGV
+          has_igv_files={caseResult.data?.has_igv_files}
         />
       )}
       <SliderVariantDetailsCard

--- a/frontend/apps/case/src/entity/variants/germline-occurrence/snv-tab.tsx
+++ b/frontend/apps/case/src/entity/variants/germline-occurrence/snv-tab.tsx
@@ -5,6 +5,7 @@ import { X } from 'lucide-react';
 import useSWR from 'swr';
 
 import {
+  CaseEntity,
   CaseSequencingExperiment,
   Count,
   CountBodyWithSqon,
@@ -62,6 +63,7 @@ type SnvOccurrenceCountInput = {
 type SNVTabProps = {
   seqId: number;
   patientSelected?: CaseSequencingExperiment;
+  caseEntity?: CaseEntity;
 };
 
 async function fetchQueryCount(input: SnvOccurrenceCountInput) {
@@ -69,7 +71,7 @@ async function fetchQueryCount(input: SnvOccurrenceCountInput) {
   return response.data;
 }
 
-function SNVTab({ seqId, patientSelected }: SNVTabProps) {
+function SNVTab({ seqId, patientSelected, caseEntity }: SNVTabProps) {
   const { t } = useI18n();
   const config = useConfig();
   const caseId = useCaseIdFromParam();
@@ -328,7 +330,7 @@ function SNVTab({ seqId, patientSelected }: SNVTabProps) {
               <CardContent>
                 <DataTable
                   id={appId}
-                  columns={getSNVOccurrenceColumns(t, onInterpretationSaved)}
+                  columns={getSNVOccurrenceColumns(t, caseEntity, onInterpretationSaved)}
                   data={fetchOccurrencesList.data ?? []}
                   defaultColumnSettings={defaultSNVSettings}
                   loadingStates={{

--- a/frontend/apps/case/src/entity/variants/germline-occurrence/table/cells/occurrence-actions-cell.tsx
+++ b/frontend/apps/case/src/entity/variants/germline-occurrence/table/cells/occurrence-actions-cell.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import { Row } from '@tanstack/react-table';
 import { ArrowUpRight, EyeIcon, FlipHorizontal2Icon } from 'lucide-react';
 
-import { GermlineSNVOccurrence } from '@/api/api';
+import { CaseEntity, GermlineSNVOccurrence } from '@/api/api';
 import { ActionButton } from '@/components/base/buttons';
 import { useI18n } from '@/components/hooks/i18n';
 import { useCaseIdFromParam } from '@/utils/helper';
@@ -12,10 +12,11 @@ import OccurrenceSliderSheet from '../../sliders/slider-germline-occurrence-shee
 
 type OccurrenceActionsMenuProps = {
   row: Row<GermlineSNVOccurrence>;
+  caseEntity: CaseEntity;
   onInterpretationSaved: () => void;
 };
 
-function OccurrenceActionsMenu({ row, onInterpretationSaved }: OccurrenceActionsMenuProps) {
+function OccurrenceActionsMenu({ row, caseEntity, onInterpretationSaved }: OccurrenceActionsMenuProps) {
   const { t } = useI18n();
   const [sheetOpen, setSheetOpen] = useState<boolean>(false);
   const [igvOpen, setIgvOpen] = useState<boolean>(false);
@@ -36,7 +37,7 @@ function OccurrenceActionsMenu({ row, onInterpretationSaved }: OccurrenceActions
         occurrence={row.original as GermlineSNVOccurrence}
         onInterpretationSaved={onInterpretationSaved}
       />
-      {caseId && (
+      {caseEntity.has_igv_files && (
         <IGVDialog
           open={igvOpen}
           setOpen={setIgvOpen}
@@ -68,6 +69,8 @@ function OccurrenceActionsMenu({ row, onInterpretationSaved }: OccurrenceActions
           {
             icon: <FlipHorizontal2Icon />,
             label: t('variant.actions.open_in_igv'),
+            tooltip: caseEntity.has_igv_files === false ? t('variant.actions.open_in_igv_disabled_tooltip') : undefined,
+            disabled: caseEntity.has_igv_files === false,
             onClick: () => setIgvOpen(true),
           },
           {

--- a/frontend/apps/case/src/entity/variants/germline-occurrence/table/germline-snv-occurrence-table-settings.tsx
+++ b/frontend/apps/case/src/entity/variants/germline-occurrence/table/germline-snv-occurrence-table-settings.tsx
@@ -1,7 +1,7 @@
 import { createColumnHelper } from '@tanstack/react-table';
 import { TFunction } from 'i18next';
 
-import { GermlineSNVOccurrence } from '@/api/api';
+import { CaseEntity, GermlineSNVOccurrence } from '@/api/api';
 import AnchorLinkCell from '@/components/base/data-table/cells/anchor-link-cell';
 import ClassificationCell from '@/components/base/data-table/cells/classification-cell';
 import ClinvarCell from '@/components/base/data-table/cells/clinvar-cell';
@@ -27,7 +27,11 @@ import OccurrenceActionsMenu from './cells/occurrence-actions-cell';
 
 const columnHelper = createColumnHelper<GermlineSNVOccurrence>();
 
-function getSNVOccurrenceColumns(t: TFunction<string, undefined>, onInterpretationSaved: () => void) {
+function getSNVOccurrenceColumns(
+  t: TFunction<string, undefined>,
+  caseEntity: CaseEntity,
+  onInterpretationSaved: () => void,
+) {
   return [
     // TODO: To be enabled when row selection function are implemented
     // {
@@ -248,7 +252,9 @@ function getSNVOccurrenceColumns(t: TFunction<string, undefined>, onInterpretati
     // Actions Buttons
     {
       id: 'actions',
-      cell: info => <OccurrenceActionsMenu row={info.row} onInterpretationSaved={onInterpretationSaved} />,
+      cell: info => (
+        <OccurrenceActionsMenu row={info.row} caseEntity={caseEntity} onInterpretationSaved={onInterpretationSaved} />
+      ),
       size: 86,
       enableResizing: false,
       enablePinning: true,

--- a/frontend/apps/case/src/entity/variants/germline-variants-tab.tsx
+++ b/frontend/apps/case/src/entity/variants/germline-variants-tab.tsx
@@ -53,7 +53,9 @@ function GermlineVariantsTab({ caseEntity, isLoading }: VariantTabProps) {
         showAffectedStatusBadge
       />
 
-      {activeInterface == GermlineVariantInterface.SNV && <SNVTab seqId={seqId} patientSelected={patientSelected} />}
+      {activeInterface == GermlineVariantInterface.SNV && (
+        <SNVTab seqId={seqId} patientSelected={patientSelected} caseEntity={caseEntity} />
+      )}
       {activeInterface == GermlineVariantInterface.CNV && <CNVTab seqId={seqId} />}
     </div>
   );

--- a/frontend/apps/case/src/entity/variants/somatic-occurrence/sliders/slider-somatic-occurrence-sheet.tsx
+++ b/frontend/apps/case/src/entity/variants/somatic-occurrence/sliders/slider-somatic-occurrence-sheet.tsx
@@ -253,7 +253,7 @@ export function SomaticOccurrenceSheetContent({
           ad_alt={expandResult.data.ad_alt}
           ad_total={expandResult.data.ad_total}
           locus={expandResult.data.locus}
-          enableIGV
+          has_igv_files={caseEntity.data?.has_igv_files}
         />
       )}
       <SliderVariantDetailsCard

--- a/frontend/apps/case/src/entity/variants/somatic-occurrence/snv-tumor-normal-tab.tsx
+++ b/frontend/apps/case/src/entity/variants/somatic-occurrence/snv-tumor-normal-tab.tsx
@@ -1,4 +1,4 @@
-import { CaseSequencingExperiment } from '@/api/api';
+import { CaseEntity, CaseSequencingExperiment } from '@/api/api';
 import { ICountInput, IListInput } from '@/components/base/query-builder-v3/hooks/use-query-builder';
 import QueryBuilder from '@/components/base/query-builder-v3/query-builder';
 import QueryBuilderDataTable from '@/components/base/query-builder-v3/query-builder-data-table';
@@ -18,9 +18,10 @@ import {
 type SomaticOccurrencesProps = {
   seqId: number;
   patientSelected?: CaseSequencingExperiment;
+  caseEntity?: CaseEntity;
 };
 
-function SNVTumorNormalTab({ seqId, patientSelected }: SomaticOccurrencesProps) {
+function SNVTumorNormalTab({ seqId, patientSelected, caseEntity }: SomaticOccurrencesProps) {
   const { t } = useI18n();
   const config = useConfig();
   const caseId = useCaseIdFromParam();
@@ -42,7 +43,7 @@ function SNVTumorNormalTab({ seqId, patientSelected }: SomaticOccurrencesProps) 
     >
       <QueryBuilderDataTable
         id={appId}
-        columns={getSomaticSNVTumorNormalColumns(t)}
+        columns={getSomaticSNVTumorNormalColumns(t, caseEntity)}
         defaultColumnSettings={defaultSomaticSNVSettings}
         enableColumnOrdering
         enableFullscreen

--- a/frontend/apps/case/src/entity/variants/somatic-occurrence/table/cells/somatic-actions-cell.tsx
+++ b/frontend/apps/case/src/entity/variants/somatic-occurrence/table/cells/somatic-actions-cell.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router';
 import { Row } from '@tanstack/react-table';
 import { ArrowUpRight, EyeIcon, FlipHorizontal2Icon } from 'lucide-react';
 
-import { GermlineSNVOccurrence } from '@/api/api';
+import { CaseEntity, GermlineSNVOccurrence } from '@/api/api';
 import { ActionButton } from '@/components/base/buttons';
 import { useI18n } from '@/components/hooks/i18n';
 import { SELECTED_VARIANT_PARAM } from '@/entity/variants/constants';
@@ -12,9 +12,10 @@ import IGVDialog from 'components/base/igv/igv-dialog';
 
 type SomaticActionsMenuProps = {
   row: Row<GermlineSNVOccurrence>;
+  caseEntity?: CaseEntity;
 };
 
-function SomaticActionsCell({ row }: SomaticActionsMenuProps) {
+function SomaticActionsCell({ row, caseEntity }: SomaticActionsMenuProps) {
   const { t } = useI18n();
   const [igvOpen, setIgvOpen] = useState<boolean>(false);
   const caseId = useCaseIdFromParam();
@@ -64,6 +65,9 @@ function SomaticActionsCell({ row }: SomaticActionsMenuProps) {
           {
             icon: <FlipHorizontal2Icon />,
             label: t('variant.actions.open_in_igv'),
+            tooltip:
+              caseEntity?.has_igv_files === false ? t('variant.actions.open_in_igv_disabled_tooltip') : undefined,
+            disabled: caseEntity?.has_igv_files === false,
             onClick: () => setIgvOpen(true),
           },
           {

--- a/frontend/apps/case/src/entity/variants/somatic-occurrence/table/somatic-snv-tumor-normal-table-settings.tsx
+++ b/frontend/apps/case/src/entity/variants/somatic-occurrence/table/somatic-snv-tumor-normal-table-settings.tsx
@@ -1,7 +1,7 @@
 import { createColumnHelper } from '@tanstack/react-table';
 import { TFunction } from 'i18next';
 
-import { GermlineSNVOccurrence, SomaticSNVOccurrence } from '@/api/api';
+import { CaseEntity, GermlineSNVOccurrence, SomaticSNVOccurrence } from '@/api/api';
 import AnchorLinkCell from '@/components/base/data-table/cells/anchor-link-cell';
 import ClinvarCell from '@/components/base/data-table/cells/clinvar-cell';
 import GeneCell from '@/components/base/data-table/cells/gene-cell';
@@ -27,7 +27,7 @@ import SomaticInterpretationCell from './cells/somatic-interpretation-cell';
 
 const columnHelper = createColumnHelper<SomaticSNVOccurrence>();
 
-function getSomaticSNVTumorNormalColumns(t: TFunction<string, undefined>) {
+function getSomaticSNVTumorNormalColumns(t: TFunction<string, undefined>, caseEntity?: CaseEntity) {
   return [
     // interpretation and note cell
     columnHelper.accessor(row => row, {
@@ -227,7 +227,7 @@ function getSomaticSNVTumorNormalColumns(t: TFunction<string, undefined>) {
     // Actions Buttons
     {
       id: 'actions',
-      cell: info => <SomaticActionsCell row={info.row} />,
+      cell: info => <SomaticActionsCell row={info.row} caseEntity={caseEntity} />,
       size: 86,
       enableResizing: false,
       enablePinning: true,

--- a/frontend/apps/case/src/entity/variants/somatic-variants-tab.tsx
+++ b/frontend/apps/case/src/entity/variants/somatic-variants-tab.tsx
@@ -59,7 +59,7 @@ function SomaticVariantsTab({ caseEntity, isLoading }: VariantTabProps) {
         }}
       />
       {activeInterface == SomaticVariantInterface.SNV_TN && (
-        <SNVTumorNormalTab seqId={seqId} patientSelected={patientSelected} />
+        <SNVTumorNormalTab seqId={seqId} patientSelected={patientSelected} caseEntity={caseEntity} />
       )}
     </div>
   );

--- a/frontend/components/base/buttons/action-button.tsx
+++ b/frontend/components/base/buttons/action-button.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { MoreVerticalIcon } from 'lucide-react';
 import { VariantProps } from 'tailwind-variants';
 
@@ -18,6 +19,8 @@ interface Action {
   icon?: React.ReactElement;
   onClick: () => void;
   hasSeparator?: boolean;
+  tooltip?: string;
+  disabled?: boolean;
 }
 
 interface ActionButtonProps
@@ -72,13 +75,25 @@ function ActionButton({
 
           <DropdownMenuContent className="py-1 px-0">
             {actions.map((action, index) => (
-              <>
-                <DropdownMenuItem key={index} onClick={action.onClick}>
-                  {action.icon}
-                  {action.label}
-                </DropdownMenuItem>
+              <Fragment key={index}>
+                {action.tooltip ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuItem disabled={action.disabled ?? false}>
+                        {action.icon}
+                        {action.label}
+                      </DropdownMenuItem>
+                    </TooltipTrigger>
+                    <TooltipContent>{action.tooltip}</TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <DropdownMenuItem onClick={action.onClick}>
+                    {action.icon}
+                    {action.label}
+                  </DropdownMenuItem>
+                )}
                 {action.hasSeparator && <Separator className="my-1" />}
-              </>
+              </Fragment>
             ))}
           </DropdownMenuContent>
         </DropdownMenu>

--- a/frontend/components/base/shadcn/dropdown-menu.tsx
+++ b/frontend/components/base/shadcn/dropdown-menu.tsx
@@ -89,7 +89,7 @@ function DropdownMenuItem({
   return (
     <DropdownMenuPrimitive.Item
       className={cn(
-        'relative flex cursor-default select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
+        'relative flex cursor-default select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:cursor-default data-disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
         inset && 'pl-8',
         className,
       )}

--- a/frontend/components/base/slider/slider-occurrence-details-card.tsx
+++ b/frontend/components/base/slider/slider-occurrence-details-card.tsx
@@ -33,7 +33,7 @@ type SliderOccurrenceDetailsCardProps = {
   mother_calls?: number[];
   ad_alt?: number;
   ad_total?: number;
-  enableIGV?: boolean;
+  has_igv_files?: boolean;
 };
 
 function getFilterValue(filter: string | undefined, t: (key: string) => string): React.ReactNode {
@@ -77,7 +77,7 @@ const SliderOccurrenceDetailsCard = ({
   mother_calls,
   ad_alt,
   ad_total,
-  enableIGV = false,
+  has_igv_files = false,
 }: SliderOccurrenceDetailsCardProps) => {
   const { t } = useI18n();
   const [igvOpen, setIGVOpen] = useState<boolean>(false);
@@ -85,7 +85,7 @@ const SliderOccurrenceDetailsCard = ({
   const filterValue = getFilterValue(filter, t);
 
   let actions = undefined;
-  if (enableIGV && start && chromosome) {
+  if (has_igv_files && start && chromosome) {
     actions = (
       <IGVDialog
         open={igvOpen}
@@ -102,6 +102,18 @@ const SliderOccurrenceDetailsCard = ({
           </Button>
         )}
       />
+    );
+  } else {
+    actions = (
+      <Tooltip>
+        <TooltipTrigger>
+          <Button variant="outline" size="xs" disabled>
+            <FlipVertical2 />
+            {t('preview_sheet.occurrence_details.actions.view_in_igv')}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('variant.actions.open_in_igv_disabled_tooltip')}</TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/frontend/translations/common/en.json
+++ b/frontend/translations/common/en.json
@@ -940,6 +940,7 @@
     "actions": {
       "preview": "Preview",
       "open_in_igv": "Open in IGV ",
+      "open_in_igv_disabled_tooltip": "No alignment file available for this case",
       "ucsc": "UCSC",
       "litvar": "LitVar",
       "view_variant": "View variant"

--- a/frontend/translations/common/fr.json
+++ b/frontend/translations/common/fr.json
@@ -941,6 +941,7 @@
     "actions": {
       "preview": "Aperçu",
       "open_in_igv": "Ouvrir dans IGV ",
+      "open_in_igv_disabled_tooltip": "Aucun fichier d'alignement disponible pour ce cas",
       "ucsc": "UCSC",
       "litvar": "LitVar",
       "view_variant": "Voir variant"


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Currently, when no CRAM alignment file is available for a case, the "View in IGV" / "Ouvrir IGV" button still opens — resulting in an empty modal with no tracks. This is confusing and gives the impression something went wrong.

## 📝 Changes

<!-- List the main changes in this PR. -->

- Add tooltip on action button
- Update disabled behavior for commanditem
- Add no igv available tooltips when needed
<img width="284" height="251" alt="2026-04-28_07-08" src="https://github.com/user-attachments/assets/550c0919-12d2-44e0-9645-606376e1d389" />
<img width="326" height="227" alt="2026-04-28_07-21_1" src="https://github.com/user-attachments/assets/84e8cba9-daa7-4472-a46c-2adc0f13f799" />
<img width="346" height="315" alt="2026-04-28_07-21" src="https://github.com/user-attachments/assets/8cf515c3-e05e-4ed4-94e9-ae6b955adccc" />
<img width="728" height="445" alt="2026-04-28_07-14" src="https://github.com/user-attachments/assets/b65b356a-d8ef-4ab7-8e22-bc2a544a23a0" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1329](https://d3b.atlassian.net/browse/SJRA-1329)<!-- End JIRA Issues -->


[SJRA-1329]: https://d3b.atlassian.net/browse/SJRA-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ