### PR TITLE
feat: SJRA-1567 Adjust Cypress tests related to recent changes

### DIFF
--- a/cypress/pom/shared/Data.ts
+++ b/cypress/pom/shared/Data.ts
@@ -67,7 +67,7 @@ export const data = {
     type: 'SNV',
     dbsnp: 'rs72840396',
     gene: 'HPSE2',
-    consequence: 'Splice Region Variant',
+    consequence: 'Splice Region',
     aa_change: null,
     consequenceImpact: CommonSelectors.colorIndicator('emerald'),
     maneC: true,

--- a/cypress/pom/shared/Selectors.ts
+++ b/cypress/pom/shared/Selectors.ts
@@ -90,6 +90,6 @@ export const CommonSelectors = {
   tooltipPopper: '[class*="radix-tooltip-content"]',
   underlineHeader: '[class*="decoration-dotted"]',
   unpinIcon: '[class*="lucide-pin-off"]',
-  userIcon: 'button[aria-haspopup="menu"] [class*="bg-cyan/20 text-cyan-foreground"]',
+  userIcon: 'button[aria-haspopup="menu"] [data-slot="avatar"]',
   variantPreview: '[role="dialog"][class*="data-[state=open]:slide-in-from-right"]',
 };


### PR DESCRIPTION
# feat: SJRA-1567 Adjust Cypress tests related to recent changes

## 📌 Context

Des changements récents dans l'interface ont modifié l'affichage de certaines données et la structure du menu utilisateur. Les tests Cypress reposant sur ces éléments ne correspondaient plus à l'application et devaient être ajustés pour rester valides.

## 📝 Changes

- **`cypress/pom/shared/Data.ts`** : ajustement de la valeur attendue de la conséquence du variant SNV `HPSE2` — passage de `Splice Region Variant` à `Splice Region` pour refléter le libellé affiché actuellement.
- **`cypress/pom/shared/Selectors.ts`** : mise à jour du sélecteur `userIcon`, qui ciblait des classes CSS fragiles (`bg-cyan/20 text-cyan-foreground`), pour utiliser l'attribut stable `[data-slot="avatar"]`.

## 🧪 Tests

- Aucun nouveau test ajouté : il s'agit uniquement d'ajustements de Page Object Models (donnée attendue et sélecteur) pour aligner les tests existants sur l'état actuel de l'interface.
- Les tests Cypress impactés ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1567](https://d3b.atlassian.net/browse/SJRA-1567)<!-- End JIRA Issues -->

[SJRA-1567]: https://d3b.atlassian.net/browse/SJRA-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ