### PR TITLE
feat: SJRA-1452 install ranger in local deployment

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -49,6 +49,49 @@ services:
       - "8080:8080"
       - "9000:9000"
 
+  # Standalone Postgres standing in for the external/managed DB that backs Ranger in production.
+  # In prod this container is dropped and Ranger points at the managed endpoint (see
+  # scripts/ranger/install.properties -> db_host).
+  ranger-db:
+    image: postgres:14
+    container_name: ranger-db
+    hostname: ranger-db
+    environment:
+      POSTGRES_PASSWORD: rangerR0cks!   # superuser "postgres" -- Ranger's bootstrap (db_root) account
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+
+  # Apache Ranger admin. DB connection is externalized via the mounted install.properties so the
+  # same setup mirrors a production install against an external Postgres (edit that file for prod).
+  # No Solr/ZooKeeper: audit shipping is a no-op and the admin still boots.
+  ranger:
+    image: apache/ranger:2.7.0
+    container_name: ranger
+    hostname: ranger
+    depends_on:
+      ranger-db:
+        condition: service_healthy
+    environment:
+      RANGER_VERSION: "2.7.0"
+      RANGER_DB_TYPE: postgres
+    volumes:
+      - ./scripts/ranger/install.properties:/opt/ranger/admin/install.properties
+      # Replaces the stock script (which creates demo dev_* services) -- registers only our StarRocks service.
+      - ./scripts/ranger/create-ranger-services.py:/home/ranger/scripts/create-ranger-services.py
+      - ./scripts/ranger/ranger-servicedef-starrocks.json:/home/ranger/scripts/ranger-servicedef-starrocks.json
+    command: ["/home/ranger/scripts/ranger.sh"]
+    ports:
+      - "6080:6080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:6080/login.jsp > /dev/null || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+
   api:
     build:
       context: .

--- a/backend/scripts/ranger/create-ranger-services.py
+++ b/backend/scripts/ranger/create-ranger-services.py
@@ -1,0 +1,57 @@
+# Replaces the stock apache/ranger:2.7.0 create-ranger-services.py (which creates nine demo
+# dev_* service instances pointing at non-existent Hadoop/Hive/etc. containers).
+#
+# ranger.sh runs this once on first setup (when /opt/ranger/.setupDone is absent), ~30s after the
+# admin starts. By fully replacing the stock script, the dev_* services are never created; instead
+# we register our StarRocks service definition and a single "starrocks" service instance.
+#
+# Scope: service-def + service only. No access policies, and no StarRocks engine integration
+# (no fe.conf change) -- the service config below is used by Ranger only for test-connection /
+# resource lookup in the policy UI, and is harmless if StarRocks is unreachable.
+
+import json
+
+from apache_ranger.client.ranger_client import RangerClient
+from apache_ranger.model.ranger_service import RangerService
+from apache_ranger.model.ranger_service_def import RangerServiceDef
+
+ranger_client = RangerClient('http://ranger:6080', ('admin', 'rangerR0cks!'))
+
+SERVICEDEF_FILE = '/home/ranger/scripts/ranger-servicedef-starrocks.json'
+
+
+def missing(getter, name):
+    try:
+        return getter(name) is None
+    except Exception:
+        # The stock script treats a non-JSON / 404 response as "does not exist".
+        return True
+
+
+# 1. Register the StarRocks service definition (idempotent).
+with open(SERVICEDEF_FILE) as f:
+    starrocks_def = RangerServiceDef(json.load(f))
+
+try:
+    if missing(ranger_client.get_service_def, 'starrocks'):
+        ranger_client.create_service_def(starrocks_def)
+        print(" starrocks service-def created!")
+    else:
+        print(" starrocks service-def already exists")
+except Exception as e:
+    print(f"An exception occured creating the starrocks service-def: {e}")
+
+# 2. Create the StarRocks service instance (idempotent).
+starrocks = RangerService({'name': 'starrocks', 'type': 'starrocks',
+                           'configs': {'username': 'root', 'password': '',
+                                       'jdbc.driverClassName': 'com.mysql.cj.jdbc.Driver',
+                                       'jdbc.url': 'jdbc:mysql://starrocks:9030'}})
+
+try:
+    if missing(ranger_client.get_service, 'starrocks'):
+        ranger_client.create_service(starrocks)
+        print(" starrocks service created!")
+    else:
+        print(" starrocks service already exists")
+except Exception as e:
+    print(f"An exception occured creating the starrocks service: {e}")

--- a/backend/scripts/ranger/install.properties
+++ b/backend/scripts/ranger/install.properties
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This file provides a list of the deployment variables for the Policy Manager Web Application.
+#
+# It is the copy of the apache/ranger:2.7.0 image's baked-in install.properties
+# (release-ranger-2.7.0 -> scripts/ranger-admin-install-postgres.properties). It is mounted over
+# /opt/ranger/admin/install.properties so the Ranger DB connection is an explicit, editable surface.
+#
+# The Ranger entrypoint (ranger.sh) runs `setup.sh`, which reads this file, connects to the DB as
+# db_root_user to create db_name + db_user, loads the Ranger schema, then writes .setupDone.
+#
+# PRODUCTION: Ranger runs against an external/managed Postgres. To retarget it, change `db_host`
+# (and the credentials below) to point at that endpoint, and drop the local `ranger-db` container
+# from docker-compose.yml. Everything else stays the same.
+#
+
+PYTHON_COMMAND_INVOKER=python3
+RANGER_ADMIN_LOG_DIR=/var/log/ranger
+RANGER_PID_DIR_PATH=/var/run/ranger
+DB_FLAVOR=POSTGRES
+SQL_CONNECTOR_JAR=/usr/share/java/postgresql.jar
+RANGER_ADMIN_LOGBACK_CONF_FILE=/opt/ranger/admin/ews/webapp/WEB-INF/classes/conf/logback.xml
+
+# --- DB connection (the prod knob) ---------------------------------------------------------------
+# NOTE: setup.sh does NOT support trailing inline "#" comments on a value line -- they get parsed
+# as part of the value. Keep all explanatory comments on their own lines.
+#
+# db_root_user / db_root_password: privileged bootstrap account; creates db_name + db_user and loads schema.
+db_root_user=postgres
+db_root_password=rangerR0cks!
+# db_host: in production, point this at the external/managed Postgres endpoint (host[:port]).
+db_host=ranger-db
+
+db_name=ranger
+# db_user / db_password: runtime account Ranger uses after bootstrap.
+db_user=rangeradmin
+db_password=rangerR0cks!
+# -------------------------------------------------------------------------------------------------
+
+postgres_core_file=db/postgres/optimized/current/ranger_core_db_postgres.sql
+postgres_audit_file=db/postgres/xa_audit_db_postgres.sql
+mysql_core_file=db/mysql/optimized/current/ranger_core_db_mysql.sql
+mysql_audit_file=db/mysql/xa_audit_db.sql
+
+rangerAdmin_password=rangerR0cks!
+rangerTagsync_password=rangerR0cks!
+rangerUsersync_password=rangerR0cks!
+keyadmin_password=rangerR0cks!
+
+
+# Audit shipping is a no-op without a Solr container; admin still boots fine (see backend/docker-compose.yml).
+audit_store=solr
+audit_solr_urls=http://ranger-solr:8983/solr/ranger_audits
+audit_solr_collection_name=ranger_audits
+
+# audit_store=elasticsearch
+audit_elasticsearch_urls=
+audit_elasticsearch_port=9200
+audit_elasticsearch_protocol=http
+audit_elasticsearch_user=elastic
+audit_elasticsearch_password=elasticsearch
+audit_elasticsearch_index=ranger_audits
+audit_elasticsearch_bootstrap_enabled=true
+
+policymgr_external_url=http://ranger-admin:6080
+policymgr_http_enabled=true
+
+unix_user=ranger
+unix_user_pwd=ranger
+unix_group=ranger
+
+# Following variables are referenced in db_setup.py. Do not remove these
+oracle_core_file=
+sqlserver_core_file=
+sqlanywhere_core_file=
+cred_keystore_filename=
+
+# #################  DO NOT MODIFY ANY VARIABLES BELOW #########################
+#
+# --- These deployment variables are not to be modified unless you understand the full impact of the changes
+#
+################################################################################
+XAPOLICYMGR_DIR=$PWD
+app_home=$PWD/ews/webapp
+TMPFILE=$PWD/.fi_tmp
+LOGFILE=$PWD/logfile
+LOGFILES="$LOGFILE"
+
+JAVA_BIN='java'
+JAVA_VERSION_REQUIRED='1.8'
+
+ranger_admin_max_heap_size=1g
+#retry DB and Java patches after the given time in seconds.
+PATCH_RETRY_INTERVAL=120
+STALE_PATCH_ENTRY_HOLD_TIME=10
+
+hadoop_conf=
+authentication_method=UNIX

--- a/backend/scripts/ranger/ranger-servicedef-starrocks.json
+++ b/backend/scripts/ranger/ranger-servicedef-starrocks.json
@@ -1,0 +1,181 @@
+{
+  "name": "starrocks",
+  "displayName": "starrocks",
+  "implClass": "",
+  "label": "StarRocks",
+  "description": "StarRocks",
+  "resources": [
+    {
+      "itemId": 1, "name": "catalog", "type": "string", "level": 10, "parent": "",
+      "mandatory": true, "isValidLeaf": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks Catalog", "description": "StarRocks Catalog",
+      "accessTypeRestrictions": ["usage", "create database", "drop", "alter"]
+    },
+    {
+      "itemId": 2, "name": "database", "type": "string", "level": 20, "parent": "catalog",
+      "mandatory": true, "isValidLeaf": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks Database", "description": "StarRocks Database",
+      "accessTypeRestrictions": ["create table", "drop", "alter", "create view", "create function", "create materialized view"]
+    },
+    {
+      "itemId": 3, "name": "table", "type": "string", "level": 30, "parent": "database",
+      "mandatory": true, "isValidLeaf": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks Table", "description": "StarRocks Table",
+      "accessTypeRestrictions": ["delete", "drop", "insert", "alter", "export", "update", "refresh"]
+    },
+    {
+      "itemId": 4, "name": "column", "type": "string", "level": 40, "parent": "table",
+      "mandatory": true, "isValidLeaf": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks Column", "description": "StarRocks Column",
+      "accessTypeRestrictions": ["select"]
+    },
+    {
+      "itemId": 5, "name": "view", "type": "string", "level": 30, "parent": "database",
+      "mandatory": true, "isValidLeaf": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks View", "description": "StarRocks View",
+      "accessTypeRestrictions": ["drop", "alter"]
+    },
+    {
+      "itemId": 6, "name": "materialized_view", "type": "string", "level": 30, "parent": "database",
+      "mandatory": true, "isValidLeaf": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks Materialized View", "description": "StarRocks Materialized View",
+      "accessTypeRestrictions": ["refresh", "drop", "alter"]
+    },
+    {
+      "itemId": 7, "name": "function", "type": "string", "level": 30, "parent": "database",
+      "mandatory": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks Function", "description": "StarRocks Function",
+      "accessTypeRestrictions": ["usage", "drop"]
+    },
+    {
+      "itemId": 8, "name": "global_function", "type": "string", "level": 10, "parent": "",
+      "mandatory": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks Global Function", "description": "StarRocks Global Function",
+      "accessTypeRestrictions": ["usage", "drop"]
+    },
+    {
+      "itemId": 9, "name": "resource", "type": "string", "level": 10, "parent": "",
+      "mandatory": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks Resource", "description": "StarRocks Resource",
+      "accessTypeRestrictions": ["usage", "alter", "drop"]
+    },
+    {
+      "itemId": 10, "name": "resource_group", "type": "string", "level": 10, "parent": "",
+      "mandatory": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks Resource Group", "description": "StarRocks Resource Group",
+      "accessTypeRestrictions": ["alter", "drop"]
+    },
+    {
+      "itemId": 11, "name": "storage_volume", "type": "string", "level": 10, "parent": "",
+      "mandatory": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks Storage Volume", "description": "StarRocks Storage Volume",
+      "accessTypeRestrictions": ["drop", "alter", "usage"]
+    },
+    {
+      "itemId": 12, "name": "user", "type": "string", "level": 10, "parent": "",
+      "mandatory": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+      "matcherOptions": { "wildCard": true, "ignoreCase": true },
+      "label": "StarRocks User", "description": "StarRocks User",
+      "accessTypeRestrictions": ["impersonate"]
+    },
+    {
+      "itemId": 13, "name": "system", "type": "string", "level": 10, "parent": "",
+      "mandatory": true, "lookupSupported": true, "recursiveSupported": false, "excludesSupported": true,
+      "validationRegEx": "\\*", "validationMessage": "System only supports wildcard '*'",
+      "label": "StarRocks System", "description": "StarRocks System",
+      "accessTypeRestrictions": ["grant", "node", "create resource", "plugin", "file", "blacklist", "operate", "create external catalog", "repository", "create resource group", "create global function", "create storage volume"]
+    }
+  ],
+  "accessTypes": [
+    { "itemId": 1,  "name": "grant",                    "label": "GRANT" },
+    { "itemId": 2,  "name": "node",                     "label": "NODE" },
+    { "itemId": 3,  "name": "operate",                  "label": "OPERATE" },
+    { "itemId": 4,  "name": "delete",                   "label": "DELETE" },
+    { "itemId": 5,  "name": "drop",                     "label": "DROP" },
+    { "itemId": 6,  "name": "insert",                   "label": "INSERT" },
+    { "itemId": 7,  "name": "select",                   "label": "SELECT" },
+    { "itemId": 8,  "name": "alter",                    "label": "ALTER" },
+    { "itemId": 9,  "name": "export",                   "label": "EXPORT" },
+    { "itemId": 10, "name": "update",                   "label": "UPDATE" },
+    { "itemId": 11, "name": "usage",                    "label": "USAGE" },
+    { "itemId": 12, "name": "plugin",                   "label": "PLUGIN" },
+    { "itemId": 13, "name": "file",                     "label": "FILE" },
+    { "itemId": 14, "name": "blacklist",                "label": "BLACKLIST" },
+    { "itemId": 15, "name": "repository",               "label": "REPOSITORY" },
+    { "itemId": 16, "name": "refresh",                  "label": "REFRESH" },
+    { "itemId": 17, "name": "impersonate",              "label": "IMPERSONATE" },
+    { "itemId": 18, "name": "create database",          "label": "CREATE DATABASE" },
+    { "itemId": 19, "name": "create table",             "label": "CREATE TABLE" },
+    { "itemId": 20, "name": "create view",              "label": "CREATE VIEW" },
+    { "itemId": 21, "name": "create function",          "label": "CREATE FUNCTION" },
+    { "itemId": 22, "name": "create global function",   "label": "CREATE GLOBAL FUNCTION" },
+    { "itemId": 23, "name": "create materialized view", "label": "CREATE MATERIALIZED VIEW" },
+    { "itemId": 24, "name": "create resource",          "label": "CREATE RESOURCE" },
+    { "itemId": 25, "name": "create resource group",    "label": "CREATE RESOURCE GROUP" },
+    { "itemId": 26, "name": "create external catalog",  "label": "CREATE EXTERNAL CATALOG" },
+    { "itemId": 27, "name": "create storage volume",    "label": "CREATE STORAGE VOLUME" }
+  ],
+  "configs": [
+    { "itemId": 1, "name": "username",              "type": "string",   "mandatory": true,  "label": "Username", "defaultValue": "root" },
+    { "itemId": 2, "name": "password",              "type": "password", "mandatory": false,  "label": "Password" },
+    { "itemId": 3, "name": "jdbc.driverClassName",  "type": "string",   "mandatory": true,  "defaultValue": "com.mysql.cj.jdbc.Driver" },
+    { "itemId": 4, "name": "jdbc.url",              "type": "string",   "mandatory": true,  "defaultValue": "jdbc:mysql://127.0.0.1:9030" }
+  ],
+  "enums": [],
+  "contextEnrichers": [],
+  "policyConditions": [
+    {
+      "itemId": 100, "name": "ip-range",
+      "evaluator": "org.apache.ranger.plugin.conditionevaluator.RangerIpMatcher",
+      "evaluatorOptions": {}, "label": "IP Address Range", "description": "IP Address Range"
+    }
+  ],
+  "dataMaskDef": {
+    "accessTypes": [{ "name": "select" }],
+    "resources": [
+      { "name": "catalog",  "matcherOptions": { "wildCard": "true" }, "lookupSupported": true, "uiHint": "{ \"singleValue\":true }" },
+      { "name": "database", "matcherOptions": { "wildCard": "true" }, "lookupSupported": true, "uiHint": "{ \"singleValue\":true }" },
+      { "name": "table",    "matcherOptions": { "wildCard": "true" }, "lookupSupported": true, "uiHint": "{ \"singleValue\":true }" },
+      { "name": "column",   "matcherOptions": { "wildCard": "true" }, "lookupSupported": true, "uiHint": "{ \"singleValue\":true }" }
+    ],
+    "maskTypes": [
+      { "itemId": 1, "name": "MASK",      "label": "Redact",    "description": "Replace lowercase with 'x', uppercase with 'X', digits with '0'", "transformer": "cast(regexp_replace(regexp_replace(regexp_replace({col},'([A-Z])', 'X'),'([a-z])','x'),'([0-9])','0') as {type})" },
+      { "itemId": 2, "name": "MASK_HASH", "label": "Hash",      "description": "Hash the value with sha256", "transformer": "cast((hex(sha2(from_binary(to_binary({COL}, 'utf8'), 'utf8'), 256))) AS {type})" },
+      { "itemId": 3, "name": "MASK_NULL", "label": "Nullify",   "description": "Replace with NULL" },
+      { "itemId": 4, "name": "MASK_NONE", "label": "Unmasked",  "description": "No masking" },
+      { "itemId": 5, "name": "MASK_DATE_SHOW_YEAR", "label": "Date: show only year", "description": "Date: show only year", "transformer": "date_trunc('year', {col})" },
+      { "itemId": 6, "name": "CUSTOM",    "label": "Custom",    "description": "Custom" }
+    ]
+  },
+  "rowFilterDef": {
+    "accessTypes": [{ "name": "select" }],
+    "resources": [
+      { "name": "catalog",  "matcherOptions": { "wildCard": "true" }, "lookupSupported": true, "mandatory": true, "uiHint": "{ \"singleValue\":true }" },
+      { "name": "database", "matcherOptions": { "wildCard": "true" }, "lookupSupported": true, "mandatory": true, "uiHint": "{ \"singleValue\":true }" },
+      { "name": "table",    "matcherOptions": { "wildCard": "true" }, "lookupSupported": true, "mandatory": true, "uiHint": "{ \"singleValue\":true }" }
+    ]
+  }
+}


### PR DESCRIPTION
## 📌 Context

Adds **Apache Ranger** to the backend local `docker-compose` stack, following the direction of the
multi-tenancy ADR (`docs/adr/multi-tenancy-security.md`) and the Ranger POC (`docs/adr/ranger-poc/`).

Scope is intentionally limited to standing Ranger up and registering a StarRocks **service** in it.
There is **no StarRocks engine enforcement** yet (no `fe.conf` change / `access_control = ranger`),
so the existing API/worker behaviour is unchanged. Ranger is backed by a standalone Postgres that
**mimics the production external/managed DB**, so the install model matches what we'll do in prod.

## 📝 Changes

- Add two services to `backend/docker-compose.yml`:
  - `ranger` (`apache/ranger:2.7.0`) on port `6080`
  - `ranger-db` (`postgres:14`) — a plain Postgres standing in for the external/managed prod DB
- `backend/scripts/ranger/install.properties` — the Ranger DB connection, mounted over
  `/opt/ranger/admin/install.properties`. This is the single editable surface: for prod you change
  `db_host` + credentials to the managed endpoint and drop the local `ranger-db` container.
- `backend/scripts/ranger/create-ranger-services.py` — replaces the stock Ranger bootstrap script
  so the nine demo `dev_*` services are **not** created; instead it registers the StarRocks
  service-def and a single `starrocks` service (idempotent).
- `backend/scripts/ranger/ranger-servicedef-starrocks.json` — StarRocks Ranger service definition
  (catalog → database → table → column resources, access types, data-mask & row-filter defs).

## ☑️ TO-DOs

- [x] No outstanding tasks — change is self-contained and verified locally.

## 🧪 Tests

No automated tests (docker-compose infra). Verified manually:

```bash
cd backend && docker compose up -d ranger-db ranger
```

- `ranger` becomes healthy; Admin UI at http://localhost:6080 (login `admin` / `rangerR0cks!`).
- DB provisioned through the externalized `install.properties`:
  `ranger` database + `rangeradmin` role created in `ranger-db`.
- Service list shows **only** `starrocks` (plus Ranger's built-in `tag`) — none of the `dev_*` demo services.
- `starrocks` service-def is registered.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1452](https://d3b.atlassian.net/browse/SJRA-1452)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Why a separate Postgres** (not the app's `radiant` DB, not the `apache/ranger-db` image): to
  mirror an external/managed prod DB. The `apache/ranger:2.7.0` image bakes its DB config with no
  env override, which is why we mount a full `install.properties`.
- ⚠️ Ranger's property parser does **not** support trailing inline `#` comments on a value line
  (they get parsed into the value) — comments in `install.properties` are kept on their own lines.
- **"Test Connection" on the `starrocks` service fails** with *"Configuration validation is not
  implemented for starrocks"* — this is **expected** and harmless. It only needs the *optional*
  `ranger-starrocks-plugin` (autocomplete / test-connection only); policy enforcement does not
  depend on it, so we deliberately did not install it.
- A `tag` service also appears in Ranger — it's a built-in, not one of the demo services.

[SJRA-1452]: https://d3b.atlassian.net/browse/SJRA-1452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ