### PR TITLE
fix(variant): SJRA-1415 add clinvar link in evidence tab

### DIFF
--- a/frontend/apps/variant/src/entity/evidence/clinVar-card.tsx
+++ b/frontend/apps/variant/src/entity/evidence/clinVar-card.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router';
 import { ExternalLink, Search } from 'lucide-react';
 import useSWR from 'swr';
 
-import { ApiError, ClinvarRCV } from '@/api/api';
+import { ApiError, ClinvarVariantConditions } from '@/api/api';
 import DataTable from '@/components/base/data-table/data-table';
 import { Button } from '@/components/base/shadcn/button';
 import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/base/shadcn/card';
@@ -28,7 +28,7 @@ function ClinVarCard() {
   const params = useParams<{ locusId: string }>();
   const [search, setSearch] = useState('');
 
-  const { data, isLoading } = useSWR<ClinvarRCV[], ApiError, ClinVarConditionsSearchInput>(
+  const { data, isLoading } = useSWR<ClinvarVariantConditions, ApiError, ClinVarConditionsSearchInput>(
     {
       key: 'interpreted-cases',
       locusId: params.locusId!,
@@ -41,7 +41,7 @@ function ClinVarCard() {
   );
 
   const filteredData =
-    data?.filter(item => {
+    data?.conditions?.filter(item => {
       if (!search.trim()) return true;
 
       const traits = item.traits || [];
@@ -54,13 +54,12 @@ function ClinVarCard() {
         <CardTitle className="text-xl font-semibold">{t('variant_entity.evidence.clin_var.title')}</CardTitle>
         <CardDescription>{t('variant_entity.evidence.clin_var.description')}</CardDescription>
         <CardAction>
-          {/* TODO update with clinvar id of variant after back fix */}
-          {data?.[0]?.clinvar_id && (
+          {data?.clinvar_id && (
             <Button
               variant="outline"
               onClick={() => {
                 window.open(
-                  `https://www.ncbi.nlm.nih.gov/clinvar/variation/${data?.[0]?.clinvar_id}`,
+                  `https://www.ncbi.nlm.nih.gov/clinvar/variation/${data?.clinvar_id}`,
                   '_blank',
                   'noopener,noreferrer',
                 );

--- a/frontend/apps/variant/src/entity/evidence/clinVar-card.tsx
+++ b/frontend/apps/variant/src/entity/evidence/clinVar-card.tsx
@@ -54,9 +54,21 @@ function ClinVarCard() {
         <CardTitle className="text-xl font-semibold">{t('variant_entity.evidence.clin_var.title')}</CardTitle>
         <CardDescription>{t('variant_entity.evidence.clin_var.description')}</CardDescription>
         <CardAction>
-          <Button variant="outline">
-            ClinVar <ExternalLink />
-          </Button>
+          {/* TODO update with clinvar id of variant after back fix */}
+          {data?.[0]?.clinvar_id && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                window.open(
+                  `https://www.ncbi.nlm.nih.gov/clinvar/variation/${data?.[0]?.clinvar_id}`,
+                  '_blank',
+                  'noopener,noreferrer',
+                );
+              }}
+            >
+              {t('variant_entity.overview.clin_var')} <ExternalLink />
+            </Button>
+          )}
         </CardAction>
       </CardHeader>
       <CardContent className="space-y-4">


### PR DESCRIPTION
# Fix (variant): add clinvar link in evidence tab

## 📌 Context

ClinVar button un Evidence tab is not working.

## 📝 Changes

- Implement clinvar button
- manage display if variant has a clinvar id or not

## 🧪 Tests

#### If variant has a global clinvar id 
https://github.com/user-attachments/assets/e1fa2c2a-30b5-4595-8cbc-c0d04463a8b1

#### If variant has not a global clinvar id
<img width="1717" height="552" alt="Capture d’écran, le 2026-05-06 à 15 09 59" src="https://github.com/user-attachments/assets/8c93a90d-e85c-48cc-b40f-478907b9de81" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1415](https://d3b.atlassian.net/browse/SJRA-1415)<!-- End JIRA Issues -->


[SJRA-1415]: https://d3b.atlassian.net/browse/SJRA-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ