### PR TITLE
fix(somatic): SJRA-1405 add ad_ratio to somatic occurrence list

### DIFF
--- a/backend/cmd/api/somatic_snv_occurrences_integration_test.go
+++ b/backend/cmd/api/somatic_snv_occurrences_integration_test.go
@@ -78,14 +78,11 @@ func testSomaticSNVStatistics(t *testing.T, data string, body string, expected s
 }
 
 func Test_Somatic_SNV_List(t *testing.T) {
-	testSomaticSNVList(t, "simple", `{"additional_fields":["locus_id"]}`, `[{"aa_change":"p.Arg19His", "chromosome": "1", "clinvar":["Benign", "Pathogenic"], "end": 0, "germline_pc_wgs":3, "germline_pf_wgs":0.99, "gnomad_v3_af":0.001, "has_interpretation":false, "has_note": true, "hgvsg":"hgvsg1", "hotspot":true, "is_canonical":true, "is_mane_plus":null, "is_mane_select":true, "locus_id":"1000", "omim_inheritance_code":["code1"], "picked_consequences":["splice acceptor"], "rsnumber":"rs111111111", "seq_id":74, "somatic_pc_tn_wgs":6, "somatic_pf_tn_wgs":0.55, "start": 1111, "symbol":"BRAF", "task_id":74, "transcript_id": "T001", "variant_class":"class1", "vep_impact":"MODIFIER"}]`)
+	testSomaticSNVList(t, "simple", `{"additional_fields":["locus_id"]}`, `[{"aa_change":"p.Arg19His", "ad_ratio":0.66, "chromosome": "1", "clinvar":["Benign", "Pathogenic"], "end": 0, "germline_pc_wgs":3, "germline_pf_wgs":0.99, "gnomad_v3_af":0.001, "has_interpretation":false, "has_note": true, "hgvsg":"hgvsg1", "hotspot":true, "is_canonical":true, "is_mane_plus":null, "is_mane_select":true, "locus_id":"1000", "omim_inheritance_code":["code1"], "picked_consequences":["splice acceptor"], "rsnumber":"rs111111111", "seq_id":74, "somatic_pc_tn_wgs":6, "somatic_pf_tn_wgs":0.55, "start": 1111, "symbol":"BRAF", "task_id":74, "transcript_id": "T001", "variant_class":"class1", "vep_impact":"MODIFIER"}]`)
 }
 
 func Test_Somatic_SNV_List_Return_Filtered_Occurrences_When_Sqon_Specified(t *testing.T) {
 	body := `{
-			"additional_fields":[
-				"ad_ratio"
-			],
 			"sqon":{
 				"op":"in",
 				"content":{

--- a/backend/internal/types/somatic_snv_occurrence.go
+++ b/backend/internal/types/somatic_snv_occurrence.go
@@ -187,6 +187,7 @@ var SomaticSNVOccurrencesDefaultFields = []Field{
 	GermlinePcWgsField,
 	SomaticPfTnWgsField,
 	SomaticPcTnWgsField,
+	SomaticSNVTumorAdRatioField,
 }
 
 var SomaticSNVOccurrencesFields = append(SomaticSNVOccurrencesDefaultFields,
@@ -226,7 +227,6 @@ var SomaticSNVOccurrencesFields = append(SomaticSNVOccurrencesDefaultFields,
 	// Occurrence facets
 	SomaticSNVFilterField,
 	SomaticSNVInfoQdField,
-	SomaticSNVTumorAdRatioField,
 	SomaticSNVTumorAdAltField,
 	SomaticSNVTumorAdTotalField,
 )


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Afin de normaliser avec Germline SNV, il faut que Somatic SNV retourne aussi ad_ratio par défaut.

## 📝 Changes
- Ajout de SomaticSNVTumorAdRatioField à SomaticSNVOccurrencesDefaultFields
<img width="1237" height="848" alt="image" src="https://github.com/user-attachments/assets/b8f1e5d6-419a-4a17-9f7b-2697eb974156" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1405](https://d3b.atlassian.net/browse/SJRA-1405)<!-- End JIRA Issues -->


[SJRA-1405]: https://d3b.atlassian.net/browse/SJRA-1405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ