### PR TITLE
fix(interpretation): SJRA-1424 scientific notation for pli and loeuf

### DIFF
--- a/frontend/apps/case/tsconfig.app.json
+++ b/frontend/apps/case/tsconfig.app.json
@@ -3,6 +3,7 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",
+    "rootDir": "../..",
     "esModuleInterop": true,
     "types": ["react", "react-dom"],
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",

--- a/frontend/components/base/occurrence/gene-section.tsx
+++ b/frontend/components/base/occurrence/gene-section.tsx
@@ -1,7 +1,7 @@
 import AnchorLink from '@/components/base/navigation/anchor-link';
 import { Badge } from '@/components/base/shadcn/badge';
 import { useI18n } from '@/components/hooks/i18n';
-import { toExponentialNotationAtThreshold } from '@/components/lib/number-format';
+import { toExponentialNotation } from '@/components/lib/number-format';
 
 import EmptyField from '../information/empty-field';
 
@@ -38,7 +38,7 @@ export default function GeneSection({
               target="_blank"
               size="sm"
             >
-              {toExponentialNotationAtThreshold(gnomad_pli)}
+              {toExponentialNotation(gnomad_pli)}
             </AnchorLink>
           ) : (
             <EmptyField />
@@ -54,7 +54,7 @@ export default function GeneSection({
               target="_blank"
               size="sm"
             >
-              {toExponentialNotationAtThreshold(gnomad_loeuf)}
+              {toExponentialNotation(gnomad_loeuf)}
             </AnchorLink>
           ) : (
             <EmptyField />


### PR DESCRIPTION
# Fix (interpretation): scientific notation for pli and loeuf

## 📌 Context

pLI with scientific notation

## 📝 Changes

- Fix format display for pLI and loeuf values

## 🧪 Tests

### Somatic

<img width="392" height="162" alt="Capture d’écran, le 2026-05-06 à 10 32 57" src="https://github.com/user-attachments/assets/691faac8-6699-47c8-814c-bde00a5d5fc5" />

### Germline

<img width="392" height="162" alt="Capture d’écran, le 2026-05-06 à 10 33 28" src="https://github.com/user-attachments/assets/4a812cb9-88d9-4344-a496-feb7a0f46be7" />

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1424](https://d3b.atlassian.net/browse/SJRA-1424)<!-- End JIRA Issues -->

[SJRA-1424]: https://d3b.atlassian.net/browse/SJRA-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ