### PR TITLE
Fix/sjra 1515 popvoer

### DIFF
--- a/frontend/components/base/notes/notes-container.tsx
+++ b/frontend/components/base/notes/notes-container.tsx
@@ -30,6 +30,7 @@ type NoteContainerBaseProps = {
 
 export type NotesContainerProps = NoteContainerBaseProps & {
   enableEmptyIcon?: boolean;
+  enableSkeletonLoading?: boolean;
 };
 
 export type GetOccurrenceNoteInput = Omit<NotesContainerProps, 'enableEmptyIcon'>;
@@ -54,7 +55,7 @@ async function saveNote(_url: string, { arg }: { arg: CreateOccurrenceNoteInput 
  *
  * - ListFetcher refresh the table list when a note is saved or deleted to update the note's icon state
  */
-function NotesContainer({ enableEmptyIcon = false, ...props }: NotesContainerProps) {
+function NotesContainer({ enableEmptyIcon = false, enableSkeletonLoading = true, ...props }: NotesContainerProps) {
   const { t } = useI18n();
   const { sub } = useLoginContext();
   const { onChangeCallback } = useNotesContext();
@@ -128,7 +129,9 @@ function NotesContainer({ enableEmptyIcon = false, ...props }: NotesContainerPro
       </div>
       <TooltipProvider>
         <div className="flex-1 overflow-y-auto">
-          {fetcher.isLoading && new Array(3).fill(0).map((_, index) => <NoteSkeleton key={index} />)}
+          {enableSkeletonLoading &&
+            fetcher.isLoading &&
+            new Array(3).fill(0).map((_, index) => <NoteSkeleton key={index} />)}
           {enableEmptyIcon && !fetcher.isLoading && fetcher.data?.length === 0 && (
             <div className="flex flex-col items-center justify-center gap-4 py-16 px-6">
               <EmptyNoteIcon />

--- a/frontend/components/base/notes/notes-popover.tsx
+++ b/frontend/components/base/notes/notes-popover.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { MessageSquare } from 'lucide-react';
 
 import { Button } from '@/components/base/shadcn/button';
@@ -18,8 +19,15 @@ type NotesPopoverProps = NotesContainerProps & {
 function NotesPopover({ hasNotes, loading = false, ...props }: NotesPopoverProps) {
   const { t } = useI18n();
 
+  /*
+   * workaround to prevent popover for closing when deleting a comment
+   */
+  const handlePreventClosing = useCallback((e: { preventDefault: () => void }) => {
+    if (document.querySelector('[role="alertdialog"]')) e.preventDefault();
+  }, []);
+
   return (
-    <Popover modal>
+    <Popover>
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -38,8 +46,13 @@ function NotesPopover({ hasNotes, loading = false, ...props }: NotesPopoverProps
           <TooltipContent>{hasNotes ? t('notes.variant.tooltip.view') : t('notes.variant.tooltip.add')}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <PopoverContent align="start" className="w-105 p-0 gap-0 flex flex-col max-h-130">
-        <NotesContainer {...props} />
+      <PopoverContent
+        align="start"
+        className="w-105 p-0 gap-0 flex flex-col max-h-130"
+        onFocusOutside={handlePreventClosing}
+        onInteractOutside={handlePreventClosing}
+      >
+        <NotesContainer {...props} enableSkeletonLoading={false} />
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Lors de l'affichage pour la première fois des notes d'un variant, la composante s'affiche, disparaît et s'affiche ensuite correctement près de la ligne du variant. Lors du second affichage des notes du même variant, la composante s'affiche correctement au bon endroit dès le premier coup.

## 📝 Changes

- Remove skeleton loading on popover note since shadcn popover can miscompute the popover position on the first frame

https://github.com/user-attachments/assets/d4ca6ed1-c8c6-4278-88d8-630d92eab96a


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1515](https://d3b.atlassian.net/browse/SJRA-1515)<!-- End JIRA Issues -->


[SJRA-1515]: https://d3b.atlassian.net/browse/SJRA-1515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ