### PR TITLE
feat: SJRA-713 configure SSL for StarRocks connection

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -113,6 +113,7 @@ Copy `.env.template` → `.env`. Key variables:
 | Variable | Purpose | Default |
 |---|---|---|
 | `DB_HOST/PORT/NAME/USERNAME/PASSWORD` | StarRocks | localhost:9030 |
+| `DB_SSL_CA` | Path to CA bundle to enable TLS to StarRocks; unset = plaintext | — |
 | `PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD` | PostgreSQL | localhost:5432 |
 | `API_PORT` | API listen port | 8090 |
 | `KEYCLOAK_HOST/REALM/CLIENT` | Keycloak | localhost:8080 |

--- a/backend/internal/database/starrocks.go
+++ b/backend/internal/database/starrocks.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"time"
@@ -8,7 +10,7 @@ import (
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 
-	_ "github.com/go-sql-driver/mysql"
+	gomysql "github.com/go-sql-driver/mysql"
 	_ "github.com/joho/godotenv/autoload"
 )
 
@@ -20,12 +22,41 @@ var (
 	dbPassword = os.Getenv("DB_PASSWORD")
 )
 
+// registerStarrocksTLS reads the CA bundle at caPath, registers a TLS config
+// named configName with the mysql driver (verifying against serverName), and
+// returns the DSN tls param ("&tls=<configName>"). An empty caPath is a no-op
+// and returns ("", nil) — TLS stays disabled.
+func registerStarrocksTLS(caPath, configName, serverName string) (string, error) {
+	if caPath == "" {
+		return "", nil
+	}
+	pem, err := os.ReadFile(caPath)
+	if err != nil {
+		return "", fmt.Errorf("read DB_SSL_CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return "", fmt.Errorf("parse DB_SSL_CA: no certs found in %s", caPath)
+	}
+	if err := gomysql.RegisterTLSConfig(configName, &tls.Config{
+		RootCAs:    pool,
+		ServerName: serverName,
+	}); err != nil {
+		return "", fmt.Errorf("register TLS config: %w", err)
+	}
+	return "&tls=" + configName, nil
+}
+
 func NewStarrocksDB() (*gorm.DB, error) {
 	if dbHost == "" {
 		return nil, fmt.Errorf("DB_HOST is not set")
 	}
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?interpolateParams=true&parseTime=true",
-		dbUserName, dbPassword, dbHost, dbPort, dbName)
+	tlsParam, err := registerStarrocksTLS(os.Getenv("DB_SSL_CA"), "starrocks", dbHost)
+	if err != nil {
+		return nil, err
+	}
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?interpolateParams=true&parseTime=true%s",
+		dbUserName, dbPassword, dbHost, dbPort, dbName, tlsParam)
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
 	if err != nil {
 		return nil, err

--- a/backend/internal/database/starrocks_test.go
+++ b/backend/internal/database/starrocks_test.go
@@ -1,0 +1,69 @@
+package database
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestCA generates a self-signed CA certificate, writes it as PEM to a
+// file in t.TempDir(), and returns the path.
+func writeTestCA(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Unix(0, 0),
+		NotAfter:              time.Unix(1<<31-1, 0),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	return path
+}
+
+func Test_registerStarrocksTLS_EmptyPath_Disabled(t *testing.T) {
+	param, err := registerStarrocksTLS("", "starrocks-empty", "localhost")
+	assert.NoError(t, err)
+	assert.Equal(t, "", param)
+}
+
+func Test_registerStarrocksTLS_ValidCA_ReturnsParam(t *testing.T) {
+	caPath := writeTestCA(t)
+	param, err := registerStarrocksTLS(caPath, "starrocks-valid", "localhost")
+	assert.NoError(t, err)
+	assert.Equal(t, "&tls=starrocks-valid", param)
+}
+
+func Test_registerStarrocksTLS_MissingFile_Errors(t *testing.T) {
+	param, err := registerStarrocksTLS(filepath.Join(t.TempDir(), "does-not-exist.pem"), "starrocks-missing", "localhost")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read DB_SSL_CA")
+	assert.Equal(t, "", param)
+}
+
+func Test_registerStarrocksTLS_GarbagePEM_Errors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "garbage.pem")
+	require.NoError(t, os.WriteFile(path, []byte("not a pem file"), 0o600))
+	param, err := registerStarrocksTLS(path, "starrocks-garbage", "localhost")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no certs found")
+	assert.Equal(t, "", param)
+}


### PR DESCRIPTION
## 📌 Context

The StarRocks connection (`backend/internal/database/starrocks.go`) builds a MySQL-protocol DSN with no TLS — the link to the analytical DB is plaintext. To connect to a TLS-fronted StarRocks (e.g. `starrocks-qa.dev.qlin.aws.sante.quebec:9030`) we need to trust a custom CA, while keeping local dev and existing deployments working unchanged.

This mirrors the optional-knob pattern already used for Postgres (`PGSSLMODE` / `PGSSLROOTCERT`): a new **optional** `DB_SSL_CA` env var. When unset, behavior is byte-for-byte identical to today (no TLS). When set, the CA is loaded, a custom `tls.Config` is registered with the `go-sql-driver/mysql` driver, and `&tls=starrocks` is appended to the DSN.

## 📝 Changes

- **`starrocks.go`**: New `registerStarrocksTLS(caPath, configName, serverName)` helper — no-op returning `("", nil)` when `DB_SSL_CA` is unset; otherwise reads the CA bundle, builds a cert pool, registers the TLS config (with `ServerName` for SAN verification), and returns the DSN `tls` param. `NewStarrocksDB` reads `DB_SSL_CA` and appends the param to the DSN.
- Switched the `go-sql-driver/mysql` import from blank to the aliased `gomysql` (needed to call `RegisterTLSConfig`); no dependency bump — `v1.8.1` already provides it.
- **`starrocks_test.go`** (new): unit tests for the helper (no DB container required).
- **`backend/CLAUDE.md`**: documented `DB_SSL_CA` in the Configuration table.

## ☑️ TO-DOs

- [ ] Confirm the StarRocks server cert SANs include the `DB_HOST` value used in the target env (`openssl s_client -connect <host>:9030 -showcerts`).
- [ ] Set `DB_SSL_CA` in the QA/target deployment config.

## 🧪 Tests

New self-contained unit tests in `backend/internal/database/starrocks_test.go` (generate a self-signed CA in-test, no DB needed):

- `Test_registerStarrocksTLS_EmptyPath_Disabled` — unset → `("", nil)`
- `Test_registerStarrocksTLS_ValidCA_ReturnsParam` — valid CA → `&tls=...`
- `Test_registerStarrocksTLS_MissingFile_Errors` — missing file → error
- `Test_registerStarrocksTLS_GarbagePEM_Errors` — non-PEM bytes → error

```bash
cd backend
go build ./...
go test ./internal/database/ -v
```

Full backend suite (`make test`) passes — no regressions.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-713](https://d3b.atlassian.net/browse/SJRA-713)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- The knob is strictly optional and additive; default (unset) behavior is unchanged, so local dev and existing deployments are unaffected.
- `ServerName: dbHost` is required for SAN verification — the StarRocks cert SANs must include the host used in `DB_HOST`.
- The end-to-end TLS connection check against a live TLS-fronted instance is manual (outside the automated suite).
- `golang-migrate` Postgres path already handles its own SSL vars — untouched.

[SJRA-713]: https://d3b.atlassian.net/browse/SJRA-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ