### PR TITLE
feat: SJRA-1445 Adjust Cypress tests - tenant path-prefix routing

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
     keycloak_realm: "CQDG",
     keycloak_client: "cqdg-client",
     api_client: 'radiant',
+    api_tenant: 'radiant',
     api_base_url: "https://radiant-api.qa.juno.cqdg.ferlab.bio/",
   },
   env: {

--- a/cypress/CLAUDE.md
+++ b/cypress/CLAUDE.md
@@ -141,7 +141,7 @@ Shared POM utilities in `pom/shared/`:
 | Command | Purpose |
 |---|---|
 | `cy.getToken()` | Password grant → returns access_token |
-| `cy.apiCall(method, path, body, token)` | Authenticated request with auto-retry on 500 |
+| `cy.apiCall(method, path, body, token)` | Authenticated request with auto-retry on 500. `path` is tenant-scoped without the tenant prefix (e.g. `cases/search`); the tenant segment (`api_tenant`) is prepended automatically |
 | `cy.validateAcceptedBatchResponse(resp, type)` | Assert batch creation response structure |
 | `cy.validateSuccessBatchProcessed(resp)` | Assert completed batch (status=SUCCESS) |
 | `cy.validateReport(resp, level, code, msg, path)` | Assert error/warning/info in report |

--- a/cypress/support/apiCommands.ts
+++ b/cypress/support/apiCommands.ts
@@ -9,13 +9,16 @@ const getExpose = (key: string): string => {
  * Makes an authenticated API call with automatic retry logic for 500 errors.
  * Retries up to the specified number of times if a 500 status code is received.
  * @param method The HTTP method (GET, POST, PUT, DELETE, etc.).
- * @param query The API endpoint path (e.g., 'patients/batch', 'analysis/123').
+ * @param query The tenant-scoped API endpoint path, without the tenant prefix
+ *              (e.g., 'patients/batch', 'cases/search'). The tenant segment is
+ *              prepended automatically from the `api_tenant` exposed config.
  * @param body The request body as a JSON string.
  * @param token The Bearer authentication token.
  * @param retries The number of retry attempts on 500 errors (default: 3).
  */
 Cypress.Commands.add('apiCall', (method: string, query: string, body: string, token: string, retries: number = 3) => {
   const apiUrl = Cypress.expose('api_base_url');
+  const tenant = Cypress.expose('api_tenant');
 
   if (Cypress.expose('debug')) {
     cy.log('with body: ' + body);
@@ -25,7 +28,7 @@ Cypress.Commands.add('apiCall', (method: string, query: string, body: string, to
     return cy
       .request({
         method: method,
-        url: `${apiUrl}${query}`,
+        url: `${apiUrl}${tenant}/${query}`,
         headers: { Authorization: `Bearer ${token}` },
         body: body,
         failOnStatusCode: false,

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -14,11 +14,12 @@ Cypress.Commands.add('setToken', () => {
 
 Cypress.Commands.add('isValidToken', token => {
   const apiUrl = Cypress.expose('api_base_url');
+  const tenant = Cypress.expose('api_tenant');
 
   return cy
     .request({
       method: 'GET',
-      url: `${apiUrl}batches/mustReturn500ifTokenValid`,
+      url: `${apiUrl}${tenant}/batches/mustReturn500ifTokenValid`,
       headers: { Authorization: `Bearer ${token}` },
       failOnStatusCode: false,
     })


### PR DESCRIPTION
# feat: SJRA-1445 Adjust Cypress tests - tenant path-prefix routing

## 📌 Context

L'API Radiant est désormais multi-locataire (multi-tenant) : les endpoints sont préfixés par un segment de tenant dans l'URL (ex. `radiant/cases/search` au lieu de `cases/search`). Les tests Cypress doivent suivre ce nouveau routage par préfixe de chemin pour continuer à appeler l'API correctement.

## 📝 Changes

- Ajout de la configuration exposée `api_tenant` (valeur `radiant`) dans [cypress.config.ts](cypress.config.ts).
- [apiCommands.ts](cypress/support/apiCommands.ts) : `cy.apiCall` récupère `api_tenant` et préfixe automatiquement le tenant dans l'URL (`${apiUrl}${tenant}/${query}`). Les appelants passent maintenant un chemin sans préfixe de tenant.
- [e2e.js](cypress/support/e2e.js) : `cy.isValidToken` préfixe également le tenant sur son endpoint de validation (`batches/mustReturn500ifTokenValid`).
- [cypress/CLAUDE.md](cypress/CLAUDE.md) : mise à jour de la documentation de `cy.apiCall` pour préciser que le `path` est relatif au tenant (sans préfixe) et que le segment tenant est ajouté automatiquement.

## 🧪 Tests

- Aucun nouveau test ajouté ; ajustement de l'infrastructure de tests (commandes Cypress partagées) pour le routage par préfixe de tenant.
- Les tests Cypress impactés ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1445](https://d3b.atlassian.net/browse/SJRA-1445)<!-- End JIRA Issues -->

[SJRA-1445]: https://d3b.atlassian.net/browse/SJRA-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ