### PR TITLE
fix(cursor): SJRA-1511 use default cursor on tooltip

### DIFF
--- a/frontend/components/base/shadcn/badge.tsx
+++ b/frontend/components/base/shadcn/badge.tsx
@@ -8,7 +8,7 @@ import { Separator } from './separator';
 
 const badgeVariants = tv({
   slots: {
-    base: 'inline-flex items-center rounded-md transition-colors px-1.5 py-0.5 text-xs [&_svg]:size-3 gap-1 outline-none font-medium',
+    base: 'inline-flex items-center rounded-md transition-colors px-1.5 py-0.5 text-xs [&_svg]:size-3 gap-1 outline-none font-medium cursor-default',
     closeIcon: '',
     countSeparator: '',
   },

--- a/frontend/components/base/shadcn/command.tsx
+++ b/frontend/components/base/shadcn/command.tsx
@@ -118,7 +118,7 @@ function CommandItem({ className, ...props }: React.ComponentPropsWithoutRef<typ
   return (
     <CommandPrimitive.Item
       className={cn(
-        'relative flex cursor-default gap-2 select-none items-center rounded-xs px-2 py-1 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+        'relative flex cursor-pointer gap-2 select-none items-center rounded-xs px-2 py-1 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
         className,
       )}
       {...props}

--- a/frontend/components/base/shadcn/dropdown-menu.tsx
+++ b/frontend/components/base/shadcn/dropdown-menu.tsx
@@ -29,7 +29,7 @@ function DropdownMenuSubTrigger({
   return (
     <DropdownMenuPrimitive.SubTrigger
       className={cn(
-        'flex cursor-default select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+        'flex cursor-pointer select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
         inset && 'pl-8',
         className,
       )}
@@ -89,7 +89,7 @@ function DropdownMenuItem({
   return (
     <DropdownMenuPrimitive.Item
       className={cn(
-        'relative flex cursor-default select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:cursor-default data-disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
+        'relative flex cursor-pointer select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:cursor-default data-disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
         inset && 'pl-8',
         className,
       )}
@@ -108,7 +108,7 @@ function DropdownMenuCheckboxItem({
   return (
     <DropdownMenuPrimitive.CheckboxItem
       className={cn(
-        'relative flex cursor-default select-none items-center justify-between rounded-xs py-1.5 px-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
+        'relative flex cursor-pointer select-none items-center justify-between rounded-xs py-1.5 px-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
         className,
       )}
       checked={checked}
@@ -133,7 +133,7 @@ function DropdownMenuRadioItem({
   return (
     <DropdownMenuPrimitive.RadioItem
       className={cn(
-        'relative flex cursor-default select-none items-center rounded-xs py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
+        'relative flex cursor-pointer select-none items-center rounded-xs py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
         className,
       )}
       {...props}

--- a/frontend/components/base/shadcn/select.tsx
+++ b/frontend/components/base/shadcn/select.tsx
@@ -49,7 +49,7 @@ function SelectScrollUpButton({
 }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>) {
   return (
     <SelectPrimitive.ScrollUpButton
-      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      className={cn('flex cursor-pointer items-center justify-center py-1', className)}
       {...props}
     >
       <ChevronUp className="h-4 w-4" />
@@ -64,7 +64,7 @@ function SelectScrollDownButton({
 }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>) {
   return (
     <SelectPrimitive.ScrollDownButton
-      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      className={cn('flex cursor-pointer items-center justify-center py-1', className)}
       {...props}
     >
       <ChevronDown className="h-4 w-4" />
@@ -116,7 +116,7 @@ function SelectItem({ className, children, ...props }: React.ComponentPropsWitho
   return (
     <SelectPrimitive.Item
       className={cn(
-        'relative flex w-full cursor-default select-none items-center rounded-xs py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
+        'relative flex w-full cursor-pointer select-none items-center rounded-xs py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
         className,
       )}
       onContextMenu={e => {

--- a/frontend/components/base/shadcn/tooltip.tsx
+++ b/frontend/components/base/shadcn/tooltip.tsx
@@ -11,8 +11,10 @@ function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root
   return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
-function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+function TooltipTrigger({ className, ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return (
+    <TooltipPrimitive.Trigger data-slot="tooltip-trigger" className={cn('cursor-default', className)} {...props} />
+  );
 }
 
 function TooltipContent({

--- a/frontend/themes/tailwind.base.css
+++ b/frontend/themes/tailwind.base.css
@@ -316,10 +316,6 @@
 }
 
 @layer utilities {
-  .cursor-default {
-    cursor: pointer;
-  }
-
   .max-w-8xl {
     max-width: 1440px;
   }


### PR DESCRIPTION
# Fix (cursor): Use default cursor on tooltip

## 📌 Context

Text cursor on table tooltip header instead of default cursor.

## 📝 Changes

- Apply UI rule: if no action default cursor, if action on the element pointer cursor
- Remove tailwind override default is pointer
- Use default cursor on tooltip, badge without action
- Button with tooltip keep the pointer cursor except if it's disabled
- Command, dropdown, select, checkbox use pointer cursor

## 🧪 Tests

https://github.com/user-attachments/assets/86938702-9b6e-4d6d-a1eb-c1ecb0cfdc03

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1511](https://d3b.atlassian.net/browse/SJRA-1511)<!-- End JIRA Issues -->

[SJRA-1511]: https://d3b.atlassian.net/browse/SJRA-1511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ