### PR TITLE
fix: SJRA-1494 Fix documents leak between cases sharing sequencings

### DIFF
--- a/backend/internal/repository/cases.go
+++ b/backend/internal/repository/cases.go
@@ -388,7 +388,7 @@ func (r *CasesRepository) retrieveCaseTasks(caseId int) (*[]CaseTask, error) {
 	tx = utils.JoinTaskContextWithSeqExp(tx)
 	tx = utils.JoinSeqExpWithSample(tx)
 	tx = utils.JoinSampleAndCaseHasSeqExpWithFamily(tx)
-	tx = tx.Where("(tctx.case_id = ? OR tctx.case_id IS NULL) AND chseq.case_id = ?", caseId, caseId)
+	tx = tx.Where("chseq.case_id = ?", caseId)
 	tx = tx.Select("task.id, task.task_type_code as type_code, task.created_on, task_type.name_en as type_name, group_concat(f.relationship_to_proband_code) as patients_unparsed, count(distinct spl.patient_id) as patient_count")
 	tx = tx.Group("task.id, task.task_type_code, task.created_on, task_type.name_en")
 	tx = tx.Order("task.id asc")

--- a/backend/internal/repository/cases.go
+++ b/backend/internal/repository/cases.go
@@ -99,7 +99,7 @@ func (r *CasesRepository) SearchCases(userQuery types.ListQuery) (*[]CaseResult,
 	txStg := r.db.Table(fmt.Sprintf("%s chse", types.CaseHasSequencingExperimentTable.FederationName))
 	txStg = txStg.Select("DISTINCT(chse.case_id)")
 	txStg = txStg.Where("se.ingested_at IS NOT NULL AND (se.task_type = 'radiant_germline_annotation' OR (se.task_type = 'radiant_somatic_annotation' AND se.histology_type = 'tumoral'))")
-	txStg.Joins(fmt.Sprintf("JOIN %s se ON se.seq_id = chse.sequencing_experiment_id", types.SequencingTable.Name))
+	txStg = txStg.Joins(fmt.Sprintf("JOIN %s se ON se.seq_id = chse.sequencing_experiment_id", types.SequencingTable.Name))
 
 	txMembersCount := r.db.Table(types.FamilyTable.FederationName).Select("case_id, count(distinct family_member_id) as distinct_members_count").Group("case_id")
 

--- a/backend/internal/utils/repositories.go
+++ b/backend/internal/utils/repositories.go
@@ -177,7 +177,7 @@ func JoinTaskContextWithTaskHasDoc(tx *gorm.DB) *gorm.DB {
 }
 
 func JoinTaskContextWithCaseHasSeqExp(tx *gorm.DB) *gorm.DB {
-	return tx.Joins(fmt.Sprintf("LEFT JOIN %s %s ON %s.sequencing_experiment_id=%s.sequencing_experiment_id", types.CaseHasSequencingExperimentTable.FederationName, types.CaseHasSequencingExperimentTable.Alias, types.CaseHasSequencingExperimentTable.Alias, types.TaskContextTable.Alias))
+	return tx.Joins(fmt.Sprintf("LEFT JOIN %s %s ON %s.sequencing_experiment_id=%s.sequencing_experiment_id AND (%s.case_id = %s.case_id OR %s.case_id IS NULL)", types.CaseHasSequencingExperimentTable.FederationName, types.CaseHasSequencingExperimentTable.Alias, types.CaseHasSequencingExperimentTable.Alias, types.TaskContextTable.Alias, types.CaseHasSequencingExperimentTable.Alias, types.TaskContextTable.Alias, types.TaskContextTable.Alias))
 }
 
 func JoinTaskContextWithSeqExp(tx *gorm.DB) *gorm.DB {


### PR DESCRIPTION
# fix(case-entity): SJRA-1494 Fix documents leak between cases sharing sequencings

## 📌 Context

The case documents query (POST /cases/{case_id}/documents/search) fans out task_context rows across every case that owns the sequencing, because the shared join helper JoinTaskContextWithCaseHasSeqExp matches on sequencing_experiment_id only. When two cases share a sequencing, case-scoped task documents leak from one case to the other.

## 📝 Changes

- In [JoinTaskContextWithCaseHasSeqExp](backend/internal/utils/repositories.go#L179), add a `case_id` predicate to the `LEFT JOIN ON` clause so that `task_context` rows are paired with the matching `case_has_sequencing_experiment` row for the same case (or remain unmatched when `tctx.case_id IS NULL`).
- In [retrieveCaseTasks](backend/internal/repository/cases.go#L391), simplify the `WHERE` clause to only `chseq.case_id = ?` now that the per-case scoping happens in the join.

## ☑️ TO-DOs

- [ ] Code review

## 🧪 Tests

- Manually verify on a case that shares a sequencing experiment with another case: the document list should only include documents belonging to the requested case.
- Verify that tasks with no `task_context` (i.e. `tctx.case_id IS NULL`) are still returned (and their documents as well)

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1494](https://d3b.atlassian.net/browse/SJRA-1494)<!-- End JIRA Issues -->


[SJRA-1494]: https://d3b.atlassian.net/browse/SJRA-1494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ