### PR TITLE
feat: SJRA-1506 Add validation for Plus Gene button in Cypress tests

### DIFF
--- a/cypress/e2e/CaseEntity/Variants/SNV/Table/Hyperlinks.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/SNV/Table/Hyperlinks.cy.ts
@@ -32,8 +32,10 @@ describe('Case Entity - Variants - SNV - Table - Hyperlinks', () => {
   it('Gene Plus', () => {
     setupTest();
     CaseEntity_Variants_SavedFilters.snv.actions.clickNewFilterButton(); // Clean Query Builder
+    const resultCount = CaseEntity_Variants_SNV_Table.actions.getResultsCount();
     CaseEntity_Variants_SNV_Table.actions.clickTableCellLink(data.variantGermline, 'gene', true /*onPlusIcon*/);
     CaseEntity_Variants_SNV_Table.validations.shouldHaveSelectedQueryPill(data.variantGermline, 'gene');
+    CaseEntity_Variants_SNV_Table.validations.shouldShowResultsCount(resultCount, false /*beEqual*/);
   });
 
   it('Freq.', () => {

--- a/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
@@ -259,6 +259,18 @@ export const CaseEntity_Variants_SNV_Table = {
       cy.get(selectors.toggle).clickAndWait({ force: true });
     },
     /**
+     * Returns the total results count displayed in the table index result.
+     * Yields 0 when no results are displayed.
+     */
+    getResultsCount(): Cypress.Chainable<number> {
+      return cy.get(CommonSelectors.tableIndexResult).invoke('text').then(text => {
+        const ofIndex = text.toLowerCase().indexOf(' of ');
+        if (ofIndex === -1) return 0;
+        const digits = text.substring(ofIndex + 4).replace(/\D/g, '');
+        return digits ? parseInt(digits, 10) : 0;
+      });
+    },
+    /**
      * Hides a specific column in the table.
      * @param columnID The ID of the column to hide.
      */
@@ -546,6 +558,30 @@ export const CaseEntity_Variants_SNV_Table = {
       }).as('sortRequest');
       CaseEntity_Variants_SNV_Table.actions.sortColumn(columnID, false /*needIntercept*/);
       cy.wait('@sortRequest');
+    },
+    /**
+     * Checks the total results count displayed in the table index result.
+     * @param count The expected count (number or Cypress.Chainable yielding a number).
+     * @param beEqual Whether the displayed count should be equal to `count` (default: true).
+     */
+    shouldShowResultsCount(count: number | Cypress.Chainable<number>, beEqual: boolean = true) {
+      const compare = (expected: number) => {
+        cy.get(CommonSelectors.tableIndexResult).invoke('text').should(text => {
+          const ofIndex = text.toLowerCase().indexOf(' of ');
+          const digits = ofIndex === -1 ? '' : text.substring(ofIndex + 4).replace(/\D/g, '');
+          const current = digits ? parseInt(digits, 10) : 0;
+          if (beEqual) {
+            expect(current).to.eq(expected);
+          } else {
+            expect(current).to.not.eq(expected);
+          }
+        });
+      };
+      if (typeof count === 'number') {
+        compare(count);
+      } else {
+        count.then(compare);
+      }
     },
     /**
      * Validates that all columns are displayed in the correct order in the table.

--- a/cypress/pom/shared/Selectors.ts
+++ b/cypress/pom/shared/Selectors.ts
@@ -81,6 +81,7 @@ export const CommonSelectors = {
   tableCellHead: 'th',
   tableHead: (id?: string) => `table${id || ''} thead`,
   tableHeadCell: (id?: string) => `table${id || ''} thead th`,
+  tableIndexResult: '[data-cy="table-index-result"]',
   tableRow: (id?: string) => `table${id || ''} tbody tr`,
   tag: (color: string) => `[class*="bg-${color}/20 text-${color}-foreground"]`,
   tagBlank: '[class*="text-foreground"]',

--- a/frontend/components/base/data-table/data-table-index-result.tsx
+++ b/frontend/components/base/data-table/data-table-index-result.tsx
@@ -25,7 +25,7 @@ function TableIndexResult({ loading, pageIndex, pageSize, total }: TableIndexRes
   }
 
   return (
-    <span className="text-xs text-muted-foreground">
+    <span className="text-xs text-muted-foreground" data-cy="table-index-result">
       {total > 0 ? (
         <>
           {t('common.table.results')} {thousandNumberFormat(from)} - {thousandNumberFormat(to)} of{' '}


### PR DESCRIPTION
# feat: SJRA-1506 Add validation for Plus Gene button in Cypress tests

## 📌 Context

Le test Cypress « Gene Plus » de la table des variants SNV cliquait sur l'icône « plus » d'un gène et validait l'ajout de la pilule dans le Query Builder, mais ne vérifiait pas que le filtre appliqué avait un effet réel sur la table. Ce PR ajoute la validation manquante : confirmer que le nombre total de résultats affiché change après l'application du filtre. Les helpers nécessaires sont mutualisés sur le composant partagé `TableIndexResult` pour pouvoir être réutilisés par d'autres tables.

## 📝 Changes

- Ajout de l'attribut `data-cy="table-index-result"` sur le `<span>` du composant `TableIndexResult` afin d'exposer un sélecteur stable, indépendant des classes utilitaires et de la langue.
- Nouveau sélecteur partagé `CommonSelectors.tableIndexResult` (`[data-cy="table-index-result"]`).
- Nouvelle action `CaseEntity_Variants_SNV_Table.actions.getResultsCount()` qui retourne un `Cypress.Chainable<number>` correspondant au total affiché (parsing du segment situé après « of », robuste aux séparateurs de milliers EN/FR).
- Nouvelle validation `CaseEntity_Variants_SNV_Table.validations.shouldShowResultsCount(count, beEqual = true)` qui accepte un `number` ou un `Cypress.Chainable<number>` et utilise `.should()` pour bénéficier du re-try Cypress. Le paramètre `beEqual` est optionnel et vaut `true` par défaut.
- Mise à jour du test `Gene Plus` (`Hyperlinks.cy.ts`) : capture du nombre de résultats initial, puis validation qu'il diffère après le clic sur l'icône « plus » du gène (`beEqual = false`).

## 🧪 Tests

- Spec impactée : `cypress/e2e/CaseEntity/Variants/SNV/Table/Hyperlinks.cy.ts`, test `Gene Plus`.
- Exécutée localement avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1506](https://d3b.atlassian.net/browse/SJRA-1506)<!-- End JIRA Issues -->

[SJRA-1506]: https://d3b.atlassian.net/browse/SJRA-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ