### PR TITLE
fix(link): SJRA-1416 fix all tab links

### DIFF
--- a/frontend/apps/variant/src/entity/overview/most-deleterious-consequence-card.tsx
+++ b/frontend/apps/variant/src/entity/overview/most-deleterious-consequence-card.tsx
@@ -87,7 +87,10 @@ function MostDeleteriousConsequenceCard({ data, ...props }: { data: VariantOverv
             </div>
             <div className="font-semibold font-mono">
               <ConditionalField condition={!!data?.germline_pc_wgs}>
-                <Link to={`/variants/entity/${params.locusId}#${VariantEntityTabs.Cases}`} className="hover:underline">
+                <Link
+                  to={`/variants/entity/${params.locusId}?tab=${VariantEntityTabs.Cases}`}
+                  className="hover:underline"
+                >
                   {`${data.germline_pc_wgs} (${data.germline_pf_wgs.toExponential(2)})`}
                 </Link>
               </ConditionalField>

--- a/frontend/components/base/occurrence/clinical-association-section.tsx
+++ b/frontend/components/base/occurrence/clinical-association-section.tsx
@@ -31,7 +31,7 @@ export default function ClinicalAssociationSection({ omim_conditions, locus_id }
       clinicalAssociationValue.push(
         <AnchorLink
           component={Link}
-          to={`/variants/entity/${locus_id}#evidenceAndConditions`}
+          to={`/variants/entity/${locus_id}?tab=evidenceAndConditions`}
           className="justify-start"
           size="sm"
         >

--- a/frontend/components/base/slider/slider-variant-details-card.tsx
+++ b/frontend/components/base/slider/slider-variant-details-card.tsx
@@ -213,7 +213,7 @@ const ClinicalAssociationCard = ({ omim_conditions, locus_id }: ClinicalAssociat
       clinicalAssociationValue.push(
         <AnchorLink
           component={Link}
-          to={`/variants/entity/${locus_id}#evidenceAndConditions`}
+          to={`/variants/entity/${locus_id}?tab=evidenceAndConditions`}
           className="justify-start"
           size="sm"
         >


### PR DESCRIPTION
# Fix (link): Fix all tab link in the portal

## 📌 Context

The same behaviour should be verified for any other hash-based tab navigation on the variant entity page

## 📝 Changes

- Patient link in variant overview tab
- Clinical association see more in occurence slider / variant details
- Clinical association see more in interpretation dialog

## 🧪 Tests

https://github.com/user-attachments/assets/928ae994-cbfa-4802-8e46-3bbb6153b2ed

https://github.com/user-attachments/assets/0164a57d-98cf-472e-b8d6-f4b1598b4c43

https://github.com/user-attachments/assets/ba13a28c-9a46-42e6-a547-d4e694b1e40b

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1416](https://d3b.atlassian.net/browse/SJRA-1416)<!-- End JIRA Issues -->

[SJRA-1416]: https://d3b.atlassian.net/browse/SJRA-1416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ