### PR TITLE
fix: SJRA-1578 return 500 instead of 200 on handler panic

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -65,20 +65,7 @@ func setupRouter(dbStarrocks *gorm.DB, dbPostgres *gorm.DB) *gin.Engine {
 	repoTasks := repository.NewTaskRepository(dbPostgres)
 	repoAuth := repository.NewAuthRepository(dbPostgres)
 
-	r := gin.Default()
-	r.Use(gzip.Gzip(gzip.DefaultCompression))
-
-	r.Use(ginglog.Logger(3 * time.Second))
-	r.Use(ginkeycloak.RequestLogger([]string{"uid"}, "data"))
-
-	var corsAllowedOrigins = strings.Split(os.Getenv("CORS_ALLOWED_ORIGINS"), ",")
-
-	r.Use(cors.New(cors.Config{
-		AllowOrigins:     corsAllowedOrigins,
-		AllowMethods:     []string{"GET", "POST", "PUT", "OPTIONS"},
-		AllowHeaders:     []string{"Accept", "Authorization", "Content-Type"},
-		AllowCredentials: true, // Enable cookies/auth
-	}))
+	r := newEngine()
 
 	roleAccessMiddleware, err := authorization.InitAuthorizer()
 	if err != nil {
@@ -238,7 +225,35 @@ func setupRouter(dbStarrocks *gorm.DB, dbPostgres *gorm.DB) *gin.Engine {
 		casesGroup.PATCH("/batch", server.PatchCaseBatchHandler(repoBatches, auth))
 	}
 
-	r.Use(gin.Recovery())
+	return r
+}
+
+// newEngine builds the gin engine with the global middleware stack in the correct order.
+//
+// gin.Recovery() MUST be the innermost (last-registered) global middleware. On a handler
+// panic, defers unwind LIFO: the gzip middleware's deferred gz.Close() flushes the gzip
+// footer to the response, which commits a 200 status. If Recovery sits outside gzip (as it
+// did when this used gin.Default(), which registers Recovery before gzip is added), it runs
+// after that flush and can no longer override the status — the client gets 200 instead of
+// 500 ("Headers were already written. Wanted to override status code 200 with 500"). By
+// registering Recovery after gzip, it recovers and sets 500 first, then gzip compresses the
+// 500 response. See SJRA-1578.
+func newEngine() *gin.Engine {
+	r := gin.New()
+	r.Use(gin.Logger())
+	r.Use(gzip.Gzip(gzip.DefaultCompression))
+	r.Use(ginglog.Logger(3 * time.Second))
+	r.Use(ginkeycloak.RequestLogger([]string{"uid"}, "data"))
+
+	var corsAllowedOrigins = strings.Split(os.Getenv("CORS_ALLOWED_ORIGINS"), ",")
+	r.Use(cors.New(cors.Config{
+		AllowOrigins:     corsAllowedOrigins,
+		AllowMethods:     []string{"GET", "POST", "PUT", "OPTIONS"},
+		AllowHeaders:     []string{"Accept", "Authorization", "Content-Type"},
+		AllowCredentials: true, // Enable cookies/auth
+	}))
+
+	r.Use(gin.Recovery()) // innermost global middleware — see doc comment above
 	return r
 }
 

--- a/backend/cmd/api/recovery_test.go
+++ b/backend/cmd/api/recovery_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_Recovery_PanicReturns500WithGzip guards the middleware ordering: a handler panic must
+// surface as HTTP 500 even when gzip is active. Before the fix (gin.Default() put Recovery
+// outside gzip), gzip's deferred gz.Close() committed a 200 status during panic unwind and
+// Recovery could no longer override it, so the client wrongly got 200. See SJRA-1578.
+func Test_Recovery_PanicReturns500WithGzip(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	os.Setenv("CORS_ALLOWED_ORIGINS", "*")
+	defer os.Unsetenv("CORS_ALLOWED_ORIGINS")
+
+	r := newEngine()
+	r.GET("/panic", func(c *gin.Context) {
+		panic("boom")
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	// Accept-Encoding: gzip is essential — the bug only manifests when the gzip middleware
+	// compresses (and thereby flushes) the response on the way out.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}


### PR DESCRIPTION
## 📌 Context

A handler panic in QA (`POST /cases/search`, a nil-pointer in the repository layer) was returned to the client as **HTTP 200** instead of **500**. Gin logged the smoking gun:

```
[GIN-debug] [WARNING] Headers were already written. Wanted to override status code 200 with 500
```

This means failures silently look successful to clients and monitoring — the real issue, independent of whatever triggered the panic.

**Root cause — middleware ordering.** `gin.Default()` registers `Logger` + `Recovery`, and gzip was added *after* it, so `Recovery` wrapped gzip (sat outside it). On a panic, defers unwind LIFO: gzip's deferred `gz.Close()` flushes the gzip footer first, committing a `200` status, and `Recovery` then runs too late to override it. The trailing `r.Use(gin.Recovery())` was also a no-op — added after all routes were registered, it never joined any route's handler chain.

## 📝 Changes

- Replace `gin.Default()` with a new `newEngine()` helper built on `gin.New()`, registering `gin.Recovery()` as the **innermost** (last) global middleware — after gzip — so it sets `500` before gzip flushes the response.
- Remove the no-op trailing `r.Use(gin.Recovery())`.
- Extract middleware setup into `newEngine()` so it's unit-testable without DB args.

## ☑️ TO-DOs

- [ ] Follow-up ticket for the underlying nil-pointer dereference in the cases repository (the panic's origin) — out of scope here.

## 🧪 Tests

- New `backend/cmd/api/recovery_test.go`: a panicking route requested with `Accept-Encoding: gzip` must return `500`. Fast, DB-free.

```bash
cd backend
go build ./...
go test ./cmd/api/ -run Test_Recovery -v
```

Result: PASS — the panic now returns `500` (`| 500 | ... GET /panic`).

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1578](https://d3b.atlassian.net/browse/SJRA-1578)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- `gin.Default()` == `gin.New()` + `Logger` + `Recovery`. `gin.Logger()` is kept as the outermost middleware to preserve current request logging; `ginglog` and the keycloak logger are unchanged.
- The ordering invariant is documented in a doc comment on `newEngine()` so it isn't accidentally reverted.


[SJRA-1578]: https://d3b.atlassian.net/browse/SJRA-1578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ