### PR TITLE
feat: SJRA-1447 add default roles for users backfill

### DIFF
--- a/backend/cmd/api/auth_integration_test.go
+++ b/backend/cmd/api/auth_integration_test.go
@@ -43,6 +43,8 @@ func Test_GetMeHandler_SeededUser(t *testing.T) {
 		"name": "Radiant",
 		"tenant_actions": ["can_search_case", "can_view_kb"],
 		"orgs_by_action": {
+			"can_comment_variant": ["CHOP"],
+			"can_flag_variant": ["CHOP"],
 			"can_interpret_variant": ["CHOP"],
 			"can_read_pii": ["CHOP"]
 		}

--- a/backend/internal/repository/auth_test.go
+++ b/backend/internal/repository/auth_test.go
@@ -206,6 +206,8 @@ func Test_AuthRepository_GetMemberships_SpecificOrgAndTenantGrants(t *testing.T)
 				Name:          "Radiant",
 				TenantActions: []string{"can_search_case", "can_view_kb"},
 				OrgsByAction: map[string][]string{
+					"can_comment_variant":   {"CHOP"},
+					"can_flag_variant":      {"CHOP"},
 					"can_interpret_variant": {"CHOP"},
 					"can_read_pii":          {"CHOP"},
 				},
@@ -231,6 +233,8 @@ func Test_AuthRepository_GetMemberships_WildcardResolvesToAllTenantOrgs(t *testi
 				Name:          "Radiant",
 				TenantActions: []string{},
 				OrgsByAction: map[string][]string{
+					"can_comment_variant":   radiantOrgs,
+					"can_flag_variant":      radiantOrgs,
 					"can_interpret_variant": radiantOrgs,
 					"can_read_pii":          radiantOrgs,
 				},
@@ -318,6 +322,8 @@ func Test_AuthRepository_GetMemberships_MultipleTenantsNoCollision(t *testing.T)
 				Name:          "Radiant",
 				TenantActions: []string{},
 				OrgsByAction: map[string][]string{
+					"can_comment_variant":   radiantOrgs,
+					"can_flag_variant":      radiantOrgs,
 					"can_interpret_variant": radiantOrgs,
 					"can_read_pii":          radiantOrgs,
 				},

--- a/backend/scripts/init-sql/migrations/000012_seed_radiant_roles.up.sql
+++ b/backend/scripts/init-sql/migrations/000012_seed_radiant_roles.up.sql
@@ -1,0 +1,51 @@
+-- Seed the role catalog for the `radiant` tenant.
+--
+-- Migration 000009 created the tenant + action catalog but intentionally seeded
+-- NO roles ("tenants define their own"). Before the user backfill (cmd/migrate-authdb)
+-- can grant anything, the roles those grants reference must exist. This migration
+-- defines the three roles that encode the two authorization use-cases that exist
+-- today, plus the read/interpret split:
+--
+--   member       — base "see data" role: search cases, view the knowledge base,
+--                  download files. Every existing portal user gets this.
+--   geneticist   — clinical write/PII role: read PII, interpret/comment/flag
+--                  variants. Granted alongside `member` to existing users to
+--                  preserve today's full-portal behaviour; kept as a separate
+--                  role so read-only users can be split off later without
+--                  touching this catalog.
+--   data_manager — batch-ingestion role (maps the Keycloak `data_manager` role):
+--                  submit batches. Granted on top of member+geneticist to users
+--                  who hold the Keycloak `data_manager` client role.
+--
+-- Data-safe and idempotent: ON CONFLICT DO NOTHING throughout, so re-running on a
+-- database that already has these rows is a no-op. Action codes reference the
+-- catalog seeded in 000009; scope (org vs tenant) is a property of the action, not
+-- the role_action row.
+
+-- =============================================================================
+-- 1. Roles (per-tenant catalog)
+-- =============================================================================
+INSERT INTO public.role (tenant_code, code, name, description) VALUES
+    ('radiant', 'member',       'Member',       'Search cases, view the knowledge base, and download files.'),
+    ('radiant', 'geneticist',   'Geneticist',   'Read PII and interpret, comment on, and flag variants.'),
+    ('radiant', 'data_manager', 'Data Manager', 'Submit batches (cases, patients, samples, sequencing).')
+ON CONFLICT (tenant_code, code) DO NOTHING;
+
+-- =============================================================================
+-- 2. Role → action mappings
+-- =============================================================================
+INSERT INTO public.role_action (tenant_code, role_code, action_code) VALUES
+    -- member: read-only portal access
+    ('radiant', 'member',       'can_search_case'),    -- tenant-scoped
+    ('radiant', 'member',       'can_view_kb'),         -- tenant-scoped
+    ('radiant', 'member',       'can_download_file'),   -- org-scoped
+
+    -- geneticist: PII + clinical writes
+    ('radiant', 'geneticist',   'can_read_pii'),        -- org-scoped
+    ('radiant', 'geneticist',   'can_interpret_variant'),-- org-scoped
+    ('radiant', 'geneticist',   'can_comment_variant'), -- org-scoped
+    ('radiant', 'geneticist',   'can_flag_variant'),    -- org-scoped
+
+    -- data_manager: batch ingestion
+    ('radiant', 'data_manager', 'can_ingest_data')      -- org-scoped
+ON CONFLICT (tenant_code, role_code, action_code) DO NOTHING;

--- a/backend/test/data/auth/03_role.sql
+++ b/backend/test/data/auth/03_role.sql
@@ -1,9 +1,12 @@
 -- geneticist is an org-scoped domain role; researcher is tenant-scoped. Roles are
 -- per-tenant (PK is tenant_code + code), so the same names exist in both tenants.
 -- practitioner is a mixed-scope role: it maps both org-scoped and tenant-scoped actions.
+--
+-- The radiant `geneticist` role is NOT defined here: it is seeded as a real role by
+-- migration 000012. These tests reuse that seeded role (and its action set) rather than redefining it
+-- tenant_b keeps its own geneticist because tenant_b is a test-only tenant the migration doesn't seed.
 INSERT INTO role (tenant_code, code, name)
-VALUES ('radiant',  'geneticist',   'Geneticist'),
-       ('radiant',  'researcher',   'Researcher'),
+VALUES ('radiant',  'researcher',   'Researcher'),
        ('radiant',  'practitioner', 'Practitioner'),
        ('tenant_b', 'geneticist',   'Geneticist'),
        ('tenant_b', 'researcher',   'Researcher')

--- a/backend/test/data/auth/04_role_action.sql
+++ b/backend/test/data/auth/04_role_action.sql
@@ -1,9 +1,12 @@
 -- Actions are seeded by migration 000009. Org-scoped actions go to the geneticist
 -- role, tenant-scoped actions to the researcher role, in each tenant.
+--
+-- No rows for radiant/geneticist: that role and its actions are seeded by migration
+-- 000012 (can_read_pii, can_interpret_variant, can_comment_variant, can_flag_variant);
+-- the radiant tests reuse the seeded set. tenant_b/geneticist is a test-only role and
+-- defines its own actions below.
 INSERT INTO role_action (tenant_code, role_code, action_code)
-VALUES ('radiant',  'geneticist', 'can_read_pii'),
-       ('radiant',  'geneticist', 'can_interpret_variant'),
-       ('radiant',  'researcher', 'can_search_case'),
+VALUES ('radiant',  'researcher', 'can_search_case'),
        ('radiant',  'researcher', 'can_view_kb'),
        ('tenant_b', 'geneticist', 'can_read_pii'),
        ('tenant_b', 'geneticist', 'can_interpret_variant'),


### PR DESCRIPTION
# feat: SJRA-1447 seed radiant role catalog for authorization

## 📌 Context

The authorization model (migration `000009`) seeds the `radiant` tenant and the 8 `can_*` actions, but **no roles** — tenants define their own. Before `TENANT_ENFORCEMENT_ENABLED` can be turned on, `radiant` needs an actual role catalog (which roles exist and what each grants), and the existing Keycloak users need grants.

This PR adds the role catalog as a migration. It maps the two access levels that exist today (data access + batch ingestion) onto three roles:

| role | actions |
|---|---|
| `member` | `can_search_case`, `can_view_kb`, `can_download_file` |
| `geneticist` | `can_read_pii`, `can_interpret_variant`, `can_comment_variant`, `can_flag_variant` |
| `data_manager` | `can_ingest_data` |

The **per-user grants** are applied by a one-shot SQL script run by hand against the environment (see TO-DOs) — it is *not* committed, because it contains real user emails/names and environment-specific Keycloak `sub`s.

## 📝 Changes

- **`000012_seed_radiant_roles.up.sql`** — seeds the three `radiant` roles + their `role_action` mappings, idempotent (`ON CONFLICT DO NOTHING`). The role catalog is environment-independent, so it belongs in a migration.
- **`test/data/auth/03_role.sql` / `04_role_action.sql`** — removed the test fixtures' own `radiant/geneticist` role so the auth tests reuse the now-seeded one (a fixture role with the same `(tenant_code, code)` would union its `role_action` rows with the seeded ones and skew assertions). `tenant_b/geneticist` stays a fixture role (test-only, unseeded).
- **`auth_test.go` / `auth_integration_test.go`** — updated `GetMemberships`/`GetMe` expectations for the radiant geneticist users to include `can_comment_variant` + `can_flag_variant` (the seeded action set).

## ☑️ TO-DOs

- [ ] Run the user-backfill SQL against QA (populates `users` + `user_role` from the current Keycloak users; subs pulled from the Keycloak admin console). Kept locally, not committed.
- [ ] After the backfill is verified, flip `TENANT_ENFORCEMENT_ENABLED=true` (separate change).

## 🧪 Tests

- `internal/repository` (auth), `cmd/api` (GetMe/TenantAccess), `internal/server` all pass against the seeded catalog.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1447](https://d3b.atlassian.net/browse/SJRA-1447)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- The user backfill is deliberately **out of the repo**: real PII + Keycloak `sub`s are environment-specific (a committed SQL/migration with hardcoded subs would be wrong in another realm). It's a hand-run, idempotent script.
- Earlier exploration of a Go backfill tool (`cmd/migrate-authdb`) was dropped as overkill for a one-shot with few users in a single environment.

[SJRA-1447]: https://d3b.atlassian.net/browse/SJRA-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ