### PR TITLE
feat(filters): SJRA-916 use checkbox filter in filter button

### DIFF
--- a/frontend/apps/case/src/entity/files/files-table/files-table-filters.tsx
+++ b/frontend/apps/case/src/entity/files/files-table/files-table-filters.tsx
@@ -83,6 +83,7 @@ function FilesTableFilters({ caseId, setSearchCriteria }: FilesTableFilters) {
         default:
           return {
             ...baseOption,
+            showKey: true,
             withTooltip: true,
             options: sortOptions(apiFilters[key as keyof DocumentFilters] || []),
           };

--- a/frontend/apps/case/src/exploration/table/case-exploration-table-filters.tsx
+++ b/frontend/apps/case/src/exploration/table/case-exploration-table-filters.tsx
@@ -111,6 +111,7 @@ function FiltersGroupForm({ loading = true, setSearchCriteria }: FiltersGroupFor
             popoverSize: 'lg' as PopoverSize,
             isVisible: (filters[key] && filters[key].length > 0) || changedFilterButtons.includes(key) || false,
             options: sortOptions(apiFilters[key] || []),
+            showKey: true,
             withTooltip: true,
           };
         case 'life_status_code':

--- a/frontend/apps/file-archive/src/exploration/archive/files-archive-list-table-filters.tsx
+++ b/frontend/apps/file-archive/src/exploration/archive/files-archive-list-table-filters.tsx
@@ -71,6 +71,7 @@ function FilesTableFilters({ setSearchCriteria }: FilesTableFilters) {
           return {
             ...baseOption,
             popoverSize: 'lg' as PopoverSize,
+            showKey: true,
             withTooltip: true,
             options: sortOptions(apiFilters[key] || []),
           };
@@ -94,6 +95,7 @@ function FilesTableFilters({ setSearchCriteria }: FilesTableFilters) {
         default:
           return {
             ...baseOption,
+            showKey: true,
             withTooltip: true,
           };
       }

--- a/frontend/components/base/buttons/filter-button.tsx
+++ b/frontend/components/base/buttons/filter-button.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { LucideIcon, PlusCircle, Search } from 'lucide-react';
 
+import CheckboxFilter from '@/components/base/checkboxes/checkbox-filter';
 import { Badge } from '@/components/base/shadcn/badge';
 import { Button } from '@/components/base/shadcn/button';
-import { Checkbox } from '@/components/base/shadcn/checkbox';
 import {
   Command,
   CommandEmpty,
@@ -40,6 +40,7 @@ export interface IFilterButton {
   icon?: any;
   count?: number;
   optionRenderer?: (option: IFilterButtonItem) => React.ReactNode;
+  showKey?: boolean;
   withTooltip?: boolean;
 }
 
@@ -56,7 +57,8 @@ type FilterButtonProps = {
   isOpen?: boolean;
   closeOnSelect?: boolean;
   optionRenderer?: (option: IFilterButtonItem) => React.ReactNode;
-  withTooltip?: boolean; // new prop for tooltip functionality
+  showKey?: boolean; // display the option key in front of the label ("key - label")
+  withTooltip?: boolean; // wrap each item in a hover tooltip
 };
 
 const CustomCommandItem = ({
@@ -66,6 +68,7 @@ const CustomCommandItem = ({
   setOpen,
   actionMode,
   selected,
+  showKey,
   withTooltip,
 }: {
   option: IFilterButtonItem;
@@ -74,9 +77,70 @@ const CustomCommandItem = ({
   setOpen: (open: boolean) => void;
   actionMode: boolean;
   selected: string[];
+  showKey: boolean;
   withTooltip: boolean;
 }) => {
   const IconComponent = option.icon;
+  const isSelected = selected.includes(option.key || '');
+  const labelText = typeof option.label === 'string' ? option.label : '';
+
+  // showKey renders the single-line "key - label" display (truncated, muted label).
+  const keyLabelContent = (
+    <>
+      {option.key}
+      <span className="text-muted-foreground"> - {labelText}</span>
+    </>
+  );
+
+  // withTooltip anchors the tooltip on the label itself: the trigger is an inline-block so it
+  // sizes to the text (tooltip centered on the label, not the whole row), with max-w-full +
+  // truncate for long values. Selection is driven solely by CommandItem.onSelect (keyboard +
+  // click bubbling), so onCheckedChange is omitted; onMouseDown preventDefault keeps the
+  // search input focused.
+  let label: React.ReactNode;
+  if (withTooltip) {
+    label = (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-block max-w-full truncate align-middle">
+              {showKey ? keyLabelContent : option.label}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{option.tooltip || option.label}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  } else if (showKey) {
+    label = <span className="block truncate">{keyLabelContent}</span>;
+  } else {
+    label = option.label;
+  }
+
+  const checkboxFilter = (
+    <CheckboxFilter
+      fluid
+      size="sm"
+      className="mx-2 my-1.5"
+      checked={isSelected}
+      label={label}
+      icon={IconComponent ? <IconComponent /> : undefined}
+      count={option.count}
+      onMouseDown={e => e.preventDefault()}
+    />
+  );
+
+  let content: React.ReactNode;
+  if (actionMode) {
+    content = (
+      <Button variant="ghost" className="mx-2 my-1.5 p-0 h-full w-full items-center justify-start font-normal">
+        {option.label}
+      </Button>
+    );
+  } else {
+    content = checkboxFilter;
+  }
+
   return (
     <CommandItem
       key={option.key}
@@ -88,42 +152,7 @@ const CustomCommandItem = ({
       }}
       className="p-0 overflow-hidden hover:bg-accent hover:text-accent-foreground focus:bg-transparent focus:text-foreground"
     >
-      {actionMode ? (
-        <Button variant="ghost" className="mx-2 my-1.5 p-0 h-full w-full items-center justify-start font-normal">
-          {option.label}
-        </Button>
-      ) : (
-        <div className="flex row mx-2 my-1.5 p-0 w-full gap-2 items-center overflow-hidden">
-          <Checkbox
-            className="mr-0"
-            checked={selected.includes(option.key || '')}
-            onCheckedChange={() => {
-              handleSelect(option.key || '');
-            }}
-            onMouseDown={e => {
-              e.preventDefault();
-            }}
-          />
-          <div className="flex w-full items-center gap-1 overflow-hidden min-w-0">
-            {IconComponent && <IconComponent size={20} />}
-            {withTooltip ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div className="truncate">
-                      <span className="flex-1 min-w-0">{option.key}</span>
-                      <span className="text-muted-foreground"> - {option.label}</span>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>{option.tooltip || option.label}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ) : (
-              <span className="truncate flex-1 min-w-0">{option.label}</span>
-            )}
-          </div>
-        </div>
-      )}
+      {content}
     </CommandItem>
   );
 };
@@ -147,6 +176,7 @@ export default function FilterButton({
   icon,
   isOpen: openOnAppear = false,
   closeOnSelect = false,
+  showKey = false, // defaults to false
   withTooltip = false, // defaults to false
 }: FilterButtonProps) {
   const { t } = useI18n();
@@ -235,6 +265,7 @@ export default function FilterButton({
                   setOpen={setOpen}
                   actionMode={actionMode}
                   selected={selected}
+                  showKey={showKey}
                   withTooltip={withTooltip}
                 />
               ))}
@@ -250,6 +281,7 @@ export default function FilterButton({
                   setOpen={setOpen}
                   actionMode={actionMode}
                   selected={selected}
+                  showKey={showKey}
                   withTooltip={withTooltip}
                 />
               ))}

--- a/frontend/components/base/checkboxes/checkbox-filter.tsx
+++ b/frontend/components/base/checkboxes/checkbox-filter.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/components/lib/utils';
 
 export const checkboxFilterVariants = tv({
   slots: {
-    base: 'flex gap-2 w-full max-w-[228px] cursor-pointer justify-between',
+    base: 'flex items-start gap-2 w-full max-w-[228px] cursor-pointer justify-between',
     label: 'first-letter:capitalize line-clamp-2 cursor-pointer max-w-[154px] whitespace-normal break-words',
     description: 'w-full',
     icon: '',
@@ -17,28 +17,34 @@ export const checkboxFilterVariants = tv({
     size: {
       default: {
         base: '',
-        label: 'text-xs',
+        label: 'text-xs leading-4',
         icon: '[&_svg]:size-4',
       },
       xs: {
         base: '',
-        label: 'text-xs',
+        label: 'text-xs leading-[14px]',
         icon: '[&_svg]:size-3.5',
       },
       sm: {
         base: '',
-        label: 'text-sm',
+        label: 'text-sm leading-4',
         icon: '[&_svg]:size-4',
       },
       md: {
         base: '',
-        label: 'text-md',
+        label: 'text-md leading-5',
         icon: '[&_svg]:size-4',
       },
       lg: {
         base: 'text-lg',
-        label: 'text-lg',
+        label: 'text-lg leading-6',
         icon: '[&_svg]:size-5',
+      },
+    },
+    fluid: {
+      true: {
+        base: 'max-w-none',
+        label: 'max-w-none',
       },
     },
   },
@@ -49,10 +55,11 @@ export const checkboxFilterVariants = tv({
 
 type CheckboxFilterProps = React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> &
   VariantProps<typeof checkboxVariants> & {
-    label: string;
+    label: React.ReactNode;
     icon?: React.ReactElement;
     count?: number;
     description?: string;
+    fluid?: boolean;
     'data-cy'?: string;
   };
 
@@ -63,11 +70,12 @@ function CheckboxFilter({
   icon,
   count,
   description,
+  fluid,
   'data-cy': dataCy,
   ...props
 }: CheckboxFilterProps) {
-  const styles = checkboxFilterVariants({ size });
-  const name = label.toLowerCase().replaceAll(' ', '-');
+  const styles = checkboxFilterVariants({ size, fluid });
+  const name = typeof label === 'string' ? label.toLowerCase().replaceAll(' ', '-') : undefined;
 
   return (
     <div

--- a/frontend/components/base/data-table/filters/data-table-filters.tsx
+++ b/frontend/components/base/data-table/filters/data-table-filters.tsx
@@ -294,6 +294,7 @@ function DataTableFilters({
               selected={filter.selectedItems}
               onSelect={values => handleFilterSelect(filter.key, values)}
               isOpen={filter.isOpen}
+              showKey={filter.showKey}
               withTooltip={filter.withTooltip}
             />
           ))}

--- a/frontend/components/base/shadcn/checkbox.tsx
+++ b/frontend/components/base/shadcn/checkbox.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 
 export const checkboxVariants = tv({
   slots: {
-    base: 'peer shrink-0 rounded-xs border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring shadow-sm disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-primary-foreground',
+    base: 'peer shrink-0 rounded-xs border border-primary ring-offset-background transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-1 focus-visible:outline-ring shadow-sm disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-primary-foreground',
     icon: '',
   },
   variants: {

--- a/frontend/components/stories/buttons/filter-button.stories.tsx
+++ b/frontend/components/stories/buttons/filter-button.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Calendar, Database, FileText, Filter, Settings, Users } from 'lucide-react';
 
 import FilterButton, { IFilterButtonItem, PopoverSize } from '@/components/base/buttons/filter-button';
+import PriorityIndicator, { PriorityIndicatorCode } from '@/components/base/indicators/priority-indicator';
 
 const meta: Meta<typeof FilterButton> = {
   title: 'Buttons/Filter Button',
@@ -62,6 +63,38 @@ const longTextOptions: IFilterButtonItem[] = [
     count: 34,
     icon: Settings,
   },
+];
+
+// Mock data for a standard checkbox list with a per-item icon
+const iconOptions: IFilterButtonItem[] = [
+  { key: 'users', label: 'Users', count: 42, icon: Users },
+  { key: 'database', label: 'Database', count: 28, icon: Database },
+  { key: 'files', label: 'Files', count: 15, icon: FileText },
+  { key: 'calendar', label: 'Calendar', count: 7, icon: Calendar },
+];
+
+// Mock data without counts
+const noCountOptions: IFilterButtonItem[] = [
+  { key: 'option1', label: 'Option 1' },
+  { key: 'option2', label: 'Option 2' },
+  { key: 'option3', label: 'Option 3' },
+];
+
+// Mock data with React node labels (e.g. a PriorityIndicator instead of a plain string)
+const priorityOptions: IFilterButtonItem[] = (['routine', 'urgent', 'asap', 'stat'] as PriorityIndicatorCode[]).map(
+  (code, index) => ({
+    key: code,
+    label: <PriorityIndicator size="sm" code={code} />,
+    count: [42, 28, 15, 7][index],
+  }),
+);
+
+// Mock data for a code-based filter (key shown in front of the label + tooltip)
+const labCodeOptions: IFilterButtonItem[] = [
+  { key: 'EXTUM', label: 'Tumoral Analysis', tooltip: 'External Tumoral Analysis', count: 234 },
+  { key: 'CHUSJ', label: 'CHU Sainte-Justine Laboratory', count: 156 },
+  { key: 'LSPQ', label: 'Laboratoire de santé publique du Québec', count: 89 },
+  { key: 'MUHC', label: 'McGill University Health Centre', count: 42 },
 ];
 
 // Mock data for action mode
@@ -127,6 +160,81 @@ export const WithLongTextAndTooltips: Story = {
   ),
 };
 
+export const WithItemIcons: Story = {
+  render: () => (
+    <div className="p-4">
+      <h3 className="mb-4 text-lg font-semibold">Checkbox list with per-item icons</h3>
+      <InteractiveFilterButton
+        label="Type"
+        options={iconOptions}
+        placeholder="Search type..."
+        icon={<Filter className="size-4" />}
+      />
+    </div>
+  ),
+};
+
+export const WithoutCounts: Story = {
+  render: () => (
+    <div className="p-4">
+      <h3 className="mb-4 text-lg font-semibold">Options without counts</h3>
+      <InteractiveFilterButton
+        label="Status"
+        options={noCountOptions}
+        placeholder="Search status..."
+        icon={<Filter className="size-4" />}
+      />
+    </div>
+  ),
+};
+
+export const WithReactNodeLabels: Story = {
+  render: () => (
+    <div className="p-4">
+      <h3 className="mb-4 text-lg font-semibold">React node labels (PriorityIndicator)</h3>
+      <InteractiveFilterButton
+        label="Priority"
+        options={priorityOptions}
+        placeholder="Search priority..."
+        icon={<Filter className="size-4" />}
+      />
+    </div>
+  ),
+};
+
+export const WithKeyOnly: Story = {
+  render: () => (
+    <div className="p-4">
+      <h3 className="mb-4 text-lg font-semibold">Key display only (no tooltip)</h3>
+      <InteractiveFilterButton
+        label="Lab"
+        options={labCodeOptions}
+        popoverSize="md"
+        placeholder="Search lab..."
+        showKey
+        icon={<Filter className="size-4" />}
+      />
+    </div>
+  ),
+};
+
+export const WithKeyAndTooltip: Story = {
+  render: () => (
+    <div className="p-4">
+      <h3 className="mb-4 text-lg font-semibold">Key display + tooltip (code-based filter)</h3>
+      <InteractiveFilterButton
+        label="Lab"
+        options={labCodeOptions}
+        popoverSize="lg"
+        placeholder="Search lab..."
+        showKey
+        withTooltip
+        icon={<Filter className="size-4" />}
+      />
+    </div>
+  ),
+};
+
 export const ActionMode: Story = {
   render: () => (
     <div className="p-4">
@@ -164,6 +272,61 @@ export const AllVariants: Story = {
           placeholder="Search conditions..."
           withTooltip={true}
           icon={<Users className="size-4" />}
+        />
+      </div>
+
+      <div>
+        <h3 className="mb-4 text-lg font-semibold">Key display only (no tooltip)</h3>
+        <InteractiveFilterButton
+          label="Lab"
+          options={labCodeOptions}
+          popoverSize="md"
+          placeholder="Search lab..."
+          showKey
+          icon={<Filter className="size-4" />}
+        />
+      </div>
+
+      <div>
+        <h3 className="mb-4 text-lg font-semibold">Key display + tooltip (code-based filter)</h3>
+        <InteractiveFilterButton
+          label="Lab"
+          options={labCodeOptions}
+          popoverSize="lg"
+          placeholder="Search lab..."
+          showKey
+          withTooltip
+          icon={<Filter className="size-4" />}
+        />
+      </div>
+
+      <div>
+        <h3 className="mb-4 text-lg font-semibold">Checkbox list with per-item icons</h3>
+        <InteractiveFilterButton
+          label="Type"
+          options={iconOptions}
+          placeholder="Search type..."
+          icon={<Filter className="size-4" />}
+        />
+      </div>
+
+      <div>
+        <h3 className="mb-4 text-lg font-semibold">Options without counts</h3>
+        <InteractiveFilterButton
+          label="Status"
+          options={noCountOptions}
+          placeholder="Search status..."
+          icon={<Filter className="size-4" />}
+        />
+      </div>
+
+      <div>
+        <h3 className="mb-4 text-lg font-semibold">React node labels (PriorityIndicator)</h3>
+        <InteractiveFilterButton
+          label="Priority"
+          options={priorityOptions}
+          placeholder="Search priority..."
+          icon={<Filter className="size-4" />}
         />
       </div>
 

--- a/frontend/components/stories/inputs/checkbox-filter.stories.tsx
+++ b/frontend/components/stories/inputs/checkbox-filter.stories.tsx
@@ -65,7 +65,7 @@ export const Default: Story = {
 
     return (
       <div className="flex flex-col gap-6">
-        {['xs', 'sm'].map(size => (
+        {['default', 'xs', 'sm', 'md', 'lg'].map(size => (
           <div key={size} className="flex flex-col gap-3">
             <span className="leading-2 font-bold uppercase"> {size} </span>
             <ChecboxFilter
@@ -142,6 +142,51 @@ export const Default: Story = {
             />
           </div>
         ))}
+      </div>
+    );
+  },
+};
+
+export const Fluid: Story = {
+  args: {
+    label: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor',
+  },
+  render: args => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [checked, setChecked] = useState<string[]>([]);
+    const handleOnCheckedChange = (id: string) => (value: boolean) => {
+      if (value) {
+        setChecked([...checked, id]);
+        return;
+      }
+      setChecked(checked.filter(c => c !== id));
+    };
+
+    return (
+      <div className="flex w-[480px] flex-col gap-6 rounded-md border p-4">
+        <div className="flex flex-col gap-3">
+          <span className="leading-2 font-bold"> Default (width capped at 228px) </span>
+          <ChecboxFilter
+            {...args}
+            size="sm"
+            count={1234}
+            description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            checked={checked.includes('capped')}
+            onCheckedChange={handleOnCheckedChange('capped')}
+          />
+        </div>
+        <div className="flex flex-col gap-3">
+          <span className="leading-2 font-bold"> Fluid (fills the container) </span>
+          <ChecboxFilter
+            {...args}
+            fluid
+            size="sm"
+            count={1234}
+            description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            checked={checked.includes('fluid')}
+            onCheckedChange={handleOnCheckedChange('fluid')}
+          />
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
# Feat (filters): Use checkbox-filter in filter-button

## 📌 Context

Use custom checkbox to be able to use own options (description, icon, count).

## 📝 Changes

- Replaced the base shadcn Checkbox in dropdown rows with the CheckboxFilter component
- Decoupled the overloaded withTooltip prop into two distinct props:
     - showKey → render the inline single-line "code - label" display (truncated, muted label).
     - withTooltip → wrap the label in a hover tooltip.
- Checkbox filter label now accepts React.ReactNode
- Added a fluid variant/prop that removes the width caps (max-w-[228px] / label max-w-[154px]).
- Add focus style on checkbox
- Add stories in storybook

## 🧪 Tests


https://github.com/user-attachments/assets/e65e5eb5-62e4-400a-9235-164bee888744

<img width="1721" height="607" alt="Capture d’écran, le 2026-05-29 à 14 23 28" src="https://github.com/user-attachments/assets/ed5fa09f-d22d-4977-b454-627d37b59125" />
<img width="1721" height="607" alt="Capture d’écran, le 2026-05-29 à 14 22 41" src="https://github.com/user-attachments/assets/6a15011f-e0b9-4106-a23f-86cc30d69c81" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-916](https://d3b.atlassian.net/browse/SJRA-916)<!-- End JIRA Issues -->

[SJRA-916]: https://d3b.atlassian.net/browse/SJRA-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ