### PR TITLE
feat(flag): SJRA-1206 add variant flag table

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -58,6 +58,7 @@ func setupRouter(dbStarrocks *gorm.DB, dbPostgres *gorm.DB) *gin.Engine {
 	repoIGV := repository.NewIGVRepository(dbStarrocks)
 	repoDocuments := repository.NewDocumentsRepository(dbStarrocks)
 	repoOccurrenceNotes := repository.NewOccurrenceNotesRepository(dbPostgres)
+	repoVariantFlags := repository.NewVariantFlagsRepository(dbPostgres)
 	repoSavedFilters := repository.NewSavedFiltersRepository(dbPostgres)
 	repoUserPreferences := repository.NewUserPreferencesRepository(dbPostgres)
 	repoFacets := repository.NewFacetsRepository()
@@ -73,7 +74,7 @@ func setupRouter(dbStarrocks *gorm.DB, dbPostgres *gorm.DB) *gin.Engine {
 
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     corsAllowedOrigins,
-		AllowMethods:     []string{"GET", "POST", "PUT", "OPTIONS"},
+		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Accept", "Authorization", "Content-Type"},
 		AllowCredentials: true, // Enable cookies/auth
 	}))
@@ -177,6 +178,12 @@ func setupRouter(dbStarrocks *gorm.DB, dbPostgres *gorm.DB) *gin.Engine {
 	usersGroup.GET("/sets/:user_set_id", server.GetUserSet(repoPostgres.UserSets))
 	usersGroup.GET("/preferences/:key", server.GetUserPreferencesHandler(repoUserPreferences, auth))
 	usersGroup.POST("/preferences/:key", server.UpdateUserPreferencesHandler(repoUserPreferences, auth))
+
+	variantFlagsGroup := privateRoutes.Group("/variant-flags")
+	variantFlagsGroup.PUT("/:case_id/:occurrence_id", server.PutVariantFlagHandler(repoVariantFlags, auth))
+	variantFlagsGroup.DELETE("/:case_id/:occurrence_id", server.DeleteVariantFlagHandler(repoVariantFlags))
+	variantFlagsGroup.GET("/:case_id", server.GetVariantFlagsByCaseHandler(repoVariantFlags))
+	variantFlagsGroup.GET("/:case_id/:occurrence_id", server.GetVariantFlagHandler(repoVariantFlags))
 
 	variantsGroup := privateRoutes.Group("/variants")
 	variantsGermlineGroup := variantsGroup.Group("/germline")

--- a/backend/internal/repository/germline_cnv_occurrences.go
+++ b/backend/internal/repository/germline_cnv_occurrences.go
@@ -40,6 +40,7 @@ func (r *GermlineCNVOccurrencesRepository) GetOccurrences(caseId int, seqId int,
 		return nil, fmt.Errorf("error during query preparation %w", err)
 	}
 	tx = tx.Joins("LEFT JOIN (SELECT DISTINCT occurrence_id, case_id, seq_id, task_id FROM radiant_jdbc.public.occurrence_note WHERE deleted = false) note ON note.occurrence_id = cnvo.cnv_id AND note.task_id = cnvo.task_id AND note.seq_id = ? AND note.case_id = ?", seqId, caseId)
+	tx = tx.Joins("LEFT JOIN (SELECT occurrence_id, flag_type FROM radiant_jdbc.public.variant_flag WHERE case_id = ?) flag ON flag.occurrence_id = cnvo.cnv_id", caseId)
 	if userQuery != nil && userQuery.Filters() != nil && userQuery.HasFieldFromTables(types.GenePanelsTables...) {
 		// We group by name to avoid duplicates when joining with gene panels tables
 		// and use any_value for other fields to satisfy sql requirements
@@ -57,6 +58,7 @@ func (r *GermlineCNVOccurrencesRepository) GetOccurrences(caseId int, seqId int,
 			return fmt.Sprintf("any_value(%s.%s) as %s", field.Table.Alias, field.Name, field.GetAlias())
 		})
 		columns = append(columns, "any_value(note.occurrence_id IS NOT NULL) AS has_note")
+		columns = append(columns, "any_value(flag.flag_type) AS flag_type")
 
 		tx = tx.Select(columns)
 		// We dont use AdddSort because we want to sort on aggregated fields
@@ -70,6 +72,7 @@ func (r *GermlineCNVOccurrencesRepository) GetOccurrences(caseId int, seqId int,
 			return fmt.Sprintf("%s.%s as %s", field.Table.Alias, field.Name, field.GetAlias())
 		})
 		columns = append(columns, "note.occurrence_id IS NOT NULL AS has_note")
+		columns = append(columns, "flag.flag_type")
 		tx = tx.Select(columns)
 		utils.AddSort(tx, userQuery)
 	}

--- a/backend/internal/repository/germline_cnv_occurrences_test.go
+++ b/backend/internal/repository/germline_cnv_occurrences_test.go
@@ -37,6 +37,7 @@ func Test_GermlineCNV_GetOccurrences(t *testing.T) {
 			assert.Equal(t, 1, occurrences[0].SeqID)
 			assert.Equal(t, 1, occurrences[0].TaskID)
 			assert.True(t, occurrences[0].HasNote)
+			assert.Empty(t, occurrences[0].FlagType)
 		}
 	})
 }
@@ -340,6 +341,47 @@ func Test_GermlineCNV_GetGenesOverlap(t *testing.T) {
 				assert.ElementsMatch(t, types.JsonArray[string]{"p1.1", "p1.2"}, fullCnvOverlap.Cytoband)
 
 			}
+		}
+	})
+}
+
+func Test_GermlineCNV_GetOccurrences_FlagType_Reflects_Flag_State(t *testing.T) {
+	testutils.SequentialTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+		repo := NewGermlineCNVOccurrencesRepository(starrocks)
+		flagsRepo := NewVariantFlagsRepository(postgres)
+
+		query, err := types.NewListQueryFromSqon(GermlineCnvQueryConfigForTest, allGermlineCnvFields, nil, nil, nil)
+		assert.NoError(t, err)
+
+		// Initially no flag → FlagType is empty.
+		occurrences, err := repo.GetOccurrences(2, 1, query)
+		assert.NoError(t, err)
+		if assert.Len(t, occurrences, 1) {
+			assert.Empty(t, occurrences[0].FlagType)
+		}
+
+		_, err = flagsRepo.Upsert(types.VariantFlag{
+			CaseID:       2,
+			OccurrenceID: "1",
+			FlagType:     "flag",
+			UserID:       "11111111-1111-1111-1111-111111111111",
+			UserName:     "Test User",
+		})
+		assert.NoError(t, err)
+
+		occurrences, err = repo.GetOccurrences(2, 1, query)
+		assert.NoError(t, err)
+		if assert.Len(t, occurrences, 1) {
+			assert.Equal(t, "flag", occurrences[0].FlagType)
+		}
+
+		err = flagsRepo.Delete(2, "1")
+		assert.NoError(t, err)
+
+		occurrences, err = repo.GetOccurrences(2, 1, query)
+		assert.NoError(t, err)
+		if assert.Len(t, occurrences, 1) {
+			assert.Empty(t, occurrences[0].FlagType)
 		}
 	})
 }

--- a/backend/internal/repository/germline_snv_occurrences.go
+++ b/backend/internal/repository/germline_snv_occurrences.go
@@ -52,6 +52,7 @@ func (r *GermlineSNVOccurrencesRepository) GetOccurrences(caseId int, seqId int,
 	})
 	columns = append(columns, "i.locus_id IS NOT NULL AS has_interpretation")
 	columns = append(columns, "note.occurrence_id IS NOT NULL AS has_note")
+	columns = append(columns, "flag.flag_type")
 	columns = append(columns, "v.locus")
 
 	utils.AddLimitAndSort(tx, userQuery)
@@ -67,6 +68,7 @@ func (r *GermlineSNVOccurrencesRepository) GetOccurrences(caseId int, seqId int,
 	tx = r.db.Table("(germline__snv__occurrence g_snv_o, snv__variant v)").
 		Joins("LEFT JOIN (SELECT DISTINCT locus_id, case_id, sequencing_id FROM radiant_jdbc.public.interpretation_germline) i ON i.locus_id = g_snv_o.locus_id AND i.sequencing_id = ? AND i.case_id = ?", fmt.Sprintf("%d", seqId), fmt.Sprintf("%d", caseId)).
 		Joins("LEFT JOIN (SELECT DISTINCT occurrence_id, case_id, seq_id, task_id FROM radiant_jdbc.public.occurrence_note WHERE deleted = false) note ON note.occurrence_id = g_snv_o.locus_id AND note.task_id = g_snv_o.task_id AND note.seq_id = ? AND note.case_id = ?", seqId, caseId).
+		Joins("LEFT JOIN (SELECT occurrence_id, flag_type FROM radiant_jdbc.public.variant_flag WHERE case_id = ?) flag ON flag.occurrence_id = g_snv_o.locus_id", caseId).
 		Select(columns).
 		Where("g_snv_o.seq_id = ? and part=? and v.locus_id = g_snv_o.locus_id and g_snv_o.locus_id in (?)", seqId, part, tx)
 

--- a/backend/internal/repository/germline_snv_occurrences_test.go
+++ b/backend/internal/repository/germline_snv_occurrences_test.go
@@ -45,6 +45,7 @@ func Test_Germline_SNV_GetOccurrences(t *testing.T) {
 			assert.Equal(t, "class1", occurrences[0].VariantClass)
 			assert.True(t, occurrences[0].HasInterpretation)
 			assert.True(t, occurrences[0].HasNote)
+			assert.Empty(t, occurrences[0].FlagType)
 			assert.Equal(t, "T001", occurrences[0].TranscriptId)
 		}
 	})
@@ -721,6 +722,47 @@ func Test_Germline_SNV_GetOccurrences_HasNote_False_When_Note_Is_Deleted(t *test
 		assert.NoError(t, err)
 		if assert.Len(t, occurrences, 1) {
 			assert.False(t, occurrences[0].HasNote)
+		}
+	})
+}
+
+func Test_Germline_SNV_GetOccurrences_FlagType_Reflects_Flag_State(t *testing.T) {
+	testutils.SequentialTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+		repo := NewGermlineSNVOccurrencesRepository(starrocks)
+		flagsRepo := NewVariantFlagsRepository(postgres)
+
+		query, err := types.NewListQueryFromSqon(GermlineSNVQueryConfigForTest, allGermlineSNVFields, nil, nil, nil)
+		assert.NoError(t, err)
+
+		// Initially no flag → FlagType is empty.
+		occurrences, err := repo.GetOccurrences(2, 1, query)
+		assert.NoError(t, err)
+		if assert.Len(t, occurrences, 1) {
+			assert.Empty(t, occurrences[0].FlagType)
+		}
+
+		_, err = flagsRepo.Upsert(types.VariantFlag{
+			CaseID:       2,
+			OccurrenceID: "1000",
+			FlagType:     "pin",
+			UserID:       "11111111-1111-1111-1111-111111111111",
+			UserName:     "Test User",
+		})
+		assert.NoError(t, err)
+
+		occurrences, err = repo.GetOccurrences(2, 1, query)
+		assert.NoError(t, err)
+		if assert.Len(t, occurrences, 1) {
+			assert.Equal(t, "pin", occurrences[0].FlagType)
+		}
+
+		err = flagsRepo.Delete(2, "1000")
+		assert.NoError(t, err)
+
+		occurrences, err = repo.GetOccurrences(2, 1, query)
+		assert.NoError(t, err)
+		if assert.Len(t, occurrences, 1) {
+			assert.Empty(t, occurrences[0].FlagType)
 		}
 	})
 }

--- a/backend/internal/repository/somatic_snv_occurrences.go
+++ b/backend/internal/repository/somatic_snv_occurrences.go
@@ -47,6 +47,7 @@ func (r *SomaticSNVOccurrencesRepository) GetOccurrences(caseId int, seqId int, 
 	})
 	columns = append(columns, "i.locus_id IS NOT NULL AS has_interpretation")
 	columns = append(columns, "note.occurrence_id IS NOT NULL AS has_note")
+	columns = append(columns, "flag.flag_type")
 	columns = append(columns, "v.locus")
 
 	utils.AddLimitAndSort(tx, userQuery)
@@ -62,6 +63,7 @@ func (r *SomaticSNVOccurrencesRepository) GetOccurrences(caseId int, seqId int, 
 	tx = r.db.Table("(somatic__snv__occurrence s_snv_o, snv__variant v)").
 		Joins("LEFT JOIN (SELECT DISTINCT locus_id, case_id, sequencing_id FROM radiant_jdbc.public.interpretation_somatic) i ON i.locus_id = s_snv_o.locus_id AND i.sequencing_id = ? AND i.case_id = ?", fmt.Sprintf("%d", seqId), fmt.Sprintf("%d", caseId)).
 		Joins("LEFT JOIN (SELECT DISTINCT occurrence_id, case_id, seq_id, task_id FROM radiant_jdbc.public.occurrence_note WHERE deleted = false) note ON note.occurrence_id = s_snv_o.locus_id AND note.task_id = s_snv_o.task_id AND note.seq_id = ? AND note.case_id = ?", seqId, caseId).
+		Joins("LEFT JOIN (SELECT occurrence_id, flag_type FROM radiant_jdbc.public.variant_flag WHERE case_id = ?) flag ON flag.occurrence_id = s_snv_o.locus_id", caseId).
 		Select(columns).
 		Where("s_snv_o.tumor_seq_id = ? and part=? and v.locus_id = s_snv_o.locus_id and s_snv_o.locus_id in (?)", seqId, part, tx)
 

--- a/backend/internal/repository/somatic_snv_occurrences_test.go
+++ b/backend/internal/repository/somatic_snv_occurrences_test.go
@@ -41,6 +41,7 @@ func Test_Somatic_SNV_GetOccurrences(t *testing.T) {
 			assert.Equal(t, 74, occurrences[0].TaskId)
 			assert.False(t, occurrences[0].HasInterpretation)
 			assert.True(t, occurrences[0].HasNote)
+			assert.Empty(t, occurrences[0].FlagType)
 			assert.Equal(t, "hgvsg1", occurrences[0].Hgvsg)
 			assert.Equal(t, "BRAF", occurrences[0].Symbol)
 			assert.Equal(t, "p.Arg19His", occurrences[0].AaChange)
@@ -222,5 +223,46 @@ func Test_Somatic_SNV_GetExpandedOccurrence(t *testing.T) {
 		assert.Equal(t, float64(0.001), *expandedOccurrence.GnomadV3Af)
 		assert.Equal(t, float32(0.66), *expandedOccurrence.AdRatio)
 		assert.Equal(t, "ENSG00000157764", expandedOccurrence.EnsemblGeneId)
+	})
+}
+
+func Test_Somatic_SNV_GetOccurrences_FlagType_Reflects_Flag_State(t *testing.T) {
+	testutils.SequentialTestWithPostgresAndStarrocks(t, "simple", func(t *testing.T, starrocks *gorm.DB, postgres *gorm.DB) {
+		repo := NewSomaticSNVOccurrencesRepository(starrocks)
+		flagsRepo := NewVariantFlagsRepository(postgres)
+
+		query, err := types.NewListQueryFromSqon(SomaticSNVQueryConfigForTest, allSomaticSNVFields, nil, nil, nil)
+		assert.NoError(t, err)
+
+		// Initially no flag → FlagType is empty.
+		occurrences, err := repo.GetOccurrences(70, 74, query)
+		assert.NoError(t, err)
+		if assert.Len(t, occurrences, 1) {
+			assert.Empty(t, occurrences[0].FlagType)
+		}
+
+		_, err = flagsRepo.Upsert(types.VariantFlag{
+			CaseID:       70,
+			OccurrenceID: "1000",
+			FlagType:     "star",
+			UserID:       "11111111-1111-1111-1111-111111111111",
+			UserName:     "Test User",
+		})
+		assert.NoError(t, err)
+
+		occurrences, err = repo.GetOccurrences(70, 74, query)
+		assert.NoError(t, err)
+		if assert.Len(t, occurrences, 1) {
+			assert.Equal(t, "star", occurrences[0].FlagType)
+		}
+
+		err = flagsRepo.Delete(70, "1000")
+		assert.NoError(t, err)
+
+		occurrences, err = repo.GetOccurrences(70, 74, query)
+		assert.NoError(t, err)
+		if assert.Len(t, occurrences, 1) {
+			assert.Empty(t, occurrences[0].FlagType)
+		}
 	})
 }

--- a/backend/internal/repository/variant_flags.go
+++ b/backend/internal/repository/variant_flags.go
@@ -1,0 +1,79 @@
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/radiant-network/radiant-api/internal/types"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type VariantFlagsRepository struct {
+	db *gorm.DB
+}
+
+type VariantFlagsDAO interface {
+	Upsert(flag types.VariantFlag) (*types.VariantFlag, error)
+	GetByCase(caseID int) ([]types.VariantFlag, error)
+	GetByCaseOccurrence(caseID int, occurrenceID string) (*types.VariantFlag, error)
+	Delete(caseID int, occurrenceID string) error
+}
+
+func NewVariantFlagsRepository(db *gorm.DB) *VariantFlagsRepository {
+	if db == nil {
+		log.Fatal("VariantFlagsRepository: db is nil")
+		return nil
+	}
+	return &VariantFlagsRepository{db: db}
+}
+
+// Upsert inserts a flag or updates the existing one keyed by (case_id, occurrence_id).
+func (r *VariantFlagsRepository) Upsert(flag types.VariantFlag) (*types.VariantFlag, error) {
+	flag.UpdatedAt = time.Now()
+	if err := r.db.
+		Clauses(
+			clause.OnConflict{
+				Columns:   []clause.Column{{Name: "case_id"}, {Name: "occurrence_id"}},
+				DoUpdates: clause.AssignmentColumns([]string{"flag_type", "user_id", "user_name", "updated_at"}),
+			},
+			clause.Returning{},
+		).
+		Create(&flag).Error; err != nil {
+		return nil, fmt.Errorf("error upserting variant flag: %w", err)
+	}
+	return &flag, nil
+}
+
+// GetByCase returns all flags for a case, for bulk table decoration.
+func (r *VariantFlagsRepository) GetByCase(caseID int) ([]types.VariantFlag, error) {
+	var flags []types.VariantFlag
+	if err := r.db.Where("case_id = ?", caseID).Find(&flags).Error; err != nil {
+		return nil, fmt.Errorf("error retrieving variant flags: %w", err)
+	}
+	return flags, nil
+}
+
+// GetByCaseOccurrence returns the flag for a single occurrence, or nil if not flagged.
+func (r *VariantFlagsRepository) GetByCaseOccurrence(caseID int, occurrenceID string) (*types.VariantFlag, error) {
+	var flag types.VariantFlag
+	if err := r.db.Where("case_id = ? AND occurrence_id = ?", caseID, occurrenceID).First(&flag).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("error retrieving variant flag: %w", err)
+		}
+		return nil, nil
+	}
+	return &flag, nil
+}
+
+// Delete removes the flag for a single occurrence. Idempotent: no error if the row does not exist.
+func (r *VariantFlagsRepository) Delete(caseID int, occurrenceID string) error {
+	if err := r.db.
+		Where("case_id = ? AND occurrence_id = ?", caseID, occurrenceID).
+		Delete(&types.VariantFlag{}).Error; err != nil {
+		return fmt.Errorf("error deleting variant flag: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/repository/variant_flags_test.go
+++ b/backend/internal/repository/variant_flags_test.go
@@ -1,0 +1,172 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/radiant-network/radiant-api/internal/types"
+	"github.com/radiant-network/radiant-api/test/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testUserID   = "11111111-1111-1111-1111-111111111111"
+	testUserName = "John Doe"
+)
+
+func Test_UpsertVariantFlag_Insert(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+		repo := NewVariantFlagsRepository(env.Postgres)
+		flag := types.VariantFlag{
+			CaseID:       1,
+			OccurrenceID: "upsert-insert-occ",
+			FlagType:     "flag",
+			UserID:       testUserID,
+			UserName:     testUserName,
+		}
+
+		saved, err := repo.Upsert(flag)
+
+		assert.NoError(t, err)
+		if assert.NotNil(t, saved) {
+			assert.Equal(t, 1, saved.CaseID)
+			assert.Equal(t, "upsert-insert-occ", saved.OccurrenceID)
+			assert.Equal(t, "flag", saved.FlagType)
+			assert.Equal(t, testUserID, saved.UserID)
+			assert.Equal(t, testUserName, saved.UserName)
+			assert.NotZero(t, saved.CreatedAt)
+			assert.NotZero(t, saved.UpdatedAt)
+		}
+	})
+}
+
+func Test_UpsertVariantFlag_Update(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+		repo := NewVariantFlagsRepository(env.Postgres)
+		occurrenceID := "upsert-update-occ"
+
+		first, err := repo.Upsert(types.VariantFlag{
+			CaseID: 1, OccurrenceID: occurrenceID, FlagType: "flag",
+			UserID: testUserID, UserName: testUserName,
+		})
+		assert.NoError(t, err)
+
+		// A different user changes the flag type. Same (case_id, occurrence_id) → must update, not insert.
+		updated, err := repo.Upsert(types.VariantFlag{
+			CaseID: 1, OccurrenceID: occurrenceID, FlagType: "star",
+			UserID: "22222222-2222-2222-2222-222222222222", UserName: "Jane Roe",
+		})
+
+		assert.NoError(t, err)
+		if assert.NotNil(t, updated) {
+			assert.Equal(t, "star", updated.FlagType)
+			assert.Equal(t, "22222222-2222-2222-2222-222222222222", updated.UserID)
+			assert.Equal(t, "Jane Roe", updated.UserName)
+			assert.True(t, !updated.UpdatedAt.Before(first.UpdatedAt))
+		}
+
+		// Confirm exactly one row exists for this (case_id, occurrence_id).
+		all, err := repo.GetByCase(1)
+		assert.NoError(t, err)
+		matches := 0
+		for _, f := range all {
+			if f.OccurrenceID == occurrenceID {
+				matches++
+			}
+		}
+		assert.Equal(t, 1, matches)
+	})
+}
+
+func Test_GetVariantFlagByCaseOccurrence(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+		repo := NewVariantFlagsRepository(env.Postgres)
+		occurrenceID := "get-by-case-occurrence"
+
+		_, err := repo.Upsert(types.VariantFlag{
+			CaseID: 1, OccurrenceID: occurrenceID, FlagType: "pin",
+			UserID: testUserID, UserName: testUserName,
+		})
+		assert.NoError(t, err)
+
+		found, err := repo.GetByCaseOccurrence(1, occurrenceID)
+
+		assert.NoError(t, err)
+		if assert.NotNil(t, found) {
+			assert.Equal(t, 1, found.CaseID)
+			assert.Equal(t, occurrenceID, found.OccurrenceID)
+			assert.Equal(t, "pin", found.FlagType)
+		}
+	})
+}
+
+func Test_GetVariantFlagByCaseOccurrence_NotFound(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+		repo := NewVariantFlagsRepository(env.Postgres)
+
+		found, err := repo.GetByCaseOccurrence(1, "does-not-exist-occ")
+
+		assert.NoError(t, err)
+		assert.Nil(t, found)
+	})
+}
+
+func Test_GetVariantFlagsByCase(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+		repo := NewVariantFlagsRepository(env.Postgres)
+		occA := "by-case-occ-a"
+		occB := "by-case-occ-b"
+
+		_, err := repo.Upsert(types.VariantFlag{
+			CaseID: 1, OccurrenceID: occA, FlagType: "flag",
+			UserID: testUserID, UserName: testUserName,
+		})
+		assert.NoError(t, err)
+		_, err = repo.Upsert(types.VariantFlag{
+			CaseID: 1, OccurrenceID: occB, FlagType: "star",
+			UserID: testUserID, UserName: testUserName,
+		})
+		assert.NoError(t, err)
+
+		flags, err := repo.GetByCase(1)
+		assert.NoError(t, err)
+
+		// Filter to this test's occurrences so we don't see other parallel tests' rows.
+		seen := map[string]string{}
+		for _, f := range flags {
+			if f.OccurrenceID == occA || f.OccurrenceID == occB {
+				seen[f.OccurrenceID] = f.FlagType
+			}
+		}
+		assert.Equal(t, "flag", seen[occA])
+		assert.Equal(t, "star", seen[occB])
+	})
+}
+
+func Test_DeleteVariantFlag(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+		repo := NewVariantFlagsRepository(env.Postgres)
+		occurrenceID := "delete-occ"
+
+		_, err := repo.Upsert(types.VariantFlag{
+			CaseID: 1, OccurrenceID: occurrenceID, FlagType: "flag",
+			UserID: testUserID, UserName: testUserName,
+		})
+		assert.NoError(t, err)
+
+		err = repo.Delete(1, occurrenceID)
+		assert.NoError(t, err)
+
+		found, err := repo.GetByCaseOccurrence(1, occurrenceID)
+		assert.NoError(t, err)
+		assert.Nil(t, found)
+	})
+}
+
+func Test_DeleteVariantFlag_Idempotent(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+		repo := NewVariantFlagsRepository(env.Postgres)
+
+		err := repo.Delete(1, "delete-idempotent-occ")
+		assert.NoError(t, err)
+	})
+}

--- a/backend/internal/server/handlers_variant_flags.go
+++ b/backend/internal/server/handlers_variant_flags.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/radiant-network/radiant-api/internal/repository"
+	"github.com/radiant-network/radiant-api/internal/types"
+	"github.com/radiant-network/radiant-api/internal/utils"
+)
+
+// PutVariantFlagHandler
+// @Summary Set or change the flag on a variant
+// @Id putVariantFlag
+// @Description Upserts the flag for a given (case_id, occurrence_id). An occurrence has at most one flag per case.
+// @Tags variant_flags
+// @Security bearerauth
+// @Param case_id path int true "Case ID"
+// @Param occurrence_id path string true "Occurrence ID (locus_id for SNV, cnv_id for CNV)"
+// @Param message body types.SetVariantFlagInput true "Flag to set"
+// @Accept json
+// @Produce json
+// @Success 200 {object} types.VariantFlag
+// @Failure 400 {object} types.ApiError
+// @Failure 404 {object} types.ApiError
+// @Failure 500 {object} types.ApiError
+// @Router /variant-flags/{case_id}/{occurrence_id} [put]
+func PutVariantFlagHandler(repo repository.VariantFlagsDAO, auth utils.Auth) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		caseID, err := strconv.Atoi(c.Param("case_id"))
+		if err != nil {
+			HandleNotFoundError(c, "case_id")
+			return
+		}
+		occurrenceID := c.Param("occurrence_id")
+
+		var body types.SetVariantFlagInput
+		if err := c.ShouldBindJSON(&body); err != nil {
+			HandleValidationError(c, err)
+			return
+		}
+
+		userID, err := auth.RetrieveUserIdFromToken(c)
+		if err != nil {
+			HandleNotFoundError(c, "user id")
+			return
+		}
+		fullName, err := auth.RetrieveFullNameFromToken(c)
+		if err != nil {
+			HandleNotFoundError(c, "user name")
+			return
+		}
+
+		flag := types.VariantFlag{
+			CaseID:       caseID,
+			OccurrenceID: occurrenceID,
+			FlagType:     body.FlagType,
+			UserID:       *userID,
+			UserName:     *fullName,
+		}
+
+		saved, err := repo.Upsert(flag)
+		if err != nil {
+			HandleError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, saved)
+	}
+}
+
+// DeleteVariantFlagHandler
+// @Summary Clear the flag on a variant
+// @Id deleteVariantFlag
+// @Description Removes the flag for a given (case_id, occurrence_id). Idempotent: succeeds even if no flag exists.
+// @Tags variant_flags
+// @Security bearerauth
+// @Param case_id path int true "Case ID"
+// @Param occurrence_id path string true "Occurrence ID (locus_id for SNV, cnv_id for CNV)"
+// @Produce json
+// @Success 204
+// @Failure 404 {object} types.ApiError
+// @Failure 500 {object} types.ApiError
+// @Router /variant-flags/{case_id}/{occurrence_id} [delete]
+func DeleteVariantFlagHandler(repo repository.VariantFlagsDAO) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		caseID, err := strconv.Atoi(c.Param("case_id"))
+		if err != nil {
+			HandleNotFoundError(c, "case_id")
+			return
+		}
+		occurrenceID := c.Param("occurrence_id")
+
+		if err := repo.Delete(caseID, occurrenceID); err != nil {
+			HandleError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	}
+}
+
+// GetVariantFlagsByCaseHandler
+// @Summary Get all variant flags for a case
+// @Id getVariantFlagsByCase
+// @Description Returns all flags for the given case, for bulk decoration of the variant table.
+// @Tags variant_flags
+// @Security bearerauth
+// @Param case_id path int true "Case ID"
+// @Produce json
+// @Success 200 {array} types.VariantFlag
+// @Failure 404 {object} types.ApiError
+// @Failure 500 {object} types.ApiError
+// @Router /variant-flags/{case_id} [get]
+func GetVariantFlagsByCaseHandler(repo repository.VariantFlagsDAO) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		caseID, err := strconv.Atoi(c.Param("case_id"))
+		if err != nil {
+			HandleNotFoundError(c, "case_id")
+			return
+		}
+
+		flags, err := repo.GetByCase(caseID)
+		if err != nil {
+			HandleError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, flags)
+	}
+}
+
+// GetVariantFlagHandler
+// @Summary Get the flag for a single occurrence
+// @Id getVariantFlag
+// @Description Returns the flag for the given (case_id, occurrence_id), or 404 if not flagged.
+// @Tags variant_flags
+// @Security bearerauth
+// @Param case_id path int true "Case ID"
+// @Param occurrence_id path string true "Occurrence ID (locus_id for SNV, cnv_id for CNV)"
+// @Produce json
+// @Success 200 {object} types.VariantFlag
+// @Failure 404 {object} types.ApiError
+// @Failure 500 {object} types.ApiError
+// @Router /variant-flags/{case_id}/{occurrence_id} [get]
+func GetVariantFlagHandler(repo repository.VariantFlagsDAO) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		caseID, err := strconv.Atoi(c.Param("case_id"))
+		if err != nil {
+			HandleNotFoundError(c, "case_id")
+			return
+		}
+		occurrenceID := c.Param("occurrence_id")
+
+		flag, err := repo.GetByCaseOccurrence(caseID, occurrenceID)
+		if err != nil {
+			HandleError(c, err)
+			return
+		}
+		if flag == nil {
+			HandleNotFoundError(c, "variant flag")
+			return
+		}
+		c.JSON(http.StatusOK, flag)
+	}
+}

--- a/backend/internal/server/handlers_variant_flags_test.go
+++ b/backend/internal/server/handlers_variant_flags_test.go
@@ -1,0 +1,307 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/radiant-network/radiant-api/internal/types"
+	"github.com/radiant-network/radiant-api/test/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+var flagFixedTime = time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+
+type MockVariantFlagsRepository struct{}
+
+func (m *MockVariantFlagsRepository) Upsert(flag types.VariantFlag) (*types.VariantFlag, error) {
+	if flag.OccurrenceID == "trigger-upsert-error" {
+		return nil, fmt.Errorf("mock upsert error")
+	}
+	flag.CreatedAt = flagFixedTime
+	flag.UpdatedAt = flagFixedTime
+	return &flag, nil
+}
+
+func (m *MockVariantFlagsRepository) GetByCase(caseID int) ([]types.VariantFlag, error) {
+	if caseID == 99 {
+		return nil, fmt.Errorf("mock get by case error")
+	}
+	if caseID == 88 {
+		return []types.VariantFlag{}, nil
+	}
+	return []types.VariantFlag{
+		{
+			CaseID:       caseID,
+			OccurrenceID: "occ-1",
+			FlagType:     "flag",
+			UserID:       testutils.DefaultMockUserId,
+			UserName:     testutils.DefaultMockFullName,
+			CreatedAt:    flagFixedTime,
+			UpdatedAt:    flagFixedTime,
+		},
+	}, nil
+}
+
+func (m *MockVariantFlagsRepository) GetByCaseOccurrence(caseID int, occurrenceID string) (*types.VariantFlag, error) {
+	if occurrenceID == "not-found-occ" {
+		return nil, nil
+	}
+	if occurrenceID == "error-occ" {
+		return nil, fmt.Errorf("mock get by case+occurrence error")
+	}
+	return &types.VariantFlag{
+		CaseID:       caseID,
+		OccurrenceID: occurrenceID,
+		FlagType:     "pin",
+		UserID:       testutils.DefaultMockUserId,
+		UserName:     testutils.DefaultMockFullName,
+		CreatedAt:    flagFixedTime,
+		UpdatedAt:    flagFixedTime,
+	}, nil
+}
+
+func (m *MockVariantFlagsRepository) Delete(caseID int, occurrenceID string) error {
+	if occurrenceID == "error-delete-occ" {
+		return fmt.Errorf("mock delete error")
+	}
+	return nil
+}
+
+// --- PUT ----------------------------------------------------------------
+
+func Test_PutVariantFlagHandler(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	auth := &testutils.MockAuth{}
+	router := gin.Default()
+	router.PUT("/variant-flags/:case_id/:occurrence_id", PutVariantFlagHandler(repo, auth))
+
+	body := `{"flag_type": "star"}`
+	req, _ := http.NewRequest("PUT", "/variant-flags/1/occ-A", bytes.NewBuffer([]byte(body)))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `{
+		"case_id": 1,
+		"occurrence_id": "occ-A",
+		"flag_type": "star",
+		"user_id": "1",
+		"user_name": "Mock User",
+		"created_at": "2024-01-15T10:00:00Z",
+		"updated_at": "2024-01-15T10:00:00Z"
+	}`, w.Body.String())
+}
+
+func Test_PutVariantFlagHandler_InvalidCaseID(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	auth := &testutils.MockAuth{}
+	router := gin.Default()
+	router.PUT("/variant-flags/:case_id/:occurrence_id", PutVariantFlagHandler(repo, auth))
+
+	req, _ := http.NewRequest("PUT", "/variant-flags/abc/occ-A", bytes.NewBuffer([]byte(`{"flag_type": "flag"}`)))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func Test_PutVariantFlagHandler_MissingFlagType(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	auth := &testutils.MockAuth{}
+	router := gin.Default()
+	router.PUT("/variant-flags/:case_id/:occurrence_id", PutVariantFlagHandler(repo, auth))
+
+	req, _ := http.NewRequest("PUT", "/variant-flags/1/occ-A", bytes.NewBuffer([]byte(`{}`)))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func Test_PutVariantFlagHandler_InvalidFlagType(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	auth := &testutils.MockAuth{}
+	router := gin.Default()
+	router.PUT("/variant-flags/:case_id/:occurrence_id", PutVariantFlagHandler(repo, auth))
+
+	req, _ := http.NewRequest("PUT", "/variant-flags/1/occ-A", bytes.NewBuffer([]byte(`{"flag_type": "bookmark"}`)))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func Test_PutVariantFlagHandler_RepoError(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	auth := &testutils.MockAuth{}
+	router := gin.Default()
+	router.PUT("/variant-flags/:case_id/:occurrence_id", PutVariantFlagHandler(repo, auth))
+
+	req, _ := http.NewRequest("PUT", "/variant-flags/1/trigger-upsert-error", bytes.NewBuffer([]byte(`{"flag_type": "flag"}`)))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- DELETE -------------------------------------------------------------
+
+func Test_DeleteVariantFlagHandler(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.DELETE("/variant-flags/:case_id/:occurrence_id", DeleteVariantFlagHandler(repo))
+
+	req, _ := http.NewRequest("DELETE", "/variant-flags/1/occ-A", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func Test_DeleteVariantFlagHandler_InvalidCaseID(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.DELETE("/variant-flags/:case_id/:occurrence_id", DeleteVariantFlagHandler(repo))
+
+	req, _ := http.NewRequest("DELETE", "/variant-flags/abc/occ-A", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func Test_DeleteVariantFlagHandler_RepoError(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.DELETE("/variant-flags/:case_id/:occurrence_id", DeleteVariantFlagHandler(repo))
+
+	req, _ := http.NewRequest("DELETE", "/variant-flags/1/error-delete-occ", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GET (by case) ------------------------------------------------------
+
+func Test_GetVariantFlagsByCaseHandler(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.GET("/variant-flags/:case_id", GetVariantFlagsByCaseHandler(repo))
+
+	req, _ := http.NewRequest("GET", "/variant-flags/1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `[{
+		"case_id": 1,
+		"occurrence_id": "occ-1",
+		"flag_type": "flag",
+		"user_id": "1",
+		"user_name": "Mock User",
+		"created_at": "2024-01-15T10:00:00Z",
+		"updated_at": "2024-01-15T10:00:00Z"
+	}]`, w.Body.String())
+}
+
+func Test_GetVariantFlagsByCaseHandler_EmptyResult(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.GET("/variant-flags/:case_id", GetVariantFlagsByCaseHandler(repo))
+
+	req, _ := http.NewRequest("GET", "/variant-flags/88", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `[]`, w.Body.String())
+}
+
+func Test_GetVariantFlagsByCaseHandler_InvalidCaseID(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.GET("/variant-flags/:case_id", GetVariantFlagsByCaseHandler(repo))
+
+	req, _ := http.NewRequest("GET", "/variant-flags/abc", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func Test_GetVariantFlagsByCaseHandler_RepoError(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.GET("/variant-flags/:case_id", GetVariantFlagsByCaseHandler(repo))
+
+	req, _ := http.NewRequest("GET", "/variant-flags/99", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// --- GET (single) -------------------------------------------------------
+
+func Test_GetVariantFlagHandler(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.GET("/variant-flags/:case_id/:occurrence_id", GetVariantFlagHandler(repo))
+
+	req, _ := http.NewRequest("GET", "/variant-flags/1/occ-A", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `{
+		"case_id": 1,
+		"occurrence_id": "occ-A",
+		"flag_type": "pin",
+		"user_id": "1",
+		"user_name": "Mock User",
+		"created_at": "2024-01-15T10:00:00Z",
+		"updated_at": "2024-01-15T10:00:00Z"
+	}`, w.Body.String())
+}
+
+func Test_GetVariantFlagHandler_NotFound(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.GET("/variant-flags/:case_id/:occurrence_id", GetVariantFlagHandler(repo))
+
+	req, _ := http.NewRequest("GET", "/variant-flags/1/not-found-occ", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func Test_GetVariantFlagHandler_RepoError(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.GET("/variant-flags/:case_id/:occurrence_id", GetVariantFlagHandler(repo))
+
+	req, _ := http.NewRequest("GET", "/variant-flags/1/error-occ", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func Test_GetVariantFlagHandler_InvalidCaseID(t *testing.T) {
+	repo := &MockVariantFlagsRepository{}
+	router := gin.Default()
+	router.GET("/variant-flags/:case_id/:occurrence_id", GetVariantFlagHandler(repo))
+
+	req, _ := http.NewRequest("GET", "/variant-flags/abc/occ-A", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/backend/internal/types/germline_cnv_occurrence.go
+++ b/backend/internal/types/germline_cnv_occurrence.go
@@ -33,6 +33,7 @@ type GermlineCNVOccurrence struct {
 	GnomadSN   int               `json:"gnomad_sn,omitempty" gorm:"column:gnomad_sn"`
 	GnomadSF   float32           `json:"gnomad_sf,omitempty" gorm:"column:gnomad_sf"`
 	HasNote    bool              `json:"has_note" validate:"required"`
+	FlagType   string            `json:"flag_type,omitempty" enums:"flag,pin,star"`
 }
 
 var GermlineCNVOccurrenceTable = Table{

--- a/backend/internal/types/germline_snv_occurrence.go
+++ b/backend/internal/types/germline_snv_occurrence.go
@@ -34,6 +34,7 @@ type GermlineSNVOccurrence struct {
 	MaxImpactScore             int               `json:"max_impact_score" validate:"required"`
 	HasInterpretation          bool              `json:"has_interpretation" validate:"required"`
 	HasNote                    bool              `json:"has_note" validate:"required"`
+	FlagType                   string            `json:"flag_type,omitempty" enums:"flag,pin,star"`
 	ExomiserMoi                string            `json:"exomiser_moi" validate:"required"`
 	ExomiserAcmgClassification string            `json:"exomiser_acmg_classification" validate:"required"`
 	ExomiserAcmgEvidence       JsonArray[string] `gorm:"type:json" json:"exomiser_acmg_evidence" validate:"required"`

--- a/backend/internal/types/somatic_snv_occurrence.go
+++ b/backend/internal/types/somatic_snv_occurrence.go
@@ -6,6 +6,7 @@ type SomaticSNVOccurrence struct {
 	TaskId              int               `json:"task_id" validate:"required"`
 	HasInterpretation   bool              `json:"has_interpretation" validate:"required"`
 	HasNote             bool              `json:"has_note" validate:"required"`
+	FlagType            string            `json:"flag_type,omitempty" enums:"flag,pin,star"`
 	Hgvsg               string            `json:"hgvsg" validate:"required"`
 	Chromosome          string            `json:"chromosome" validate:"required"`
 	Start               int64             `json:"start" validate:"required"`

--- a/backend/internal/types/variant_flag.go
+++ b/backend/internal/types/variant_flag.go
@@ -1,0 +1,32 @@
+package types
+
+import "time"
+
+var VariantFlagTable = Table{
+	Name:           "variant_flag",
+	FederationName: "radiant_jdbc.public.variant_flag",
+	Alias:          "flag",
+}
+
+// VariantFlag is both the GORM model and the API response type.
+// An occurrence (SNV locus or CNV) has at most one flag per case
+// (composite primary key on case_id + occurrence_id).
+type VariantFlag struct {
+	CaseID       int       `gorm:"primaryKey;column:case_id"        json:"case_id"       validate:"required"`
+	OccurrenceID string    `gorm:"primaryKey;column:occurrence_id"  json:"occurrence_id" validate:"required"`
+	FlagType     string    `gorm:"column:flag_type"                 json:"flag_type"     validate:"required,oneof=flag pin star" enums:"flag,pin,star"`
+	UserID       string    `gorm:"column:user_id"                   json:"user_id"       validate:"required"`
+	UserName     string    `gorm:"column:user_name"                 json:"user_name"     validate:"required"`
+	CreatedAt    time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"    validate:"required"`
+	UpdatedAt    time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"    validate:"required"`
+}
+
+func (VariantFlag) TableName() string {
+	return VariantFlagTable.Name
+}
+
+// SetVariantFlagInput is the PUT request body for setting or changing a flag.
+// CaseID and OccurrenceID come from URL parameters; UserID and UserName from the JWT.
+type SetVariantFlagInput struct {
+	FlagType string `json:"flag_type" binding:"required,oneof=flag pin star"`
+}

--- a/backend/scripts/init-sql/insert_clinical_data.sql
+++ b/backend/scripts/init-sql/insert_clinical_data.sql
@@ -2049,6 +2049,12 @@ VALUES ('1', '1', '1000', 'T001', 'MONDO:0000001', 'LA6668-3', 'PM1', 'autosomal
        ('2', '1', '1000', 'T001', 'MONDO:0000001', 'LA26332-9', 'PS1,PM1,PP2', 'autosomal_dominant_de_novo,x_linked_dominant_de_novo', '2025-06-27 19:51:00.0')
 ON CONFLICT (sequencing_id, case_id, locus_id, transcript_id) DO NOTHING;
 
+INSERT INTO "variant_flag" (case_id, occurrence_id, flag_type, user_id, user_name)
+VALUES (1, '1000', 'flag', '11111111-1111-1111-1111-111111111111', 'Seed User'),
+       (2, '1000', 'pin',  '11111111-1111-1111-1111-111111111111', 'Seed User'),
+       (2, '1',    'star', '11111111-1111-1111-1111-111111111111', 'Seed User')
+ON CONFLICT (case_id, occurrence_id) DO NOTHING;
+
 -- Reset sequences to prevent duplicate key errors when inserting new records
 SELECT setval('document_id_seq', (SELECT MAX(id) FROM document));
 SELECT setval('organization_id_seq', (SELECT MAX(id) FROM organization));

--- a/backend/scripts/init-sql/migrations/000008_add_variant_flag.up.sql
+++ b/backend/scripts/init-sql/migrations/000008_add_variant_flag.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.variant_flag (
+    case_id       integer      NOT NULL REFERENCES public.cases(id),
+    occurrence_id text         NOT NULL,
+    flag_type     varchar(16)  NOT NULL CHECK (flag_type IN ('flag', 'pin', 'star')),
+    user_id       uuid         NOT NULL,
+    user_name     varchar(255) NOT NULL,
+    created_at    timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at    timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY (case_id, occurrence_id)
+);

--- a/backend/test/testutils/setup_postgres.go
+++ b/backend/test/testutils/setup_postgres.go
@@ -37,6 +37,7 @@ func cleanUp(gormDb *gorm.DB) {
 	db.Exec("DELETE FROM family WHERE id >= 1000")
 	db.Exec("DELETE FROM obs_categorical WHERE id >= 1000")
 	db.Exec("DELETE FROM occurrence_note where case_id != 1 AND case_id != 71")
+	db.Exec("DELETE FROM variant_flag")
 	db.Exec("DELETE FROM task WHERE id >= 1000")
 	db.Exec("DELETE FROM task_context WHERE task_id >= 1000")
 	db.Exec("DELETE FROM task_has_document WHERE task_id >= 1000")


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Variant Flags allow geneticists to visually mark variants of interest during case review. Flags are lightweight, generic markers — independent of the interpretation workflow — designed to support personal triage and team coordination without requiring a formal classification decision.

## 📝 Changes

- Add VariantFlag table
- Update Germline SNV, CNV and Somatic SNV to return the flag type
- Add CRUD endpoint
- Add test


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1206](https://d3b.atlassian.net/browse/SJRA-1206)<!-- End JIRA Issues -->

[SJRA-1206]: https://d3b.atlassian.net/browse/SJRA-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ