### PR TITLE
fix: SJRA-1577 fix missing default tenant

### DIFF
--- a/frontend/components/base/query-builder/hooks/use-aggregation-builder.tsx
+++ b/frontend/components/base/query-builder/hooks/use-aggregation-builder.tsx
@@ -96,7 +96,14 @@ export function useGermlineSNVAggregationBuilder({
     data,
     async () =>
       occurrencesApi
-        .aggregateGermlineSNVOccurrences(caseId, seqId, taskId!, data!.aggregationBody, data!.withDictionary)
+        .aggregateGermlineSNVOccurrences(
+          DEFAULT_TENANT,
+          caseId,
+          seqId,
+          taskId!,
+          data!.aggregationBody,
+          data!.withDictionary,
+        )
         .then(response => response.data),
     {
       revalidateOnFocus: false,
@@ -234,7 +241,14 @@ export function useSomaticSNVAggregationBuilder({
     data,
     async () =>
       occurrencesApi
-        .aggregateSomaticSNVOccurrences(caseId, seqId, taskId!, data!.aggregationBody, data!.withDictionary)
+        .aggregateSomaticSNVOccurrences(
+          DEFAULT_TENANT,
+          caseId,
+          seqId,
+          taskId!,
+          data!.aggregationBody,
+          data!.withDictionary,
+        )
         .then(response => response.data),
     {
       revalidateOnFocus: false,


### PR DESCRIPTION
## 📌 Context

Two aggregation fetchers in `use-aggregation-builder.tsx` were calling the
occurrence API without that leading tenant argument, shifting every subsequent
argument by one position (`caseId` landing in the `tenant` slot, etc.) and
producing incorrect requests.

## 📝 Changes

- `frontend/components/base/query-builder/hooks/use-aggregation-builder.tsx`:
  pass `DEFAULT_TENANT` as the first argument to
  `occurrencesApi.aggregateGermlineSNVOccurrences` and
  `occurrencesApi.aggregateSomaticSNVOccurrences`, matching the other
  tenant-scoped calls in the file.

## ☑️ TO-DOs

- [ ] Code review

## 🧪 Tests

- `npm run typecheck` (portals/radiant): no `TS2345`/`TS2554` argument errors remain;
  remaining errors are pre-existing `verbatimModuleSyntax` warnings unrelated to this change.
- Swept the rest of the frontend for the same issue — the type checker confirms
  every other tenant-scoped API call already passes a tenant, and there are no
  hardcoded tenant strings outside the `DEFAULT_TENANT` constant.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1577](https://d3b.atlassian.net/browse/SJRA-1577)<!-- End JIRA Issues -->


[SJRA-1577]: https://d3b.atlassian.net/browse/SJRA-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ