### PR TITLE
fix(dropdown): SJRA-1534 add pointer event non when disabled

### DIFF
--- a/frontend/components/base/shadcn/dropdown-menu.tsx
+++ b/frontend/components/base/shadcn/dropdown-menu.tsx
@@ -90,7 +90,7 @@ function DropdownMenuItem({
   return (
     <DropdownMenuPrimitive.Item
       className={cn(
-        'relative flex cursor-pointer select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:cursor-default data-disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
+        'relative flex cursor-pointer select-none items-center gap-2 rounded-xs px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:cursor-default data-disabled:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
         inset && 'pl-8',
         className,
       )}


### PR DESCRIPTION
# Fix (dropdown menu): Add pointer event non when disabled

## 📌 Context

Cases actions item disabled shouldn't navigate to case entity.

## 📝 Changes

- When dropdown menu item is disabled add pointer events none 

## 🧪 Tests

https://github.com/user-attachments/assets/b7955af3-a90a-454c-b833-3f30c96d3368

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1534](https://d3b.atlassian.net/browse/SJRA-1534)<!-- End JIRA Issues -->

[SJRA-1534]: https://d3b.atlassian.net/browse/SJRA-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ