### PR TITLE
feat(tooltip): SJRA-1417 add delay duration

### DIFF
--- a/frontend/components/.storybook/preview.tsx
+++ b/frontend/components/.storybook/preview.tsx
@@ -95,7 +95,7 @@ const preview: Preview = {
     Story => (
       <I18nextProvider i18n={i18n}>
         <ThemeProvider>
-          <TooltipProvider delayDuration={0}>
+          <TooltipProvider>
             <AlertDialogProvider>
               <Story />
             </AlertDialogProvider>

--- a/frontend/components/base/shadcn/sidebar.tsx
+++ b/frontend/components/base/shadcn/sidebar.tsx
@@ -113,7 +113,7 @@ function SidebarProvider({
 
   return (
     <SidebarContext.Provider value={contextValue}>
-      <TooltipProvider delayDuration={0}>
+      <TooltipProvider>
         <div
           style={
             {

--- a/frontend/components/base/shadcn/tooltip.tsx
+++ b/frontend/components/base/shadcn/tooltip.tsx
@@ -3,7 +3,7 @@ import { Tooltip as TooltipPrimitive } from 'radix-ui';
 
 import { cn } from '@/lib/utils';
 
-function TooltipProvider({ delayDuration = 0, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+function TooltipProvider({ delayDuration = 600, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return <TooltipPrimitive.Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />;
 }
 

--- a/frontend/portals/radiant/app/root.tsx
+++ b/frontend/portals/radiant/app/root.tsx
@@ -85,7 +85,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <I18nProvider initialLanguage={loaderData?.language}>
           <ConfigProvider config={__PROJECT__}>
             <ThemeProvider>
-              <TooltipProvider delayDuration={0}>
+              <TooltipProvider>
                 <AlertDialogProvider>
                   <BetaFeatureProvider>{children}</BetaFeatureProvider>
                 </AlertDialogProvider>


### PR DESCRIPTION
# Feat (tooltip): add delay duration

## 📌 Context

Sometimes when hovering over icons, especially in the variants table, the tooltips hide the buttons in the rows above.

## 📝 Changes

- Add delay duration on tooltip component

## 🧪 Tests

https://github.com/user-attachments/assets/942ec75f-90dc-4a56-b755-b40ace8e4acd

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1417](https://d3b.atlassian.net/browse/SJRA-1417)<!-- End JIRA Issues -->

[SJRA-1417]: https://d3b.atlassian.net/browse/SJRA-1417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ