### PR TITLE
fix(prediction): SJRA-1408 fix translation

### DIFF
--- a/frontend/apps/variant/src/entity/overview/prediction-scores-card.tsx
+++ b/frontend/apps/variant/src/entity/overview/prediction-scores-card.tsx
@@ -38,7 +38,7 @@ const getPredictionList = (data: VariantOverview, t: TFunction<string, undefined
 
   // sift
   if (data.sift_pred && data.sift_score !== undefined) {
-    const siftPref = t(`common.filters.values.sift_pred.${data.sift_pred}`);
+    const siftPref = t(`common.filters.values.sift_pred.${data.sift_pred.toLowerCase()}`);
     predictions.push({
       key: 'sift',
       label: t('variant.predictions.sift'),
@@ -92,7 +92,7 @@ const getPredictionList = (data: VariantOverview, t: TFunction<string, undefined
 
   // fathmm
   if (data.fathmm_pred && data.fathmm_score !== undefined) {
-    const fatmmPref = t(`common.filters.values.fathmm_pred.${data.fathmm_pred}`);
+    const fatmmPref = t(`common.filters.values.fathmm_pred.${data.fathmm_pred.toLowerCase()}`);
     predictions.push({
       key: 'fathmm',
       label: t('variant.predictions.fathmm'),
@@ -149,7 +149,7 @@ const getPredictionList = (data: VariantOverview, t: TFunction<string, undefined
 
   // lrt
   if (data?.lrt_pred && data.lrt_score !== undefined) {
-    const lrtPred = t(`common.filters.values.lrt_pred.${data.lrt_pred}`);
+    const lrtPred = t(`common.filters.values.lrt_pred.${data.lrt_pred.toLowerCase()}`);
     predictions.push({
       key: 'lrt',
       label: t('variant.predictions.lrt'),
@@ -164,7 +164,7 @@ const getPredictionList = (data: VariantOverview, t: TFunction<string, undefined
 
   // polyphen2_hvar
   if (data.polyphen2_hvar_pred && data.polyphen2_hvar_score !== undefined) {
-    const hvarPred = t(`common.filters.values.polyphen2_hvar_pred.${data.polyphen2_hvar_pred}`);
+    const hvarPred = t(`common.filters.values.polyphen2_hvar_pred.${data.polyphen2_hvar_pred.toLowerCase()}`);
     predictions.push({
       key: 'polyphen2_hvar',
       label: t('variant.predictions.polyphen2hvar'),

--- a/frontend/apps/variant/src/entity/transcripts/transcript-details.tsx
+++ b/frontend/apps/variant/src/entity/transcripts/transcript-details.tsx
@@ -73,7 +73,7 @@ const getPredictionList = (data: Transcript, t: TFunction<string, undefined>) =>
 
   // sift
   if (data.sift_pred && data.sift_score !== undefined) {
-    const siftPref = t(`common.filters.values.sift_pred.${data.sift_pred}`);
+    const siftPref = t(`common.filters.values.sift_pred.${data.sift_pred.toLowerCase()}`);
     predictions.push({
       key: 'sift',
       label: t('variant.predictions.sift'),
@@ -88,7 +88,7 @@ const getPredictionList = (data: Transcript, t: TFunction<string, undefined>) =>
 
   // fathmm
   if (data.fathmm_pred && data.fathmm_score !== undefined) {
-    const fatmmPref = t(`common.filters.values.fathmm_pred.${data.fathmm_pred}`);
+    const fatmmPref = t(`common.filters.values.fathmm_pred.${data.fathmm_pred.toLowerCase()}`);
     predictions.push({
       key: 'fathmm',
       label: t('variant.predictions.fathmm'),
@@ -145,7 +145,7 @@ const getPredictionList = (data: Transcript, t: TFunction<string, undefined>) =>
 
   // lrt
   if (data?.lrt_pred && data.lrt_score !== undefined) {
-    const lrtPred = t(`common.filters.values.lrt_pred.${data.lrt_pred}`);
+    const lrtPred = t(`common.filters.values.lrt_pred.${data.lrt_pred.toLowerCase()}`);
     predictions.push({
       key: 'lrt',
       label: t('variant.predictions.lrt'),
@@ -174,7 +174,7 @@ const getPredictionList = (data: Transcript, t: TFunction<string, undefined>) =>
 
   // polyphen2_hvar
   if (data.polyphen2_hvar_pred && data.polyphen2_hvar_score !== undefined) {
-    const hvarPred = t(`common.filters.values.polyphen2_hvar_pred.${data.polyphen2_hvar_pred}`);
+    const hvarPred = t(`common.filters.values.polyphen2_hvar_pred.${data.polyphen2_hvar_pred.toLowerCase()}`);
     predictions.push({
       key: 'polyphen2_hvar',
       label: t('variant.predictions.polyphen2hvar'),


### PR DESCRIPTION
# Fix (variant): fix prediction scores translation

## 📌 Context

After update translation for facet, we lost translation in other places.

## 📝 Changes

- lower case all values like facet render do

## 🧪 Tests

### Variant entity: transcript tab
<img width="284" height="223" alt="Capture d’écran, le 2026-04-29 à 12 17 49" src="https://github.com/user-attachments/assets/d786f702-1969-42de-a5b0-5bb8ee9f0f57" />

### Variant entity: overview tab
<img width="493" height="223" alt="Capture d’écran, le 2026-04-29 à 12 16 40" src="https://github.com/user-attachments/assets/46d586e8-0aa3-4f27-91a0-8edd6410a69f" />
<img width="462" height="452" alt="Capture d’écran, le 2026-04-29 à 12 16 31" src="https://github.com/user-attachments/assets/ca3b105b-9aae-4ec7-bacf-a7fa7d9d1adc" />

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

<!-- End JIRA Issues -->