### PR TITLE
fix(clinvar): SJRA-1552 fix typo

### DIFF
--- a/backend/internal/repository/facets.go
+++ b/backend/internal/repository/facets.go
@@ -79,8 +79,8 @@ func NewFacetsRepository() *FacetsRepository {
 			Name: "clinvar",
 			Values: []string{
 				"Affects", "association", "association_not_found", "Benign", "confers_sensitivity",
-				"Conflicting_classifications_of_pathogenicity", "conflicting_data_from_submitters", "Conflicting_interpretations_of_pathogenicity", "drug_response", "established_risk_allele",
-				"Likely_benign", "Likely_pathogenic", "likely_pathogenic_low_penetrance", "Likely_risk_allele", "low_penetrance",
+				"Conflicting_classifications_of_pathogenicity", "conflicting_data_from_submitters", "Conflicting_interpretations_of_pathogenicity", "drug_response", "Established_risk_allele",
+				"Likely_benign", "Likely_pathogenic", "likely_pathogenic_low_penetrance", "Likely_risk_allele", "_low_penetrance",
 				"no_classification_for_the_single_variant", "not_provided", "other", "Pathogenic", "pathogenic_low_penetrance",
 				"protective", "risk_factor", "Uncertain_risk_allele", "Uncertain_significance",
 			},


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Le dictionnaire de la facette ClinVar contient 2 typos.

- established_risk_allele devrait être Established_risk_allele
- low_penetrance devrait être _low_penetrance


## 📝 Changes

- established_risk_allele => Established_risk_allele
- low_penetrance => _low_penetrance

## 🧪 Tests

<img width="2327" height="918" alt="2026-06-03_11-00_1" src="https://github.com/user-attachments/assets/408163db-98ec-45cd-af50-e39eb435f6ca" />
<img width="2449" height="942" alt="2026-06-03_11-00" src="https://github.com/user-attachments/assets/d7682cbe-163c-4778-8992-3c262070a6ef" />

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1552](https://d3b.atlassian.net/browse/SJRA-1552)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->

- 

[SJRA-1552]: https://d3b.atlassian.net/browse/SJRA-1552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ