### PR TITLE
feat(zod): SJRA-1555 add translations

### DIFF
--- a/frontend/apps/case/src/entity/variants/interpretation/pubmed-form-field.tsx
+++ b/frontend/apps/case/src/entity/variants/interpretation/pubmed-form-field.tsx
@@ -37,7 +37,7 @@ function PubmedFormField() {
         }
       },
       onError: () => {
-        if (pubmedFetchKey?.index) {
+        if (pubmedFetchKey?.index != undefined) {
           setError(`pubmed.${pubmedFetchKey.index}.citation`, {
             message: t('variant.interpretation_form.generic.pub_med_id_not_found'),
           });

--- a/frontend/apps/case/src/entity/variants/interpretation/types.ts
+++ b/frontend/apps/case/src/entity/variants/interpretation/types.ts
@@ -18,7 +18,7 @@ export type InterpretationFormProps<T> = {
 };
 
 export const genericInterpretationFormSchema = z.object({
-  interpretation: z.string().refine(val => !isEditorHasEmptyContent(val), { message: 'This field is required' }),
+  interpretation: z.string().refine(val => !isEditorHasEmptyContent(val), { message: 'required' }),
   pubmed: (
     z.object({
       citation: z.string(),
@@ -33,10 +33,10 @@ export type GenericInterpretationSchemaType = z.infer<typeof genericInterpretati
 
 export const germlineInterpretationFormSchema = (
   z.object({
-    classification: z.string().min(1, 'This field is required'),
-    classification_criterias: z.string().array().min(1, 'This field is required'),
-    condition: z.string().min(1, 'This field is required'),
-    transmission_modes: z.string().array().min(1, 'This field is required'),
+    classification: z.string().min(1, 'required'),
+    classification_criterias: z.string().array().min(1, 'required'),
+    condition: z.string().min(1, 'required'),
+    transmission_modes: z.string().array().min(1, 'required'),
   }) satisfies ZodSchema<InterpretationGermline>
 ).merge(genericInterpretationFormSchema);
 
@@ -44,8 +44,8 @@ export type GermlineInterpretationSchemaType = z.infer<typeof germlineInterpreta
 
 export const somaticInterpretationFormSchema = (
   z.object({
-    tumoral_type: z.string().min(1, 'This field is required'),
-    clinical_utility: z.string().min(1, 'This field is required'),
+    tumoral_type: z.string().min(1, 'required'),
+    clinical_utility: z.string().min(1, 'required'),
     oncogenicity: z.string().optional(),
     oncogenicity_classification_criterias: z.string().array().optional(),
   }) satisfies ZodSchema<InterpretationSomatic>

--- a/frontend/components/base/query-builder/saved-filter/update-filter-dialog.tsx
+++ b/frontend/components/base/query-builder/saved-filter/update-filter-dialog.tsx
@@ -18,7 +18,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../../shadcn/dialog';
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../shadcn/form';
+import { Form, FormControl, FormField, FormItem, FormLabel } from '../../shadcn/form';
 import { Input } from '../../shadcn/input';
 import { useQBContext } from '../hooks/use-query-builder';
 import { fetchSavedFilters } from '../query-builder';
@@ -33,7 +33,7 @@ interface UpdateFilterDialogProps {
 }
 
 const formSchema = z.object({
-  name: z.string().min(2, 'Min 2 characters').max(50, 'Max 50 characters'),
+  name: z.string().min(2, 'min_2').max(50, { message: 'max_50' }),
 });
 
 function UpdateFilterDialog({ open, onOpenChange, savedFilter, isFromManage = false }: UpdateFilterDialogProps) {
@@ -128,7 +128,6 @@ function UpdateFilterDialog({ open, onOpenChange, savedFilter, isFromManage = fa
                     <FormControl>
                       <Input placeholder={t('common.saved_filter.edit_dialog.fields.title.placeholder')} {...field} />
                     </FormControl>
-                    <FormMessage />
                   </FormItem>
                 )}
                 schema={formSchema}

--- a/frontend/components/base/shadcn/form.tsx
+++ b/frontend/components/base/shadcn/form.tsx
@@ -6,6 +6,7 @@ import { InfoIcon } from 'lucide-react';
 import z from 'zod';
 
 import { Label } from '@/base/shadcn/label';
+import { useI18n } from '@/components/hooks/i18n';
 import { isFieldRequired } from '@/components/lib/zod';
 import { cn } from '@/lib/utils';
 
@@ -143,9 +144,16 @@ function FormDescription({ className, ...props }: React.HTMLAttributes<HTMLParag
 }
 FormDescription.displayName = 'FormDescription';
 
+/**
+ * Translations
+ * Since we cannot pass zod's threshold value
+ * we must use unique translation key
+ * eg. min_2, max_50
+ */
 function FormMessage({ className, children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  const { t } = useI18n();
   const { error, formMessageId } = useFormField();
-  const body = error ? String(error?.message) : children;
+  const body = error ? t(`common.form.errors.${String(error?.message)}`) : children;
 
   if (!body) {
     return null;

--- a/frontend/translations/common/en.json
+++ b/frontend/translations/common/en.json
@@ -18,6 +18,13 @@
     "edit": "Edit",
     "delete": "Delete",
     "cancel": "Cancel",
+    "form": {
+      "errors": {
+        "required": "This field is required",
+        "min_2": "Min 2 characters",
+        "max_50": "Max 50 characters"
+      }
+    },
     "editor": {
       "headings": {
         "normal": "Normal",

--- a/frontend/translations/common/fr.json
+++ b/frontend/translations/common/fr.json
@@ -18,6 +18,13 @@
     "cancel": "Annuler",
     "close": "Fermer",
     "view_all": "Voir tout",
+    "form": {
+      "errors": {
+        "required": "Ce champ est requis",
+        "min_2": "2 caractères minimum",
+        "max_50": "50 caractères maximum"
+      }
+    },
     "editor": {
       "headings": {
         "normal": "Normal",


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Dans le formulaire d’interprétation en français, le message “This field is required” s’affiche en anglais.
Traduire également ceux-ci (ex. Min 2 characters)

## 📝 Changes
- Add zod translations
- Fix duplicate error message in UpdateFilterDialog
- Display an issue where pubmed error was not displayed if pubmed was not found

## 🧪 Tests

<img width="791" height="392" alt="image" src="https://github.com/user-attachments/assets/a226c6c4-92a1-4dea-8281-d7286bb2f062" />
<img width="837" height="368" alt="image" src="https://github.com/user-attachments/assets/a5d787cf-57c5-44de-9eda-ea31366d1813" />
<img width="810" height="466" alt="image" src="https://github.com/user-attachments/assets/88e0d5a6-f1fc-4b29-a343-3236e3859907" />
<img width="798" height="332" alt="image" src="https://github.com/user-attachments/assets/b3c574c1-fac9-4ef4-92b7-d4c77b90a260" />
<img width="1161" height="1099" alt="image" src="https://github.com/user-attachments/assets/7295b4d3-fec0-46a3-a4bf-82566003c9e5" />
<img width="1183" height="1039" alt="image" src="https://github.com/user-attachments/assets/98cd365c-ff58-4231-bdb6-823d664d558b" />
<img width="596" height="192" alt="image" src="https://github.com/user-attachments/assets/4536da73-9b7e-4ab9-9a30-010deee2bec4" />
<img width="608" height="223" alt="image" src="https://github.com/user-attachments/assets/95c5f2ec-2afa-4a93-b356-63e575d9c63a" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1555](https://d3b.atlassian.net/browse/SJRA-1555)<!-- End JIRA Issues -->


[SJRA-1555]: https://d3b.atlassian.net/browse/SJRA-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ