### PR TITLE
feat(variants): SJRA-1396 display full name of functional scores

### DIFF
--- a/frontend/components/base/query-builder-v3/facets/multiselect-facet.tsx
+++ b/frontend/components/base/query-builder-v3/facets/multiselect-facet.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable complexity */
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { TFunction } from 'i18next';
 import isEqual from 'lodash/isEqual';
 import { SearchIcon } from 'lucide-react';
 
@@ -43,23 +42,6 @@ type MultiSelectAggregation = {
   count: number;
   label: string;
 };
-
-/**
- * Add label to aggregations
- */
-export function getAggregatesWithLabel(
-  aggregations: Aggregation[],
-  t: TFunction<string, undefined>,
-  sanitize: Function,
-  lazyTranslate: Function,
-) {
-  return aggregations.map(aggregation => ({
-    ...aggregation,
-    label: t(`common.filters.values.${aggregation.key}.${sanitize(aggregation.key)}`, {
-      defaultValue: lazyTranslate(aggregation.key),
-    }),
-  }));
-}
 
 /**
  * Handle search through aggregates
@@ -133,7 +115,7 @@ export function MultiSelectFacet({ field, maxVisibleItems = 5 }: MultiFacetProps
   const aggregates = useMemo(() => {
     const multiAggregates = (apiAggregates ?? []).map((aggregate: Aggregation) => ({
       ...aggregate,
-      label: t(`common.filters.values.${aggregate.key}.${sanitize(aggregate.key)}`, {
+      label: t(`common.filters.values.${field.key}.${sanitize(aggregate.key)}`, {
         defaultValue: lazyTranslate(aggregate.key),
       }),
     })) as MultiSelectAggregation[];

--- a/frontend/components/base/slider/slider-variant-details-card.tsx
+++ b/frontend/components/base/slider/slider-variant-details-card.tsx
@@ -421,7 +421,7 @@ const PredictionCard = ({
     );
   }
 
-  // functional scrore
+  // functional scores
   const functionalScores = [];
 
   // cadd phred
@@ -453,7 +453,7 @@ const PredictionCard = ({
   if (lrt_score) {
     functionalScores.push(
       <DescriptionRow label={t('occurrence_expand.functional_scores.lrt')}>
-        {lrt_pred}
+        {t(`common.filters.values.lrt_pred.${lrt_pred?.toLowerCase()}`) || lrt_pred}
         {lrt_score && ` (${lrt_score})`}
       </DescriptionRow>,
     );
@@ -463,7 +463,7 @@ const PredictionCard = ({
   if (sift_pred) {
     functionalScores.push(
       <DescriptionRow label={t('occurrence_expand.functional_scores.sift')}>
-        {sift_pred}
+        {t(`common.filters.values.sift_pred.${sift_pred?.toLowerCase()}`) || sift_pred}
         {sift_score && ` (${sift_score})`}
       </DescriptionRow>,
     );
@@ -473,7 +473,7 @@ const PredictionCard = ({
   if (fathmm_pred) {
     functionalScores.push(
       <DescriptionRow label={t('occurrence_expand.functional_scores.fathmm')}>
-        {fathmm_pred}
+        {t(`common.filters.values.fathmm_pred.${fathmm_pred?.toLowerCase()}`) || fathmm_pred}
         {fathmm_score && ` (${fathmm_score})`}
       </DescriptionRow>,
     );
@@ -490,7 +490,7 @@ const PredictionCard = ({
   if (polyphen2_hvar_pred) {
     functionalScores.push(
       <DescriptionRow label={t('occurrence_expand.functional_scores.polyphen2_hvar')}>
-        {polyphen2_hvar_pred}
+        {t(`common.filters.values.polyphen2_hvar_pred.${polyphen2_hvar_pred?.toLowerCase()}`) || polyphen2_hvar_pred}
         {polyphen2_hvar_score && ` (${polyphen2_hvar_score})`}
       </DescriptionRow>,
     );

--- a/frontend/translations/common/en.json
+++ b/frontend/translations/common/en.json
@@ -595,22 +595,22 @@
           "uncertain_significance": "Uncertain Significance"
         },
         "fathmm_pred": {
-          "T": "Tolerated",
-          "D": "Damaging"
+          "t": "Tolerated",
+          "d": "Damaging"
         },
         "lrt_pred": {
-          "N": "Neutral",
-          "D": "Deleterious",
-          "U": "Unknown"
+          "n": "Neutral",
+          "d": "Deleterious",
+          "u": "Unknown"
         },
         "polyphen2_hvar_pred": {
-          "B": "Benign",
-          "D": "Damaging",
-          "P": "Possibly Damaging"
+          "b": "Benign",
+          "d": "Damaging",
+          "p": "Possibly Damaging"
         },
         "sift_pred": {
-          "T": "Tolerated",
-          "D": "Damaging"
+          "t": "Tolerated",
+          "d": "Damaging"
         },
         "transmission_mode": {
           "autosomal_dominant": "Autosomal Dominant",

--- a/frontend/translations/common/fr.json
+++ b/frontend/translations/common/fr.json
@@ -596,22 +596,22 @@
           "uncertain_significance": "Signification incertaine"
         },
         "fathmm_pred": {
-          "T": "Toléré",
-          "D": "Délétère"
+          "t": "Toléré",
+          "d": "Délétère"
         },
         "lrt_pred": {
-          "N": "Neutre",
-          "D": "Délétère",
-          "U": "Inconnu"
+          "n": "Neutre",
+          "d": "Délétère",
+          "u": "Inconnu"
         },
         "polyphen2_hvar_pred": {
-          "B": "Bénin",
-          "D": "Délétère",
-          "P": "Potentiellement délétère"
+          "b": "Bénin",
+          "d": "Délétère",
+          "p": "Potentiellement délétère"
         },
         "sift_pred": {
-          "T": "Toléré",
-          "D": "Délétère"
+          "t": "Toléré",
+          "d": "Délétère"
         },
         "transmission_mode": {
           "autosomal_dominant": "Dominant autosomique",


### PR DESCRIPTION
# Feat (variants): display full name of functional scores

## 📌 Context

Replace acronym by full word.

## 📝 Changes

- In variants tabs, facet values displays full name
- In variant slider, functional scores displays full name

## 🧪 Tests

### Facets (somatic and germline)

<img width="260" height="707" alt="Capture d’écran, le 2026-04-28 à 15 16 18" src="https://github.com/user-attachments/assets/458f4df8-220a-41b1-becb-ebfbe6c08889" />

<img width="260" height="229" alt="Capture d’écran, le 2026-04-28 à 15 16 36" src="https://github.com/user-attachments/assets/a01a83ec-8eb3-4750-84c6-9b3edc9a47f3" />

### Sliders somatic

<img width="263" height="253" alt="Capture d’écran, le 2026-04-28 à 15 23 50" src="https://github.com/user-attachments/assets/e644a344-f0b1-498a-9e15-73f56e5bb93e" />
<img width="263" height="253" alt="Capture d’écran, le 2026-04-28 à 15 23 35" src="https://github.com/user-attachments/assets/0c6055a5-2b35-42e1-9f40-cd5797d547bf" />

### Sliders germline

<img width="263" height="253" alt="Capture d’écran, le 2026-04-28 à 15 26 01" src="https://github.com/user-attachments/assets/98b0f99b-5d4c-4b04-a0b6-b4a6cd8d1d64" />
<img width="263" height="253" alt="Capture d’écran, le 2026-04-28 à 15 25 34" src="https://github.com/user-attachments/assets/7c58cb37-17a8-4d77-b0a9-288069df7835" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1396](https://d3b.atlassian.net/browse/SJRA-1396)<!-- End JIRA Issues -->

[SJRA-1396]: https://d3b.atlassian.net/browse/SJRA-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ