### PR TITLE
fix(flag): SJRA-1514 update state on pagination

### DIFF
--- a/frontend/components/base/dropdowns/occurrence-flag-dropdown.tsx
+++ b/frontend/components/base/dropdowns/occurrence-flag-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Flag, LucideIcon, Pin, Star } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWRMutation from 'swr/mutation';
@@ -100,6 +100,11 @@ function OccurrenceFlagDropdown({
   );
   const [selectedFlag, setSelectedFlag] = useState<OccurrenceFlagType | null>(flag ?? null);
   const selectedFlagConfig = selectedFlag ? FLAGS[selectedFlag] : null;
+
+  // Prevent data-table cache to reset to previous value
+  useEffect(() => {
+    setSelectedFlag(flag ?? null);
+  }, [flag, caseId, taskId, seqId, occurrenceId]);
 
   return (
     <DropdownMenu>


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Two related flag persistence issues observed in the SNV occurrence table:

Flag lost on page navigation: Setting a flag on a variant, navigating to the next table page, then returning to the previous page causes the flag to no longer appear on the variant.

Flag incorrectly applied to wrong variant: After flagging a variant and navigating to the next table page, the flag appears on a row at the same position as the flagged row on the previous page — even though it is a different variant with a different ID.

Expected behaviour: A flag is keyed by the variant's unique ID (locus_id / occurrence_id). It must persist on that specific variant regardless of table page, and must never appear on a different variant.

## 📝 Changes

<!-- List the main changes in this PR. -->

- Data-Table has his own cache system for custom cell, explaining why flag with is inner state has using the previous value.

https://github.com/user-attachments/assets/9230f0ea-deff-4358-9105-022fb42cf2df


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1514](https://d3b.atlassian.net/browse/SJRA-1514)<!-- End JIRA Issues -->


[SJRA-1514]: https://d3b.atlassian.net/browse/SJRA-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ