### PR TITLE
feat: SJRA-1573 key users by user_id (Keycloak sub) instead of email

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -76,19 +76,19 @@ Auth utilities live in `internal/utils/auth.go` (`KeycloakAuth` interface).
 
 ### Multi-tenancy authorization model (`auth_db`)
 
-Authorization is **data**, not a separate service. Migration `000009_init_auth_multi_tenancy.up.sql` adds the model as 8 PostgreSQL tables (in `public`; the ADR's `auth_db.*` is the logical name, federated into StarRocks as `radiant_jdbc.public.*`). See `docs/adr/multi-tenancy-security.md` §5.
+Authorization is **data**, not a separate service. Migration `000009_init_auth_multi_tenancy.up.sql` adds the model as 8 PostgreSQL tables (in `public`; the ADR's `auth_db.*` is the logical name, federated into StarRocks as `radiant_jdbc.public.*`). Migration `000011_rekey_users_by_user_id.up.sql` then re-keys identity to `user_id` (see below). See `docs/adr/multi-tenancy-security.md` §5.
 
-Identifiers are **varchar `code` natural keys** — no integer surrogate ids — so every reference column is `*_code`. Users are keyed by **`email`** (the one identifier known at invite time, IdP-agnostic); `user_id uuid` (the Keycloak `sub`) is a nullable attribute filled on first login — same column name used by `saved_filter` / `user_preference` / `user_set` / `occurrence_note`.
+Identifiers are **varchar `code` natural keys** — no integer surrogate ids — so every reference column is `*_code`. Users are keyed by **`user_id`** (the Keycloak `sub`), which is required and unique; `email` / `first_name` / `last_name` are optional attributes. `user_id` is the same column name used by `saved_filter` / `user_preference` / `user_set` / `occurrence_note`. **Consequence:** a user must exist in Keycloak (have a `sub`) before they can be granted roles — there is no pre-provisioning by email before first login. (Migration 000009 originally keyed users by email; 000011 reversed that.)
 
 | Table | Key | Purpose |
 |---|---|---|
 | `tenant` | `code` | Tenant catalog (e.g. `radiant`) |
 | `organization` | `(code, tenant_code)` | Orgs, each belonging to one tenant (pre-existing table; `id` dropped, `tenant_code` added) |
-| `users` | `email` | Identity registry; `user_id uuid` (Keycloak sub) nullable until first login |
+| `users` | `user_id` | Identity registry, keyed by the Keycloak `sub` (required, unique); `email` / `first_name` / `last_name` are optional attributes |
 | `role` | `(tenant_code, code)` | Per-tenant role catalog |
 | `action` | `code` | Global action catalog; `scope` ∈ {`org`,`tenant`} |
 | `role_action` | `(tenant_code, role_code, action_code)` | Role → action mapping; FK to `role` `ON DELETE CASCADE` |
-| `user_role` | `(email, tenant_code, org_code, role_code)` | Single grant table; `org_code` is nullable — `NULL` = not org-scoped (tenant-wide grant), `'*'` = all orgs in tenant, specific code = that org. Uniqueness enforced by two partial indexes (one for non-NULL `org_code`, one for NULL). |
+| `user_role` | `(user_id, tenant_code, org_code, role_code)` | Single grant table (`user_id` FK → `users`); `org_code` is nullable — `NULL` = not org-scoped (tenant-wide grant), `'*'` = all orgs in tenant, specific code = that org. Uniqueness enforced by two partial indexes (one for non-NULL `org_code`, one for NULL). |
 
 The child clinical tables (`cases`, `patient`, `sample`, `sequencing_experiment`) reference `organization(code, tenant_code)` via compound FKs; StarRocks federation joins are `ON x.<>_code = org.code AND x.tenant_code = org.tenant_code`.
 

--- a/backend/cmd/api/auth_integration_test.go
+++ b/backend/cmd/api/auth_integration_test.go
@@ -12,10 +12,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func assertGetMeHandler(t *testing.T, email string, expected string) {
+// user_id (Keycloak sub) values matching the seeded auth fixtures (test/data/auth/05_users.sql).
+// nobodyID has no rows, to exercise the no-grants path.
+const (
+	aliceID  = "25286548-fbef-4e93-b3c4-c659e6169396"
+	nobodyID = "c7dd9459-3b2f-4f8d-94a3-5db90a9c7091"
+)
+
+func assertGetMeHandler(t *testing.T, userID string, expected string) {
 	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
 		repo := repository.NewAuthRepository(env.Postgres)
-		auth := &testutils.MockAuth{Email: email}
+		auth := &testutils.MockAuth{Id: userID}
 
 		router := gin.Default()
 		router.GET("/auth/me", server.GetMeHandler(repo, auth))
@@ -31,7 +38,7 @@ func assertGetMeHandler(t *testing.T, email string, expected string) {
 
 func Test_GetMeHandler_SeededUser(t *testing.T) {
 	// alice: geneticist @ CHOP + researcher tenant-wide, in the radiant tenant.
-	assertGetMeHandler(t, "alice@test.authz", `[{
+	assertGetMeHandler(t, aliceID, `[{
 		"code": "radiant",
 		"name": "Radiant",
 		"tenant_actions": ["can_search_case", "can_view_kb"],
@@ -43,15 +50,15 @@ func Test_GetMeHandler_SeededUser(t *testing.T) {
 }
 
 func Test_GetMeHandler_UserWithoutGrants(t *testing.T) {
-	assertGetMeHandler(t, "nobody@test.authz", `[]`)
+	assertGetMeHandler(t, nobodyID, `[]`)
 }
 
 // assertTenantAccess wires the real AuthRepository behind RequireTenantAccess and requests a
 // tenant-scoped route as the given user, returning the resulting status code.
-func assertTenantAccess(t *testing.T, email, tenant string, enforce bool, expectedStatus int) {
+func assertTenantAccess(t *testing.T, userID, tenant string, enforce bool, expectedStatus int) {
 	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
 		repo := repository.NewAuthRepository(env.Postgres)
-		auth := &testutils.MockAuth{Email: email}
+		auth := &testutils.MockAuth{Id: userID}
 
 		router := gin.Default()
 		tenantRoutes := router.Group("/:tenant")
@@ -68,15 +75,15 @@ func assertTenantAccess(t *testing.T, email, tenant string, enforce bool, expect
 
 func Test_RequireTenantAccess_Member_Allowed(t *testing.T) {
 	// alice holds roles in radiant.
-	assertTenantAccess(t, "alice@test.authz", "radiant", true, http.StatusOK)
+	assertTenantAccess(t, aliceID, "radiant", true, http.StatusOK)
 }
 
 func Test_RequireTenantAccess_CrossTenant_Forbidden(t *testing.T) {
 	// alice has no grant in tenant_b → cross-tenant access is rejected.
-	assertTenantAccess(t, "alice@test.authz", "tenant_b", true, http.StatusForbidden)
+	assertTenantAccess(t, aliceID, "tenant_b", true, http.StatusForbidden)
 }
 
 func Test_RequireTenantAccess_EnforcementDisabled_AllowsCrossTenant(t *testing.T) {
 	// With enforcement off, even a non-member reaches the handler (no day-1 lockout).
-	assertTenantAccess(t, "alice@test.authz", "tenant_b", false, http.StatusOK)
+	assertTenantAccess(t, aliceID, "tenant_b", false, http.StatusOK)
 }

--- a/backend/internal/repository/auth.go
+++ b/backend/internal/repository/auth.go
@@ -15,9 +15,9 @@ type AuthRepository struct {
 }
 
 type AuthRepositoryDAO interface {
-	HasAction(email, tenantCode, orgCode, actionCode string) (bool, error)
-	HasTenantAccess(email, tenantCode string) (bool, error)
-	GetMemberships(email string) ([]types.TenantMembership, error)
+	HasAction(userID, tenantCode, orgCode, actionCode string) (bool, error)
+	HasTenantAccess(userID, tenantCode string) (bool, error)
+	GetMemberships(userID string) ([]types.TenantMembership, error)
 }
 
 func NewAuthRepository(db *gorm.DB) *AuthRepository {
@@ -32,7 +32,7 @@ func NewAuthRepository(db *gorm.DB) *AuthRepository {
 // by the action's scope, not the grant's org_code (a role may map both scopes): a
 // tenant-scoped action matches any grant in the tenant regardless of orgCode; an
 // org-scoped action requires a grant at orgCode or the '*' wildcard.
-func (r *AuthRepository) HasAction(email, tenantCode, orgCode, actionCode string) (bool, error) {
+func (r *AuthRepository) HasAction(userID, tenantCode, orgCode, actionCode string) (bool, error) {
 	var allowed bool
 	err := r.db.Raw(`
 		SELECT EXISTS (
@@ -40,11 +40,11 @@ func (r *AuthRepository) HasAction(email, tenantCode, orgCode, actionCode string
 			FROM user_role ur
 			JOIN role_action ra ON ra.tenant_code = ur.tenant_code AND ra.role_code = ur.role_code
 			JOIN action a       ON a.code = ra.action_code
-			WHERE ur.email = ? AND ur.tenant_code = ? AND ra.action_code = ?
+			WHERE ur.user_id = ? AND ur.tenant_code = ? AND ra.action_code = ?
 			  AND (a.scope = ? OR (a.scope = ? AND (ur.org_code = ? OR ur.org_code = '*')))
-		)`, email, tenantCode, actionCode, types.ActionScopeTenant, types.ActionScopeOrg, orgCode).Scan(&allowed).Error
+		)`, userID, tenantCode, actionCode, types.ActionScopeTenant, types.ActionScopeOrg, orgCode).Scan(&allowed).Error
 	if err != nil {
-		return false, fmt.Errorf("error checking action %q for %q: %w", actionCode, email, err)
+		return false, fmt.Errorf("error checking action %q for %q: %w", actionCode, userID, err)
 	}
 	return allowed, nil
 }
@@ -52,15 +52,15 @@ func (r *AuthRepository) HasAction(email, tenantCode, orgCode, actionCode string
 // HasTenantAccess reports whether the user holds at least one role in the given tenant.
 // It backs the tenant-routing middleware: any grant (org-scoped or tenant-wide) makes the
 // caller a member of the tenant.
-func (r *AuthRepository) HasTenantAccess(email, tenantCode string) (bool, error) {
+func (r *AuthRepository) HasTenantAccess(userID, tenantCode string) (bool, error) {
 	var allowed bool
 	err := r.db.Raw(`
 		SELECT EXISTS (
 			SELECT 1 FROM user_role ur
-			WHERE ur.email = ? AND ur.tenant_code = ?
-		)`, email, tenantCode).Scan(&allowed).Error
+			WHERE ur.user_id = ? AND ur.tenant_code = ?
+		)`, userID, tenantCode).Scan(&allowed).Error
 	if err != nil {
-		return false, fmt.Errorf("error checking tenant access for %q in %q: %w", email, tenantCode, err)
+		return false, fmt.Errorf("error checking tenant access for %q in %q: %w", userID, tenantCode, err)
 	}
 	return allowed, nil
 }
@@ -80,7 +80,7 @@ type membershipGrant struct {
 // Each action routes by its own scope (a role may map both): tenant-scoped → tenant_actions;
 // org-scoped → orgs_by_action, where a specific org_code maps to that org and '*' expands to
 // every org in the tenant (ADR §5.4).
-func (r *AuthRepository) GetMemberships(email string) ([]types.TenantMembership, error) {
+func (r *AuthRepository) GetMemberships(userID string) ([]types.TenantMembership, error) {
 	var grants []membershipGrant
 	if err := r.db.Raw(`
 		SELECT ur.tenant_code, t.name AS tenant_name, ur.org_code, ra.action_code, a.scope, ra.role_code,
@@ -94,9 +94,9 @@ func (r *AuthRepository) GetMemberships(email string) ([]types.TenantMembership,
 			FROM organization
 			GROUP BY tenant_code
 		) o ON o.tenant_code = ur.tenant_code
-		WHERE ur.email = ?
-		ORDER BY ur.tenant_code, ra.action_code, ur.org_code`, email).Scan(&grants).Error; err != nil {
-		return nil, fmt.Errorf("error loading grants for %q: %w", email, err)
+		WHERE ur.user_id = ?
+		ORDER BY ur.tenant_code, ra.action_code, ur.org_code`, userID).Scan(&grants).Error; err != nil {
+		return nil, fmt.Errorf("error loading grants for %q: %w", userID, err)
 	}
 
 	// The ORDER BY is load-bearing twice over:

--- a/backend/internal/repository/auth_test.go
+++ b/backend/internal/repository/auth_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// user_id (Keycloak sub) values for the seeded auth fixtures (test/data/auth/05_users.sql).
+// ghost is a user_id with no users/user_role rows, for the unknown-user paths.
+const (
+	aliceID = "25286548-fbef-4e93-b3c4-c659e6169396"
+	wendyID = "79a8855e-3782-4dc8-be2a-8afdb34d6359"
+	danID   = "e10fee0b-063b-4dcd-b086-90d1c9eb239d"
+	carolID = "b6e6d0dd-7aa5-4018-ae03-1f5076801360"
+	patID   = "6c330322-c746-4436-bb76-efd2cd943686"
+	twID    = "4a330f72-24a1-4d37-8ad7-ff9989245fd3"
+	ghostID = "29cef9cb-e954-473b-b672-60b682a06afd"
+)
+
 func Test_splitOrgCodes_Empty(t *testing.T) {
 	assert.Equal(t, []string{}, splitOrgCodes(""))
 }
@@ -43,11 +55,11 @@ func Test_AuthRepository_HasAction_OrgScoped_SpecificOrg(t *testing.T) {
 	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
 		repo := NewAuthRepository(env.Postgres)
 
-		atGrantedOrg, err := repo.HasAction("alice@test.authz", "radiant", "CHOP", "can_read_pii")
+		atGrantedOrg, err := repo.HasAction(aliceID, "radiant", "CHOP", "can_read_pii")
 		assert.NoError(t, err)
 		assert.True(t, atGrantedOrg, "alice has can_read_pii at her granted org")
 
-		atOtherOrg, err := repo.HasAction("alice@test.authz", "radiant", "CHUSJ", "can_read_pii")
+		atOtherOrg, err := repo.HasAction(aliceID, "radiant", "CHUSJ", "can_read_pii")
 		assert.NoError(t, err)
 		assert.False(t, atOtherOrg, "alice has no grant at CHUSJ")
 	})
@@ -57,11 +69,11 @@ func Test_AuthRepository_HasAction_OrgScoped_Wildcard(t *testing.T) {
 	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
 		repo := NewAuthRepository(env.Postgres)
 
-		atChop, err := repo.HasAction("wendy@test.authz", "radiant", "CHOP", "can_read_pii")
+		atChop, err := repo.HasAction(wendyID, "radiant", "CHOP", "can_read_pii")
 		assert.NoError(t, err)
 		assert.True(t, atChop)
 
-		atChusj, err := repo.HasAction("wendy@test.authz", "radiant", "CHUSJ", "can_read_pii")
+		atChusj, err := repo.HasAction(wendyID, "radiant", "CHUSJ", "can_read_pii")
 		assert.NoError(t, err)
 		assert.True(t, atChusj, "wildcard grant covers every org in the tenant")
 	})
@@ -71,11 +83,11 @@ func Test_AuthRepository_HasAction_TenantScoped_IgnoresOrg(t *testing.T) {
 	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
 		repo := NewAuthRepository(env.Postgres)
 
-		noOrg, err := repo.HasAction("alice@test.authz", "radiant", "", "can_search_case")
+		noOrg, err := repo.HasAction(aliceID, "radiant", "", "can_search_case")
 		assert.NoError(t, err)
 		assert.True(t, noOrg)
 
-		withIrrelevantOrg, err := repo.HasAction("alice@test.authz", "radiant", "CHUSJ", "can_search_case")
+		withIrrelevantOrg, err := repo.HasAction(aliceID, "radiant", "CHUSJ", "can_search_case")
 		assert.NoError(t, err)
 		assert.True(t, withIrrelevantOrg, "org arg is ignored for a tenant-scoped action")
 	})
@@ -86,11 +98,11 @@ func Test_AuthRepository_HasAction_OrgScoped_IsolatedToGrantedOrg(t *testing.T) 
 		repo := NewAuthRepository(env.Postgres)
 
 		// dan is geneticist at CHUSJ only.
-		atOwnOrg, err := repo.HasAction("dan@test.authz", "radiant", "CHUSJ", "can_read_pii")
+		atOwnOrg, err := repo.HasAction(danID, "radiant", "CHUSJ", "can_read_pii")
 		assert.NoError(t, err)
 		assert.True(t, atOwnOrg)
 
-		atOtherOrg, err := repo.HasAction("dan@test.authz", "radiant", "CHOP", "can_read_pii")
+		atOtherOrg, err := repo.HasAction(danID, "radiant", "CHOP", "can_read_pii")
 		assert.NoError(t, err)
 		assert.False(t, atOtherOrg, "dan's grant at CHUSJ must not leak to CHOP")
 	})
@@ -100,11 +112,11 @@ func Test_AuthRepository_HasAction_UnknownActionOrUser(t *testing.T) {
 	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
 		repo := NewAuthRepository(env.Postgres)
 
-		unknownAction, err := repo.HasAction("alice@test.authz", "radiant", "CHOP", "can_do_nothing")
+		unknownAction, err := repo.HasAction(aliceID, "radiant", "CHOP", "can_do_nothing")
 		assert.NoError(t, err)
 		assert.False(t, unknownAction)
 
-		unknownUser, err := repo.HasAction("ghost@test.authz", "radiant", "CHOP", "can_read_pii")
+		unknownUser, err := repo.HasAction(ghostID, "radiant", "CHOP", "can_read_pii")
 		assert.NoError(t, err)
 		assert.False(t, unknownUser)
 	})
@@ -115,7 +127,7 @@ func Test_AuthRepository_HasTenantAccess_Member(t *testing.T) {
 		repo := NewAuthRepository(env.Postgres)
 
 		// alice holds roles in radiant.
-		allowed, err := repo.HasTenantAccess("alice@test.authz", "radiant")
+		allowed, err := repo.HasTenantAccess(aliceID, "radiant")
 		assert.NoError(t, err)
 		assert.True(t, allowed)
 	})
@@ -126,7 +138,7 @@ func Test_AuthRepository_HasTenantAccess_NonMember(t *testing.T) {
 		repo := NewAuthRepository(env.Postgres)
 
 		// alice has no grant in tenant_b.
-		allowed, err := repo.HasTenantAccess("alice@test.authz", "tenant_b")
+		allowed, err := repo.HasTenantAccess(aliceID, "tenant_b")
 		assert.NoError(t, err)
 		assert.False(t, allowed)
 	})
@@ -137,11 +149,11 @@ func Test_AuthRepository_HasTenantAccess_MultiTenantMember(t *testing.T) {
 		repo := NewAuthRepository(env.Postgres)
 
 		// carol belongs to both tenants.
-		inRadiant, err := repo.HasTenantAccess("carol@test.authz", "radiant")
+		inRadiant, err := repo.HasTenantAccess(carolID, "radiant")
 		assert.NoError(t, err)
 		assert.True(t, inRadiant)
 
-		inTenantB, err := repo.HasTenantAccess("carol@test.authz", "tenant_b")
+		inTenantB, err := repo.HasTenantAccess(carolID, "tenant_b")
 		assert.NoError(t, err)
 		assert.True(t, inTenantB)
 	})
@@ -151,7 +163,7 @@ func Test_AuthRepository_HasTenantAccess_UnknownUser(t *testing.T) {
 	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
 		repo := NewAuthRepository(env.Postgres)
 
-		allowed, err := repo.HasTenantAccess("ghost@test.authz", "radiant")
+		allowed, err := repo.HasTenantAccess(ghostID, "radiant")
 		assert.NoError(t, err)
 		assert.False(t, allowed)
 	})
@@ -164,17 +176,17 @@ func Test_AuthRepository_HasTenantAccess_OrgScopeShapesAllCountAsMember(t *testi
 		repo := NewAuthRepository(env.Postgres)
 
 		// wendy's only grant is a wildcard ('*') org role.
-		wildcardOnly, err := repo.HasTenantAccess("wendy@test.authz", "radiant")
+		wildcardOnly, err := repo.HasTenantAccess(wendyID, "radiant")
 		assert.NoError(t, err)
 		assert.True(t, wildcardOnly, "wildcard-org grant counts as membership")
 
 		// dan's only grant is a single specific-org role (CHUSJ).
-		specificOrgOnly, err := repo.HasTenantAccess("dan@test.authz", "radiant")
+		specificOrgOnly, err := repo.HasTenantAccess(danID, "radiant")
 		assert.NoError(t, err)
 		assert.True(t, specificOrgOnly, "specific-org grant counts as membership")
 
 		// alice holds a tenant-wide (org_code NULL) grant alongside an org one.
-		tenantWide, err := repo.HasTenantAccess("alice@test.authz", "radiant")
+		tenantWide, err := repo.HasTenantAccess(aliceID, "radiant")
 		assert.NoError(t, err)
 		assert.True(t, tenantWide, "tenant-wide (NULL org) grant counts as membership")
 	})
@@ -184,7 +196,7 @@ func Test_AuthRepository_GetMemberships_SpecificOrgAndTenantGrants(t *testing.T)
 	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
 		repo := NewAuthRepository(env.Postgres)
 
-		got, err := repo.GetMemberships("alice@test.authz")
+		got, err := repo.GetMemberships(aliceID)
 		assert.NoError(t, err)
 		assert.Equal(t, []types.TenantMembership{
 			{
@@ -209,7 +221,7 @@ func Test_AuthRepository_GetMemberships_WildcardResolvesToAllTenantOrgs(t *testi
 		err := env.Postgres.Raw(`SELECT code FROM organization WHERE tenant_code = ? ORDER BY code`, "radiant").Scan(&radiantOrgs).Error
 		assert.NoError(t, err)
 
-		got, err := repo.GetMemberships("wendy@test.authz")
+		got, err := repo.GetMemberships(wendyID)
 		assert.NoError(t, err)
 		assert.Equal(t, []types.TenantMembership{
 			{
@@ -232,7 +244,7 @@ func Test_AuthRepository_GetMemberships_MixedScopeRole_RoutesByActionScope(t *te
 	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
 		repo := NewAuthRepository(env.Postgres)
 
-		got, err := repo.GetMemberships("pat@test.authz")
+		got, err := repo.GetMemberships(patID)
 		assert.NoError(t, err)
 		assert.Equal(t, []types.TenantMembership{
 			{
@@ -254,7 +266,7 @@ func Test_AuthRepository_GetMemberships_OrgActionGrantedTenantWide_OmittedFromOr
 	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
 		repo := NewAuthRepository(env.Postgres)
 
-		got, err := repo.GetMemberships("tw@test.authz")
+		got, err := repo.GetMemberships(twID)
 		assert.NoError(t, err)
 		assert.Equal(t, []types.TenantMembership{
 			{
@@ -272,15 +284,15 @@ func Test_AuthRepository_HasAction_MixedScopeRole(t *testing.T) {
 		repo := NewAuthRepository(env.Postgres)
 
 		// pat's grant is org-specific (CHUSJ), but a tenant-scoped action applies tenant-wide.
-		tenantAction, err := repo.HasAction("pat@test.authz", "radiant", "", "can_search_case")
+		tenantAction, err := repo.HasAction(patID, "radiant", "", "can_search_case")
 		assert.NoError(t, err)
 		assert.True(t, tenantAction, "tenant-scoped action holds even when checked without an org")
 
-		atGrantedOrg, err := repo.HasAction("pat@test.authz", "radiant", "CHUSJ", "can_read_pii")
+		atGrantedOrg, err := repo.HasAction(patID, "radiant", "CHUSJ", "can_read_pii")
 		assert.NoError(t, err)
 		assert.True(t, atGrantedOrg)
 
-		atOtherOrg, err := repo.HasAction("pat@test.authz", "radiant", "CHOP", "can_read_pii")
+		atOtherOrg, err := repo.HasAction(patID, "radiant", "CHOP", "can_read_pii")
 		assert.NoError(t, err)
 		assert.False(t, atOtherOrg, "org-scoped action stays scoped to the granted org")
 	})
@@ -296,7 +308,7 @@ func Test_AuthRepository_GetMemberships_MultipleTenantsNoCollision(t *testing.T)
 		err := env.Postgres.Raw(`SELECT code FROM organization WHERE tenant_code = ? ORDER BY code`, "radiant").Scan(&radiantOrgs).Error
 		assert.NoError(t, err)
 
-		got, err := repo.GetMemberships("carol@test.authz")
+		got, err := repo.GetMemberships(carolID)
 		assert.NoError(t, err)
 		assert.Equal(t, []types.TenantMembership{
 			{

--- a/backend/internal/server/handlers_auth.go
+++ b/backend/internal/server/handlers_auth.go
@@ -23,12 +23,12 @@ import (
 // @Router /auth/me [get]
 func GetMeHandler(repo repository.AuthRepositoryDAO, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		email, err := auth.RetrieveEmailFromToken(c)
+		userID, err := auth.RetrieveUserIdFromToken(c)
 		if err != nil {
 			HandleUnauthorizedError(c)
 			return
 		}
-		memberships, err := repo.GetMemberships(*email)
+		memberships, err := repo.GetMemberships(*userID)
 		if err != nil {
 			HandleError(c, err)
 			return

--- a/backend/internal/server/middlewares.go
+++ b/backend/internal/server/middlewares.go
@@ -25,14 +25,14 @@ func RequireTenantAccess(auth utils.Auth, repo repository.AuthRepositoryDAO, enf
 		tenant := c.Param("tenant")
 
 		if enforce {
-			email, err := auth.RetrieveEmailFromToken(c)
+			userID, err := auth.RetrieveUserIdFromToken(c)
 			if err != nil {
 				HandleUnauthorizedError(c)
 				c.Abort()
 				return
 			}
 
-			allowed, err := repo.HasTenantAccess(*email, tenant)
+			allowed, err := repo.HasTenantAccess(*userID, tenant)
 			if err != nil {
 				HandleError(c, err)
 				c.Abort()

--- a/backend/internal/server/middlewares_test.go
+++ b/backend/internal/server/middlewares_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// mockUserID stands in for a Keycloak sub (uuid). These tests use a stubbed repo, so the
+// value isn't looked up — it just needs to be a realistic user_id.
+const mockUserID = "25286548-fbef-4e93-b3c4-c659e6169396"
+
 // tenantTestRouter wires RequireTenantAccess in front of a handler that echoes the resolved
 // tenant, so tests can assert both the gate's status code and what it stored in context.
 func tenantTestRouter(repo *mockAuthRepository, auth *testutils.MockAuth, enforce bool) *gin.Engine {
@@ -30,7 +34,7 @@ func tenantTestRouter(repo *mockAuthRepository, auth *testutils.MockAuth, enforc
 
 func Test_RequireTenantAccess_Member_PassesAndSetsContext(t *testing.T) {
 	repo := &mockAuthRepository{hasTenantAccess: true}
-	auth := &testutils.MockAuth{Email: "alice@test.authz"}
+	auth := &testutils.MockAuth{Id: mockUserID}
 	router := tenantTestRouter(repo, auth, true)
 
 	req, _ := http.NewRequest("GET", "/radiant/cases/filters", nil)
@@ -43,7 +47,7 @@ func Test_RequireTenantAccess_Member_PassesAndSetsContext(t *testing.T) {
 
 func Test_RequireTenantAccess_NonMember_Returns403(t *testing.T) {
 	repo := &mockAuthRepository{hasTenantAccess: false}
-	auth := &testutils.MockAuth{Email: "alice@test.authz"}
+	auth := &testutils.MockAuth{Id: mockUserID}
 	router := tenantTestRouter(repo, auth, true)
 
 	req, _ := http.NewRequest("GET", "/tenant_b/cases/filters", nil)
@@ -53,7 +57,7 @@ func Test_RequireTenantAccess_NonMember_Returns403(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
-func Test_RequireTenantAccess_EmailError_Returns401(t *testing.T) {
+func Test_RequireTenantAccess_TokenError_Returns401(t *testing.T) {
 	repo := &mockAuthRepository{hasTenantAccess: true}
 	auth := &testutils.MockAuth{Error: fmt.Errorf("no token")}
 	router := tenantTestRouter(repo, auth, true)
@@ -67,7 +71,7 @@ func Test_RequireTenantAccess_EmailError_Returns401(t *testing.T) {
 
 func Test_RequireTenantAccess_RepoError_Returns500(t *testing.T) {
 	repo := &mockAuthRepository{tenantErr: fmt.Errorf("db down")}
-	auth := &testutils.MockAuth{Email: "alice@test.authz"}
+	auth := &testutils.MockAuth{Id: mockUserID}
 	router := tenantTestRouter(repo, auth, true)
 
 	req, _ := http.NewRequest("GET", "/radiant/cases/filters", nil)
@@ -82,7 +86,7 @@ func Test_RequireTenantAccess_RepoError_Returns500(t *testing.T) {
 // before users are backfilled).
 func Test_RequireTenantAccess_EnforcementDisabled_AllowsAndSetsContext(t *testing.T) {
 	repo := &mockAuthRepository{hasTenantAccess: false, tenantErr: fmt.Errorf("must not be called")}
-	auth := &testutils.MockAuth{Email: "alice@test.authz"}
+	auth := &testutils.MockAuth{Id: mockUserID}
 	router := tenantTestRouter(repo, auth, false)
 
 	req, _ := http.NewRequest("GET", "/tenant_b/cases/filters", nil)

--- a/backend/internal/utils/auth.go
+++ b/backend/internal/utils/auth.go
@@ -19,7 +19,6 @@ type Auth interface {
 	RetrieveAzpFromToken(c *gin.Context) (*string, error)
 	RetrieveResourceAccessFromToken(c *gin.Context) (*map[string]ginkeycloak.ServiceRole, error)
 	RetrieveUsernameFromToken(c *gin.Context) (*string, error)
-	RetrieveEmailFromToken(c *gin.Context) (*string, error)
 	RetrieveFullNameFromToken(c *gin.Context) (*string, error)
 	UserHasRole(c *gin.Context, role string, resourceName string) (bool, error)
 }
@@ -70,18 +69,6 @@ func (auth KeycloakAuth) RetrieveUsernameFromToken(c *gin.Context) (*string, err
 		return nil, err
 	}
 	return &token.PreferredUsername, nil
-}
-
-func (auth KeycloakAuth) RetrieveEmailFromToken(c *gin.Context) (*string, error) {
-	token, err := getOrParseToken(c)
-	if err != nil {
-		return nil, err
-	}
-	// Normalize to lower case so authz lookups keyed by email (HasAction, HasTenantAccess,
-	// GetMemberships) match regardless of the case the IdP emits. The user backfill must
-	// store emails lower-cased too.
-	email := strings.ToLower(token.Email)
-	return &email, nil
 }
 
 func (auth KeycloakAuth) RetrieveFullNameFromToken(c *gin.Context) (*string, error) {

--- a/backend/internal/utils/auth_test.go
+++ b/backend/internal/utils/auth_test.go
@@ -190,62 +190,6 @@ func Test_RetrieveUsernameFromToken_ValidJWT(t *testing.T) {
 	assert.Equal(t, "superbob", *username)
 }
 
-func Test_RetrieveEmailFromToken_ValidKeycloakToken(t *testing.T) {
-	c := gin.Context{}
-	c.Set("token", ginkeycloak.KeyCloakToken{Email: "testuser@example.com"})
-
-	auth := KeycloakAuth{}
-	email, err := auth.RetrieveEmailFromToken(&c)
-
-	assert.NoError(t, err)
-	assert.NotNil(t, email)
-	assert.Equal(t, "testuser@example.com", *email)
-}
-
-func Test_RetrieveEmailFromToken_LowerCasesEmail(t *testing.T) {
-	c := gin.Context{}
-	c.Set("token", ginkeycloak.KeyCloakToken{Email: "TestUser@Example.COM"})
-
-	auth := KeycloakAuth{}
-	email, err := auth.RetrieveEmailFromToken(&c)
-
-	assert.NoError(t, err)
-	assert.NotNil(t, email)
-	assert.Equal(t, "testuser@example.com", *email, "email is normalized to lower case")
-}
-
-func Test_RetrieveEmailFromToken_ValidJWT(t *testing.T) {
-	c := gin.Context{}
-
-	token, err := jwt.GenerateMockJWT("radiant", []string{DataManagerRole})
-	assert.NoError(t, err)
-
-	c.Request = &http.Request{
-		Header: http.Header{
-			"Authorization": []string{fmt.Sprintf("Bearer %s", token)},
-		},
-	}
-
-	auth := KeycloakAuth{}
-	email, err := auth.RetrieveEmailFromToken(&c)
-
-	assert.NoError(t, err)
-	assert.NotNil(t, email)
-	assert.Equal(t, "bob@bobson.com", *email)
-}
-
-func Test_RetrieveEmailFromToken_NoTokenInContext(t *testing.T) {
-	c := gin.Context{
-		Request: &http.Request{},
-	}
-
-	auth := KeycloakAuth{}
-	email, err := auth.RetrieveEmailFromToken(&c)
-
-	assert.Error(t, err)
-	assert.Nil(t, email)
-}
-
 func Test_RetrieveUsernameFromToken_InvalidKeycloakTokenType(t *testing.T) {
 	c := gin.Context{}
 	c.Set("token", 12345)

--- a/backend/scripts/init-sql/migrations/000011_rekey_users_by_user_id.up.sql
+++ b/backend/scripts/init-sql/migrations/000011_rekey_users_by_user_id.up.sql
@@ -1,0 +1,44 @@
+-- Re-key identity from email to user_id (the Keycloak `sub`).
+--
+-- Migration 000009 keyed users by email (the identifier known at invite time,
+-- before first login). We now make user_id the required, unique identity and
+-- demote email to an optional attribute. Consequence: a user must exist in
+-- Keycloak (have a `sub`) before they can be granted roles — pre-provisioning by
+-- email alone is no longer possible. The backfill source (cmd/migrate-authdb)
+-- reads the Keycloak admin API, which supplies `sub` for every user, so this is a
+-- natural fit and lets users without an email be migrated.
+--
+-- Data-safe: public.users and public.user_role are empty in every environment
+-- (the backfill has not run yet), so no row migration is required.
+
+-- The user_role → users(email) FK must go before users' email PK can be dropped.
+ALTER TABLE public.user_role DROP CONSTRAINT user_role_email_fkey;
+
+-- =============================================================================
+-- 1. users: user_id becomes the identity; email becomes an optional attribute.
+-- =============================================================================
+ALTER TABLE public.users DROP CONSTRAINT users_pkey;        -- was PRIMARY KEY (email)
+ALTER TABLE public.users ALTER COLUMN email DROP NOT NULL;  -- PK implied NOT NULL; lift it
+ALTER TABLE public.users ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE public.users ADD CONSTRAINT users_pkey PRIMARY KEY (user_id);
+
+-- =============================================================================
+-- 2. user_role: re-key from email to user_id.
+-- =============================================================================
+-- The two partial unique indexes are keyed on email; drop them before the column.
+DROP INDEX public.user_role_unique_org_grant;
+DROP INDEX public.user_role_unique_tenant_grant;
+
+ALTER TABLE public.user_role ADD COLUMN user_id varchar(255);
+ALTER TABLE public.user_role ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE public.user_role DROP COLUMN email;
+ALTER TABLE public.user_role
+    ADD CONSTRAINT user_role_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(user_id);
+
+-- Recreate uniqueness on (user_id, ...) — same two-partial-index trick as 000009
+-- (PG 14 lacks NULLS NOT DISTINCT): one index for org-scoped grants, one for
+-- tenant-wide grants (org_code IS NULL).
+CREATE UNIQUE INDEX user_role_unique_org_grant ON public.user_role
+    (user_id, tenant_code, role_code, org_code) WHERE org_code IS NOT NULL;
+CREATE UNIQUE INDEX user_role_unique_tenant_grant ON public.user_role
+    (user_id, tenant_code, role_code) WHERE org_code IS NULL;

--- a/backend/test/data/auth/05_users.sql
+++ b/backend/test/data/auth/05_users.sql
@@ -1,8 +1,10 @@
-INSERT INTO users (email)
-VALUES ('alice@test.authz'),
-       ('wendy@test.authz'),
-       ('dan@test.authz'),
-       ('carol@test.authz'),
-       ('pat@test.authz'),
-       ('tw@test.authz')
-ON CONFLICT (email) DO NOTHING;
+-- Users keyed by user_id (the Keycloak `sub`, a uuid). Email/first_name/last_name are
+-- optional attributes; the email keeps each row recognizable.
+INSERT INTO users (user_id, email, first_name, last_name)
+VALUES ('25286548-fbef-4e93-b3c4-c659e6169396', 'alice@test.authz', 'Alice', 'Adams'),
+       ('79a8855e-3782-4dc8-be2a-8afdb34d6359', 'wendy@test.authz', 'Wendy', 'Walsh'),
+       ('e10fee0b-063b-4dcd-b086-90d1c9eb239d', 'dan@test.authz',   'Dan',   'Doyle'),
+       ('b6e6d0dd-7aa5-4018-ae03-1f5076801360', 'carol@test.authz', 'Carol', 'Cohen'),
+       ('6c330322-c746-4436-bb76-efd2cd943686', 'pat@test.authz',   'Pat',   'Patel'),
+       ('4a330f72-24a1-4d37-8ad7-ff9989245fd3', 'tw@test.authz',    'Tess',  'West')
+ON CONFLICT (user_id) DO NOTHING;

--- a/backend/test/data/auth/06_user_role.sql
+++ b/backend/test/data/auth/06_user_role.sql
@@ -6,13 +6,14 @@
 --   carol: wildcard geneticist [radiant] + wildcard geneticist & researcher [tenant_b]
 --   pat:   mixed-scope practitioner at a specific org (CHUSJ)                 [radiant]
 --   tw:    mixed-scope practitioner granted tenant-wide (org_code NULL)       [radiant]
-INSERT INTO user_role (email, tenant_code, org_code, role_code)
-VALUES ('alice@test.authz', 'radiant',  'CHOP',  'geneticist'),
-       ('alice@test.authz', 'radiant',  NULL,    'researcher'),
-       ('wendy@test.authz', 'radiant',  '*',     'geneticist'),
-       ('dan@test.authz',   'radiant',  'CHUSJ', 'geneticist'),
-       ('carol@test.authz', 'radiant',  '*',     'geneticist'),
-       ('carol@test.authz', 'tenant_b', '*',     'geneticist'),
-       ('carol@test.authz', 'tenant_b', NULL,    'researcher'),
-       ('pat@test.authz',   'radiant',  'CHUSJ', 'practitioner'),
-       ('tw@test.authz',    'radiant',  NULL,    'practitioner');
+-- user_id values are the uuids seeded in 05_users.sql.
+INSERT INTO user_role (user_id, tenant_code, org_code, role_code)
+VALUES ('25286548-fbef-4e93-b3c4-c659e6169396', 'radiant',  'CHOP',  'geneticist'),   -- alice
+       ('25286548-fbef-4e93-b3c4-c659e6169396', 'radiant',  NULL,    'researcher'),   -- alice
+       ('79a8855e-3782-4dc8-be2a-8afdb34d6359', 'radiant',  '*',     'geneticist'),   -- wendy
+       ('e10fee0b-063b-4dcd-b086-90d1c9eb239d', 'radiant',  'CHUSJ', 'geneticist'),   -- dan
+       ('b6e6d0dd-7aa5-4018-ae03-1f5076801360', 'radiant',  '*',     'geneticist'),   -- carol
+       ('b6e6d0dd-7aa5-4018-ae03-1f5076801360', 'tenant_b', '*',     'geneticist'),   -- carol
+       ('b6e6d0dd-7aa5-4018-ae03-1f5076801360', 'tenant_b', NULL,    'researcher'),   -- carol
+       ('6c330322-c746-4436-bb76-efd2cd943686', 'radiant',  'CHUSJ', 'practitioner'), -- pat
+       ('4a330f72-24a1-4d37-8ad7-ff9989245fd3', 'radiant',  NULL,    'practitioner'); -- tw

--- a/backend/test/testutils/mock_auth.go
+++ b/backend/test/testutils/mock_auth.go
@@ -10,7 +10,6 @@ import (
 const (
 	DefaultMockUserId   = "1"
 	DefaultMockUsername = "mock-username"
-	DefaultMockEmail    = "mock-user@example.com"
 	DefaultMockFullName = "Mock User"
 	DefaultMockAzp      = "mock-azp"
 	DefaultMockRole     = "mock-role"
@@ -19,7 +18,6 @@ const (
 type MockAuth struct {
 	Id             string
 	Username       string
-	Email          string
 	Name           string
 	Azp            string
 	ResourceAccess map[string]ginkeycloak.ServiceRole
@@ -72,17 +70,6 @@ func (m *MockAuth) RetrieveUsernameFromToken(c *gin.Context) (*string, error) {
 		return &result, nil
 	}
 	return &m.Username, nil
-}
-
-func (m *MockAuth) RetrieveEmailFromToken(c *gin.Context) (*string, error) {
-	if m.Error != nil {
-		return nil, m.Error
-	}
-	if m.Email == "" {
-		result := DefaultMockEmail
-		return &result, nil
-	}
-	return &m.Email, nil
 }
 
 func (m *MockAuth) RetrieveFullNameFromToken(c *gin.Context) (*string, error) {

--- a/docs/adr/multi-tenancy-security.md
+++ b/docs/adr/multi-tenancy-security.md
@@ -338,6 +338,10 @@ A dedicated database in StarRocks holds the entire authorization model:
 | `auth_db.user_tenant_role(username, tenant_id, role_id)` | Tenant-scoped role assignments |
 | `auth_db.user_org_role(username, tenant_id, org_id, role_id)` | Org-scoped role assignments; `org_id = '*'` means all orgs in tenant |
 
+> **Implementation amendment (as shipped).** The delivered schema diverges from this proposal in two ways; the live source of truth is `backend/scripts/init-sql/migrations/` + `backend/CLAUDE.md`:
+> - **Natural keys, single grant table.** Identifiers are `varchar` `*_code` natural keys (no integer `*_id`). The two assignment tables collapsed into one `user_role(user_id, tenant_code, org_code, role_code)`, where `org_code` is `NULL` (tenant-wide), `'*'` (all orgs), or a specific code (migration `000009`).
+> - **Identity keyed by `user_id` (Keycloak `sub`).** `users` is keyed by `user_id` — required and unique — with `email`/`first_name`/`last_name` as optional attributes (migration `000011_rekey_users_by_user_id`). `000009` first keyed users by `email` (to allow pre-provisioning by invite before first login); that was reversed because the canonical, stable identifier is the Keycloak `sub`. **Consequence:** a user must exist in Keycloak before they can be granted roles — no email-only pre-provisioning.
+
 Granting and revoking happens through the admin API:
 - `auth_db.user_tenant_role` / `user_org_role` rows are inserted or deleted (the source-of-truth write).
 - The admin API mirrors that change in Ranger as a side-effect — `CREATE USER IF NOT EXISTS` on StarRocks, register the user in Ranger, and add/remove them from `<tenant>_member` and `authenticated` Ranger roles. This Ranger membership is purely a derived projection of `auth_db` and can be rebuilt at any time by re-walking the auth_db assignment tables.


### PR DESCRIPTION
## 📌 Context

The authorization identity model was keyed by **email** (migration `000009`), originally to allow pre-provisioning a user by invite before their first login. We're reversing that: the canonical, stable identifier is the Keycloak `sub`. Email can change and isn't guaranteed; keying on `sub` also removes the email case-sensitivity/normalization fragility and matches the `user_id` column already used by `saved_filter` / `user_preference` / `user_set` / `occurrence_note`.

This PR re-keys `users` and `user_role` to **`user_id`** (required, unique); `email` / `first_name` / `last_name` become optional attributes. Authz lookups (`HasAction`, `HasTenantAccess`, `GetMemberships`) and the tenant middleware now resolve the caller by `sub` rather than email.

**Behavioral consequence:** a user must exist in Keycloak (have a `sub`) before they can be granted roles — there is no more email-only pre-provisioning before first login. Enforcement is still gated by `TENANT_ENFORCEMENT_ENABLED` (default off), so nothing locks out today.

## 📝 Changes

- **Migration `000011_rekey_users_by_user_id.up.sql`**: `users` PK `email` → `user_id` (`NOT NULL`), `email` now nullable/non-unique; `user_role` drops the `email` column + FK and adds `user_id NOT NULL` FK → `users(user_id)`; the two partial unique indexes recreated on `(user_id, tenant_code, role_code[, org_code])`. Data-safe — both tables are empty in every environment.
- `internal/repository/auth.go`: queries filter `ur.user_id` instead of `ur.email`; interface params renamed.
- `internal/server/middlewares.go` + `handlers_auth.go`: resolve the caller via `RetrieveUserIdFromToken` (the `sub`).
- Removed `RetrieveEmailFromToken` entirely (interface, `KeycloakAuth`, `MockAuth` + its `Email` field / `DefaultMockEmail`) — no remaining callers.
- Fixtures `test/data/auth/05_users.sql` / `06_user_role.sql`: keyed by real UUIDs, with `email`/`first_name`/`last_name` attributes for readability.
- Tests (`auth_test.go`, `auth_integration_test.go`, `middlewares_test.go`): use named UUID consts (`aliceID`, …).
- Docs: `backend/CLAUDE.md` and the multi-tenancy ADR updated to reflect `user_id` keying and the pre-provisioning consequence.

## ☑️ TO-DOs

- [x] Confirm the pre-provisioning reversal is acceptable with stakeholders (no email-before-first-login).

## 🧪 Tests

- Updated the authz repository, handler, middleware, and integration tests to key by `user_id`.
- Passing locally: `internal/repository` (auth), `internal/server`, `cmd/api`, `internal/utils`.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1573](https://d3b.atlassian.net/browse/SJRA-1573)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- Migration is up-only and assumes `users`/`user_role` are empty (true in all envs, since the backfill hasn't run yet); it is not written to migrate existing rows.

[SJRA-1573]: https://d3b.atlassian.net/browse/SJRA-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ