### PR TITLE
docs(frontend): SJRA-0000 add component selection order

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -121,6 +121,14 @@ npx shadcn@latest add accordion
 ```
 They land in `components/base/shadcn/` (lowercase folder names). Never re-run the CLI on an existing component — modify it directly instead.
 
+### Component Selection Order
+
+When suggesting UI components, follow this priority:
+
+1. **Storybook stories** (`frontend/`) — check here first; these reflect our actual design system
+2. **Existing wrappers** in `frontend/components/` — a wrapper may exist even without a story
+3. **shadcn/ui primitives** — last resort; flag explicitly when falling back here so gaps in the design system stay visible; always apply our design tokens and Tailwind config, never shadcn defaults
+
 ## Conventions
 
 - **Files/folders**: kebab-case everywhere (`user-profile.tsx`, `all-profiles/`)


### PR DESCRIPTION
# docs(frontend): SJRA-0000 add component selection order
## 📌 Context

Establishes a clear hierarchy for AI-assisted component suggestions to ensure our internal design system is respected as much as possible.

## 📝 Changes

- Prioritizes our internal design system (Storybook stories, then existing wrappers in `frontend/components/`) over raw shadcn/ui primitives
- Requires explicit flagging when falling back to shadcn primitives, so design system gaps stay visible rather than silently accumulating
- Reinforces that our design tokens and Tailwind config always govern styling, regardless of which component layer is used

## ☑️ TO-DOs

- [ ] N/A

## 🧪 Tests

- N/A — documentation-only change

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- 