### PR TITLE
feat: SJRA-1410 Add `buccal_swab` sample type

### DIFF
--- a/backend/cmd/worker/integration_test.go
+++ b/backend/cmd/worker/integration_test.go
@@ -869,7 +869,7 @@ func Test_ProcessBatch_Sample_All_Codes(t *testing.T) {
 			},
 			{
 				Code:    "SAMPLE-006",
-				Message: "Invalid field type_code for sample (CCMG / ABCD1). Reason: \"dna!\" is not a valid type code. Valid values [blood, buffy_coat, dna, not_reported, rna, saliva, solid_tissue].",
+				Message: "Invalid field type_code for sample (CCMG / ABCD1). Reason: \"dna!\" is not a valid type code. Valid values [blood, buccal_swab, buffy_coat, dna, not_reported, rna, saliva, solid_tissue].",
 				Path:    "sample[2].type_code",
 			},
 			{

--- a/backend/scripts/init-sql/migrations/000007_add_buccal_swab_sample_type.up.sql
+++ b/backend/scripts/init-sql/migrations/000007_add_buccal_swab_sample_type.up.sql
@@ -1,0 +1,1 @@
+INSERT INTO public.sample_type (code, name_en) VALUES ('buccal_swab', 'Buccal Swab') ON CONFLICT (code) DO NOTHING;


### PR DESCRIPTION
## 📌 Context

<!-- Briefly describe the purpose of this PR. Include any relevant context. -->

We need to add a new `buccal_swab` sample type, to support case creation for some of our users.

## 📝 Changes

<!-- List the main changes in this PR. -->

- Create the migration `000007` to add the `buccal_swab` type. 

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

- Validated using the Sandbox, by respawning the Portal-API pod and querying the local Postgres via StarRocks:

```
code        |name_en     |
------------+------------+
blood       |Blood       |
solid_tissue|Solid Tissue|
dna         |DNA         |
rna         |RNA         |
saliva      |Saliva      |
not_reported|Not Reported|
buffy_coat  |Buffy Coat  |
buccal_swab |Buccal Swab |           <---- It's here
```

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- https://d3b.atlassian.net/browse/SJRA-1410
<!-- End JIRA Issues -->