### PR TITLE
fix(slider): SJRA-1398 fix style and use empty field

### DIFF
--- a/frontend/apps/case/src/entity/variants/interpretation/transcript.tsx
+++ b/frontend/apps/case/src/entity/variants/interpretation/transcript.tsx
@@ -1,5 +1,6 @@
 import { VepImpact } from '@/api/api';
 import ConsequenceIndicator from '@/components/base/indicators/consequence-indicator';
+import EmptyField from '@/components/base/information/empty-field';
 import AnchorLink from '@/components/base/navigation/anchor-link';
 import { Separator } from '@/components/base/shadcn/separator';
 import { useI18n } from '@/components/hooks/i18n';
@@ -51,7 +52,7 @@ function InterpretationTranscript({
             {symbol}
           </AnchorLink>
         ) : (
-          '-'
+          <EmptyField />
         )}
       </span>
       {picked_consequences?.[0] && vep_impact ? (
@@ -60,7 +61,7 @@ function InterpretationTranscript({
           {aa_change && ` - ${aa_change}`}
         </div>
       ) : (
-        '-'
+        <EmptyField />
       )}
       <Separator className="h-5" orientation="vertical" />
       {transcript_id && (
@@ -76,7 +77,7 @@ function InterpretationTranscript({
       <div className="text-sm">
         <span className="text-muted-foreground">
           {t('variant.interpretation_form.transcript.exon')}:{' '}
-          {exon_rank && exon_total ? `${exon_rank} / ${exon_total}` : '-'}
+          {exon_rank && exon_total ? `${exon_rank} / ${exon_total}` : <EmptyField />}
         </span>
       </div>
       {dna_change && (

--- a/frontend/apps/variant/src/entity/overview/most-deleterious-consequence-card.tsx
+++ b/frontend/apps/variant/src/entity/overview/most-deleterious-consequence-card.tsx
@@ -5,6 +5,7 @@ import { VariantOverview } from '@/api/api';
 import ClassificationBadge from '@/components/base/badges/classification-badge';
 import ConsequenceIndicator from '@/components/base/indicators/consequence-indicator';
 import ConditionalField from '@/components/base/information/conditional-field';
+import EmptyField from '@/components/base/information/empty-field';
 import AnchorLink from '@/components/base/navigation/anchor-link';
 import { Card, CardContent, CardProps } from '@/components/base/shadcn/card';
 import { Separator } from '@/components/base/shadcn/separator';
@@ -39,7 +40,11 @@ function MostDeleteriousConsequenceCard({ data, ...props }: { data: VariantOverv
                 </a>
               )}
               {!data.symbol &&
-                (['intergenic', 'intergenic_variant'].includes(pickedConsequence) ? t('common.no_gene') : '-')}
+                (['intergenic', 'intergenic_variant'].includes(pickedConsequence) ? (
+                  t('common.no_gene')
+                ) : (
+                  <EmptyField />
+                ))}
             </div>
             <div className="text-xs font-mono">
               <ConditionalField condition={!!data.aa_change}>{data.aa_change}</ConditionalField>

--- a/frontend/apps/variant/src/entity/transcripts/consequence-accordion-item.tsx
+++ b/frontend/apps/variant/src/entity/transcripts/consequence-accordion-item.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 import { ArrowUpRight } from 'lucide-react';
 
 import { VariantConsequence } from '@/api/api';
+import EmptyField from '@/components/base/information/empty-field';
 import { AccordionContent, AccordionItem, AccordionTrigger } from '@/components/base/shadcn/accordion';
 import { Badge } from '@/components/base/shadcn/badge';
 import { Button } from '@/components/base/shadcn/button';
@@ -29,7 +30,7 @@ function ConsequenceAccordionItem({ value, data }: ConsequenceAccordionItemProps
         <CardHeader>
           <AccordionTrigger className="hover:cursor-pointer">
             <div className="flex flex-1 ml-4 items-center gap-2">
-              <span className="font-semibold text-base">{data.symbol || '-'}</span>
+              <span className="font-semibold text-base">{data.symbol || <EmptyField />}</span>
               {/* ref: https://d3b.atlassian.net/browse/SJRA-146 */}
               {/* TODO when vep_impact is added to the api if data.is_picked == true */}
               {/* <ImpactIndicator value="HIGH" size={16} /> */}
@@ -44,25 +45,25 @@ function ConsequenceAccordionItem({ value, data }: ConsequenceAccordionItemProps
             <div className="flex flex-1">
               <Badge variant="neutral" className="capitalize">
                 {t(`variant.biotype`, {
-                  defaultValue: data.biotype ? replaceUnderscore(data.biotype) : '-',
+                  defaultValue: data.biotype ? replaceUnderscore(data.biotype) : <EmptyField />,
                 })}
               </Badge>
             </div>
             <div className="flex flex-1 justify-end items-center gap-4 text-sm">
               <div className="flex items-center gap-2">
                 <span className="text-muted-foreground">{t('variant.predictions.pli')}:</span>
-                <span>{data?.gnomad_pli?.toExponential(2) ?? '-'}</span>
+                <span>{data?.gnomad_pli?.toExponential(2) ?? <EmptyField />}</span>
               </div>
               <Separator orientation="vertical" className="h-4" />
               <div className="flex items-center gap-2">
                 <span className="text-muted-foreground">{t('variant.predictions.loeuf')}:</span>
-                <span>{data.gnomad_loeuf || '-'}</span>
+                <span>{data.gnomad_loeuf || <EmptyField />}</span>
               </div>
               <Separator orientation="vertical" className="h-4" />
               <div className="flex items-center gap-2">
                 <span className="text-muted-foreground">{t('variant.predictions.splice_ai')}:</span>
                 <div className="flex items-center gap-2">
-                  <span>{data?.spliceai_ds ? data.spliceai_ds : '-'}</span>
+                  <span>{data?.spliceai_ds ? data.spliceai_ds : <EmptyField />}</span>
                   {data?.spliceai_type?.length && (
                     <div className="space-x-1">
                       {data.spliceai_type.map(type => (

--- a/frontend/apps/variant/src/entity/transcripts/transcript-details.tsx
+++ b/frontend/apps/variant/src/entity/transcripts/transcript-details.tsx
@@ -2,6 +2,7 @@ import { TFunction } from 'i18next';
 
 import { Transcript } from '@/api/api';
 import ConsequenceIndicator from '@/components/base/indicators/consequence-indicator';
+import EmptyField from '@/components/base/information/empty-field';
 import ExpandableList from '@/components/base/list/expandable-list';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/shadcn/tooltip';
 import TranscriptIdLink from '@/components/base/variant/transcript-id-link';
@@ -26,7 +27,9 @@ function TranscriptDetails({ data }: TranscriptDetailsProps) {
           />
         )}
         <div className="flex flex-col gap-2 text-muted-foreground text-xs font-mono">
-          <span>Exon: {data.exon_rank && data.exon_total ? `${data.exon_rank} / ${data.exon_total}` : '-'}</span>
+          <span>
+            Exon: {data.exon_rank && data.exon_total ? `${data.exon_rank} / ${data.exon_total}` : <EmptyField />}
+          </span>
           {data.dna_change && <span>{data.dna_change}</span>}
           <div>
             <Tooltip>
@@ -57,7 +60,7 @@ function TranscriptDetails({ data }: TranscriptDetailsProps) {
             {data.phyloP17way_primate}
           </>
         ) : (
-          '-'
+          <EmptyField />
         )}
       </div>
     </div>

--- a/frontend/components/base/data-table/cells/zygosity-cell.tsx
+++ b/frontend/components/base/data-table/cells/zygosity-cell.tsx
@@ -12,7 +12,7 @@ function ZygosityCell({ value }: ZygosityCellProps) {
       {{
         HEM: '1',
         HET: '0/1',
-      }[value] ?? '-'}
+      }[value] ?? <EmptyCell />}
     </span>
   );
 }

--- a/frontend/components/base/occurrence/classification-section.tsx
+++ b/frontend/components/base/occurrence/classification-section.tsx
@@ -1,6 +1,8 @@
 import ClassificationBadge from '@/components/base/badges/classification-badge';
 import { useI18n } from '@/components/hooks/i18n';
 
+import EmptyField from '../information/empty-field';
+
 import DetailSection, { DetailItem } from './detail-section';
 
 export type ClassificationSectionProps = {
@@ -20,7 +22,7 @@ export default function ClassificationSection({ clinvar }: ClassificationSection
     <DetailSection title={t('occurrence_expand.classifications.title')}>
       <DetailItem
         title={t('occurrence_expand.classifications.clinvar')}
-        value={badges?.length ? <div className="flex items-center gap-1">{badges}</div> : '-'}
+        value={badges?.length ? <div className="flex items-center gap-1">{badges}</div> : <EmptyField />}
       />
     </DetailSection>
   );

--- a/frontend/components/base/occurrence/clinical-association-section.tsx
+++ b/frontend/components/base/occurrence/clinical-association-section.tsx
@@ -7,6 +7,8 @@ import AnchorLink from '@/components/base/navigation/anchor-link';
 import { Badge } from '@/components/base/shadcn/badge';
 import { useI18n } from '@/components/hooks/i18n';
 
+import EmptyField from '../information/empty-field';
+
 import DetailSection, { DetailItem } from './detail-section';
 
 export type ClinicalAssociationSectionProps = {
@@ -53,7 +55,11 @@ export default function ClinicalAssociationSection({ omim_conditions, locus_id }
           )
         }
         value={
-          oc.inheritance_code ? <div className="flex items-center gap-1">{omimCode(oc.inheritance_code)}</div> : '-'
+          oc.inheritance_code ? (
+            <div className="flex items-center gap-1">{omimCode(oc.inheritance_code)}</div>
+          ) : (
+            <EmptyField />
+          )
         }
         colon={false}
       />,

--- a/frontend/components/base/occurrence/gene-section.tsx
+++ b/frontend/components/base/occurrence/gene-section.tsx
@@ -61,7 +61,7 @@ export default function GeneSection({
           )
         }
       />
-      <DetailItem title={t('occurrence_expand.gene.revel')} value={revel_score ?? '-'} />
+      <DetailItem title={t('occurrence_expand.gene.revel')} value={revel_score ?? <EmptyField />} />
       <DetailItem
         title={t('occurrence_expand.gene.splice_ai')}
         value={

--- a/frontend/components/base/occurrence/germline-frequency-section.tsx
+++ b/frontend/components/base/occurrence/germline-frequency-section.tsx
@@ -6,6 +6,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/shadc
 import { useI18n } from '@/components/hooks/i18n';
 import { toExponentialNotation } from '@/components/lib/number-format';
 
+import EmptyField from '../information/empty-field';
+
 import DetailSection, { DetailItem } from './detail-section';
 
 export type GermlineFrequencySectionProps = {
@@ -31,9 +33,11 @@ export default function GermlineFrequencySection({
 }: GermlineFrequencySectionProps) {
   const { t } = useI18n();
   const affectedValue =
-    germline_pc_wgs_affected && germline_pn_wgs_affected && germline_pf_wgs_affected?.toExponential(2)
-      ? `${germline_pc_wgs_affected} / ${germline_pn_wgs_affected} (${germline_pf_wgs_affected?.toExponential(2)})`
-      : '-';
+    germline_pc_wgs_affected && germline_pn_wgs_affected && germline_pf_wgs_affected?.toExponential(2) ? (
+      `${germline_pc_wgs_affected} / ${germline_pn_wgs_affected} (${germline_pf_wgs_affected?.toExponential(2)})`
+    ) : (
+      <EmptyField />
+    );
   const affectedTitle = (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -47,9 +51,11 @@ export default function GermlineFrequencySection({
   );
 
   const nonAffectedValue =
-    germline_pc_wgs_not_affected && germline_pn_wgs_not_affected && germline_pf_wgs_not_affected?.toExponential(2)
-      ? `${germline_pc_wgs_not_affected} / ${germline_pn_wgs_not_affected} (${germline_pf_wgs_not_affected?.toExponential(2)})`
-      : '-';
+    germline_pc_wgs_not_affected && germline_pn_wgs_not_affected && germline_pf_wgs_not_affected?.toExponential(2) ? (
+      `${germline_pc_wgs_not_affected} / ${germline_pn_wgs_not_affected} (${germline_pf_wgs_not_affected?.toExponential(2)})`
+    ) : (
+      <EmptyField />
+    );
   const nonAffectedTitle = (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -78,7 +84,7 @@ export default function GermlineFrequencySection({
               {toExponentialNotation(gnomad_v3_af)}
             </AnchorLink>
           ) : (
-            '-'
+            <EmptyField />
           )
         }
       />

--- a/frontend/components/base/occurrence/prediction-section.tsx
+++ b/frontend/components/base/occurrence/prediction-section.tsx
@@ -3,6 +3,8 @@ import { getClassificationCriteriaColor } from '@/components/base/classification
 import { Badge } from '@/components/base/shadcn/badge';
 import { useI18n } from '@/components/hooks/i18n';
 
+import EmptyField from '../information/empty-field';
+
 import DetailSection, { DetailItem } from './detail-section';
 
 export type PredictionSectionProps = {
@@ -32,14 +34,14 @@ export default function PredictionSection({
           ))}
       </div>
     ) : (
-      '-'
+      <EmptyField />
     );
 
   return (
     <DetailSection title={t('occurrence_expand.predictions.title')}>
       <DetailItem
         title={t('occurrence_expand.predictions.exomiser')}
-        value={exomiser_acmg_classification ? <div>{exomiser}</div> : '-'}
+        value={exomiser_acmg_classification ? <div>{exomiser}</div> : <EmptyField />}
       />
     </DetailSection>
   );

--- a/frontend/components/base/occurrence/zygosity-section.tsx
+++ b/frontend/components/base/occurrence/zygosity-section.tsx
@@ -1,6 +1,8 @@
 import { useI18n } from '@/components/hooks/i18n';
 import { replaceUnderscore, titleCase } from '@/components/lib/string-format';
 
+import EmptyField from '../information/empty-field';
+
 import DetailSection, { DetailItem } from './detail-section';
 
 export type ZygositySectionProps = {
@@ -12,9 +14,9 @@ export type ZygositySectionProps = {
 export default function ZygositySection({ zygosity, transmission, parental_origin }: ZygositySectionProps) {
   const { t } = useI18n();
 
-  const zygosityValue = zygosity ? zygosity : '-';
-  const inheritance = transmission ? titleCase(replaceUnderscore(transmission)) : '-';
-  const parentalOrigin = parental_origin ? titleCase(replaceUnderscore(parental_origin)) : '-';
+  const zygosityValue = zygosity ? zygosity : <EmptyField />;
+  const inheritance = transmission ? titleCase(replaceUnderscore(transmission)) : <EmptyField />;
+  const parentalOrigin = parental_origin ? titleCase(replaceUnderscore(parental_origin)) : <EmptyField />;
 
   return (
     <DetailSection title={t('occurrence_expand.zygosity.title')}>

--- a/frontend/components/base/sequencing/sequencing-information-dialog.tsx
+++ b/frontend/components/base/sequencing/sequencing-information-dialog.tsx
@@ -20,6 +20,8 @@ import { Separator } from '@/components/base/shadcn/separator';
 import { useI18n } from '@/components/hooks/i18n';
 import { sequencingApi } from '@/utils/api';
 
+import EmptyField from '../information/empty-field';
+
 type SequencingInput = {
   seqId: string;
 };
@@ -148,7 +150,7 @@ function SequencingInformationsDialog({ open, seqId, onClose }: SequencingInform
           <Separator className="block my-8 md:hidden" />
           <div className="flex flex-col gap-2 flex-1">
             <h2 className="text-sm font-semibold">
-              {t('case_entity.details.sample')} {data?.sample_id ?? '-'}
+              {t('case_entity.details.sample')} {data?.sample_id ?? <EmptyField />}
             </h2>
 
             {/* Type */}

--- a/frontend/components/base/slider/slider-case-details-card.tsx
+++ b/frontend/components/base/slider/slider-case-details-card.tsx
@@ -9,6 +9,8 @@ import { Badge } from '@/components/base/shadcn/badge';
 import { Button } from '@/components/base/shadcn/button';
 import { useI18n } from '@/components/hooks/i18n';
 
+import EmptyField from '../information/empty-field';
+
 import SliderCard from './slider-card';
 
 const PHENOTYPES_VISIBLE_COUNT = 6;
@@ -63,7 +65,7 @@ function FamilyMemberCard({ member }: { member: CasePatientClinicalInformation }
               {t(`common.sex.${member.sex_code}`)}
             </Badge>
             <span className="font-mono">26/12/2018</span>
-            <span>{member.ethnicity_codes ? member.ethnicity_codes.join('/') : '-'}</span>
+            <span>{member.ethnicity_codes ? member.ethnicity_codes.join('/') : <EmptyField />}</span>
           </div>
         </div>
         {isProband && (

--- a/frontend/components/base/slider/slider-occurrence-details-card.tsx
+++ b/frontend/components/base/slider/slider-occurrence-details-card.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { useState } from 'react';
 import { FlipVertical2, Triangle, Users } from 'lucide-react';
 
@@ -201,15 +202,17 @@ const SliderOccurrenceDetailsCard = ({
             <div className="flex flex-col gap-4 grow max-w-full sm:max-w-72 min-w-56">
               <DescriptionSection title="Metrics" values={[ad_alt, ad_total, genotype_quality, filter]}>
                 <DescriptionRow label={t('preview_sheet.occurrence_details.sections.metrics.quality_depth')}>
-                  <span className="font-mono">
-                    {quality_depth ? thousandNumberFormat(quality_depth) : <EmptyField />}
-                  </span>
+                  {quality_depth ? (
+                    <span className="font-mono">{thousandNumberFormat(quality_depth)}</span>
+                  ) : (
+                    <EmptyField />
+                  )}
                 </DescriptionRow>
                 <DescriptionRow label={t('preview_sheet.occurrence_details.sections.metrics.allele_depth_alt')}>
-                  <span className="font-mono">{ad_alt ? thousandNumberFormat(ad_alt) : <EmptyField />}</span>
+                  {ad_alt ? <span className="font-mono">{thousandNumberFormat(ad_alt)}</span> : <EmptyField />}
                 </DescriptionRow>
                 <DescriptionRow label={t('preview_sheet.occurrence_details.sections.metrics.total_depth_alt_ref')}>
-                  <span className="font-mono">{ad_total ? thousandNumberFormat(ad_total) : <EmptyField />}</span>
+                  {ad_total ? <span className="font-mono">{thousandNumberFormat(ad_total)}</span> : <EmptyField />}
                 </DescriptionRow>
                 {/* Optional display */}
                 {genotype_quality && (


### PR DESCRIPTION
# Fix (slider): Use empty field and fix style

## 📌 Context

Standardize the hyphen for empty values.

## 📝 Changes

- use empty field or cell instead of hardcoded dash

## 🧪 Tests

<img width="653" height="265" alt="Capture d’écran, le 2026-04-28 à 10 01 28" src="https://github.com/user-attachments/assets/b23764ac-bf6f-4ebd-8a75-5946ed06f987" />

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1398](https://d3b.atlassian.net/browse/SJRA-1398)<!-- End JIRA Issues -->

[SJRA-1398]: https://d3b.atlassian.net/browse/SJRA-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ