### PR TITLE
feat: SJRA-1400 Adjust Cypress tests related to recent changes

### DIFF
--- a/cypress/e2e/CaseEntity/Variants/CNV/Facets/RequestValidation.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/Facets/RequestValidation.cy.ts
@@ -9,7 +9,7 @@ describe('Case Entity - Variants - CNV - Facets - Request Validation', () => {
     cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV');
   };
 
-  it('MultiSelect [SJRA-1368]', () => {
+  it('MultiSelect [SJRA-1390]', () => {
     setupTest();
     CaseEntity_Variants_Facets.cnv.validations.shouldRequestOnApply('Variant', 'variant_type');
   });

--- a/cypress/e2e/CaseEntity/Variants/SNV/SavedFilters/QueryBuilder.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/SavedFilters/QueryBuilder.cy.ts
@@ -70,7 +70,7 @@ describe('Case Entity - Variants - SNV - Saved filters - Query builder', () => {
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('share', false /*isDisable*/, false /*isDirty*/);
   });
 
-  it('Duplicate without saving [SJRA-1097]', () => {
+  it('Duplicate without saving', () => {
     setupTest();
     CaseEntity_Variants_SavedFilters.snv.actions.deleteFilter('Cypress_FA');
     CaseEntity_Variants_SavedFilters.snv.actions.deleteFilter('Cypress_F1 COPY');
@@ -86,13 +86,13 @@ describe('Case Entity - Variants - SNV - Saved filters - Query builder', () => {
     ManagerFilterModal.actions.closeManager();
 
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('plus', true /*isDisable*/, false /*isDirty*/);
-    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('save', false /*isDisable*/, false /*isDirty*/);
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('duplicate', true /*isDisable*/, false /*isDirty*/);
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('delete', true /*isDisable*/, false /*isDirty*/);
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('share', true /*isDisable*/, false /*isDirty*/);
   });
 
-  it('Duplicate and save [SJRA-1097]', () => {
+  it('Duplicate and save', () => {
     setupTest();
     CaseEntity_Variants_SavedFilters.snv.actions.deleteFilter('Cypress_FA');
     CaseEntity_Variants_SavedFilters.snv.actions.deleteFilter('Cypress_F1 COPY');
@@ -102,17 +102,17 @@ describe('Case Entity - Variants - SNV - Saved filters - Query builder', () => {
     CaseEntity_Variants_SavedFilters.snv.actions.clickSaveButton();
 
     CaseEntity_Variants_SavedFilters.snv.validations.shouldDisplayFilterName(/^Cypress_F1 COPY$/);
-    CaseEntity_Variants_SavedFilters.snv.validations.shouldDisplayInDropdown('Cypress_F1 COPY', false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldDisplayInDropdown('Cypress_F1 COPY', true /*shouldExist*/);
     CaseEntity_Variants_SavedFilters.snv.actions.openManager();
 
-    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F1 COPY', false /*shouldExist*/);
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F1 COPY', true /*shouldExist*/);
     ManagerFilterModal.actions.closeManager();
 
-    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('plus', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('plus', false /*isDisable*/, false /*isDirty*/);
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
-    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('duplicate', true /*isDisable*/, false /*isDirty*/);
-    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('delete', true /*isDisable*/, false /*isDirty*/);
-    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('share', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('duplicate', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('delete', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('share', false /*isDisable*/, false /*isDirty*/);
   });
 
   it('Delete', () => {

--- a/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
@@ -151,7 +151,7 @@ const tableColumns = [
     isSortable: true,
     isPinnable: true,
     position: 12,
-    tooltip: 'gnomAD Genome 3.1.2 (allele Frequency)',
+    tooltip: 'gnomAD Genome 3.1.2 (Allele Frequency)',
   },
   {
     id: 'freq',

--- a/cypress/pom/pages/CaseEntity_Variants_SavedFilters.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SavedFilters.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress"/>
 import { CommonSelectors } from 'pom/shared/Selectors';
 import { CommonTexts } from 'pom/shared/Texts';
+import { CaseEntity_Variants_Facets } from './CaseEntity_Variants_Facets';
 
 const generateSavedFiltersFunctions = () => {
   const actions = {
@@ -14,7 +15,7 @@ const generateSavedFiltersFunctions = () => {
      * Clicks the duplicate filter button.
      */
     clickDuplicateButton() {
-      cy.get(`${CommonSelectors.querybuilderHeader} ${CommonSelectors.duplicateIcon}`).clickAndWait({ force: true });
+      cy.get(`${CommonSelectors.querybuilderHeader} button:has(${CommonSelectors.duplicateIcon})`).clickAndWait();
     },
     /**
      * Clicks the edit filter button.
@@ -46,6 +47,12 @@ const generateSavedFiltersFunctions = () => {
      */
     createFilter(name: string) {
       actions.deleteFilter(name);
+
+      CaseEntity_Variants_Facets.snv.actions.clickSidebarSection('Variant'); // Also works for CNV
+      cy.get(CommonSelectors.facetHeader).contains('Chromosome').clickAndWait({ force: true });
+      cy.get(CommonSelectors.facetHeader).contains('Chromosome').parents(CommonSelectors.facet).find(CommonSelectors.facetCheckbox('')).eq(0).click({ force: true });
+      cy.get(CommonSelectors.facetHeader).contains('Chromosome').parents(CommonSelectors.facet).find(CommonSelectors.facetApplyButton).click({ force: true });
+
       actions.clickEditButton();
       cy.get(`${CommonSelectors.modal} ${CommonSelectors.input}`).clear();
       cy.get(`${CommonSelectors.modal} ${CommonSelectors.input}`).type(name);
@@ -56,6 +63,11 @@ const generateSavedFiltersFunctions = () => {
       cy.wait('@postSavedFilters');
 
       validations.shouldDisplayFilterName(name);
+
+      // Prevents a race condition bug that only occurs with automated tests. Allows you to obtain the correct localStorage.
+      cy.url().then(currentUrl => {
+        cy.visit(currentUrl);
+      });
     },
     /**
      * Deletes a filter.
@@ -74,6 +86,11 @@ const generateSavedFiltersFunctions = () => {
             cy.intercept('**/saved_filters{,/**}').as('deleteSavedFilters');
             cy.get(`${CommonSelectors.alert} ${CommonSelectors.destructiveButton}`).click({ force: true });
             cy.wait('@deleteSavedFilters');
+
+            // Prevents a race condition bug that only occurs with automated tests. Allows you to obtain the correct localStorage.
+            cy.url().then(currentUrl => {
+              cy.visit(currentUrl);
+            });
 
             actions.openMyFiltersDropdown();
             cy.get('body').contains(name).should('not.exist');
@@ -145,7 +162,7 @@ const generateSavedFiltersFunctions = () => {
     shouldDisplayInDropdown(name: string | RegExp, shouldExist: boolean = true) {
       const strExist = shouldExist ? 'exist' : 'not.exist';
       actions.openMyFiltersDropdown();
-      cy.get('body').contains(name).should(strExist);
+      cy.get(CommonSelectors.menuPopper).contains(name).should(strExist);
     },
     /**
      * Checks that the icon have the expected enabled/disabled and dirty states.

--- a/cypress/pom/pages/ManagerFilterModal.ts
+++ b/cypress/pom/pages/ManagerFilterModal.ts
@@ -50,7 +50,7 @@ export const ManagerFilterModal = {
      */
     shouldDisplayInManager(name: string, shouldExist: boolean = true) {
       const strExist = shouldExist ? 'exist' : 'not.exist';
-      cy.get(CommonSelectors.modal).contains(name).should(strExist);
+      cy.get(`${CommonSelectors.modal}:contains("${name}")`).should(strExist);
     },
   },
 };


### PR DESCRIPTION
# feat: SJRA-1400 Adjust Cypress tests related to recent changes

## 📌 Contexte

Mise à jour des tests Cypress pour les aligner avec les récents changements de comportement de l'application, ainsi que l'ajout de correctifs pour des problèmes de stabilité (race conditions) observés en exécution automatisée.

## 📝 Changements

- **CNV - Facets - RequestValidation** : remplacement du tag `[SJRA-1368]` par `[SJRA-1390]` sur le test `MultiSelect` (suivi d'un nouveau bug).
- **SNV - SavedFilters - QueryBuilder** :
  - Retrait du tag `[SJRA-1097]` sur les tests `Duplicate without saving` et `Duplicate and save` (bug résolu).
  - Ajustement des états attendus des icônes (`plus`, `save`, `duplicate`, `delete`, `share`) suite aux changements récents de comportement.
  - Mise à jour des assertions `shouldDisplayInDropdown` et `shouldDisplayInManager` pour refléter que le filtre dupliqué doit maintenant exister dans le dropdown et dans le gestionnaire.
- **CaseEntity_Variants_SNV_Table** : correction de la casse du tooltip `gnomAD Genome 3.1.2 (Allele Frequency)`.
- **CaseEntity_Variants_SavedFilters (POM)** :
  - `clickDuplicateButton` : sélecteur mis à jour pour cibler le bouton contenant l'icône au lieu de l'icône directement.
  - `createFilter` : ajout d'une étape qui applique un filtre sur la facette `Chromosome` avant la sauvegarde, afin de créer un filtre réellement fonctionnel.
  - `createFilter` et `deleteFilter` : ajout d'un `cy.visit(currentUrl)` après la sauvegarde/suppression pour contourner une race condition liée au `localStorage` qui ne survient qu'en exécution automatisée.
  - `shouldDisplayInDropdown` : assertion commentée temporairement (le bug n'est pas encore complètement résolu, à valider avec l'équipe de développement).
- **ManagerFilterModal (POM)** : `shouldDisplayInManager` utilise maintenant un sélecteur jQuery `:contains()` pour une vérification plus fiable.

## 🧪 Tests

- Les tests Cypress impactés ont été exécutés localement et passent avec succès.
- Suites concernées :
  - `cypress/e2e/CaseEntity/Variants/CNV/Facets/RequestValidation.cy.ts`
  - `cypress/e2e/CaseEntity/Variants/SNV/SavedFilters/QueryBuilder.cy.ts`

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1400](https://d3b.atlassian.net/browse/SJRA-1400)<!-- End JIRA Issues -->


[SJRA-1368]: https://d3b.atlassian.net/browse/SJRA-1368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SJRA-1390]: https://d3b.atlassian.net/browse/SJRA-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SJRA-1097]: https://d3b.atlassian.net/browse/SJRA-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SJRA-1400]: https://d3b.atlassian.net/browse/SJRA-1400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ