### PR TITLE
refactor: SJRA-1576 move auth repository interfaces to the consumer side

### DIFF
--- a/backend/.claude/rules/go-code-review.md
+++ b/backend/.claude/rules/go-code-review.md
@@ -26,7 +26,7 @@ wouldn't (or risk a cycle)?*
 | Situation | Put the interface… | Why |
 |---|---|---|
 | Consumer would otherwise **not** import the implementer's package (or it'd risk a cycle) | **Consumer side** | Keeps the consumer decoupled — the load-bearing case |
-| Consumer **already** imports the implementer's package | Either; producer side is fine | Coupling-neutral; centralizing the contract reads better |
+| Consumer **already** imports the implementer's package | Either is allowed; still prefer a narrow interface next to the consumer | Coupling-neutral, so placement won't break the graph — but a per-consumer slice beats one shared fat contract |
 | Broad, reused extension point | Producer or a neutral package | Like `io.Reader` living in `io` |
 | Single impl, no consumer needs the abstraction yet | **Don't write one** | Return the struct; add the interface when a consumer needs it |
 
@@ -36,9 +36,17 @@ Worked examples in this repo:
   `internal/types`; `client`/`repository` return concrete structs and never import `service`.
   Putting these interfaces in `client`/`repository` would force `service` to import both —
   avoid that.
-- **Coupling-neutral (producer side is fine):** `repository.AuthRepositoryDAO` lives next to
-  its implementation and is consumed by `internal/server` handlers — which already import
-  `repository` everywhere, so the interface's home doesn't change the graph.
+- **Narrow consumer-side interfaces beat one shared producer-side `*DAO`:** the auth repository
+  was once exposed as a single `repository.AuthRepositoryDAO` interface next to its
+  implementation. It was coupling-neutral (`internal/server` already imports `repository`), so
+  it didn't *break* the import-graph rule — but it was the weaker shape: one fat contract that
+  also carried a `HasAction` method no handler called ("for mocking" / preemptive). It now lives
+  as two narrow, unexported interfaces in `internal/server`, each scoped to one consumer:
+  `membershipReader` (just `GetMemberships`, in `handlers_auth.go`) and `tenantAccessChecker`
+  (just `HasTenantAccess`, in `middlewares.go`). `NewAuthRepository` returns the concrete
+  `*AuthRepository`, which satisfies both for free. **Lesson:** coupling-neutral means "either
+  placement is *allowed*," not "producer side is *preferred*" — when a consumer needs only a
+  slice, declare that slice next to the consumer, and don't keep contract methods nobody calls.
 
 Don't write `Interface`+`Impl` pairs "for mocking" when there's one implementation and no
 consumer that needs the abstraction yet — that's the preemptive-interface anti-pattern.

--- a/backend/.claude/rules/universal.md
+++ b/backend/.claude/rules/universal.md
@@ -4,7 +4,7 @@ Apply these to every coding task in the Go backend (`backend/`). They are intent
 
 Go style conventions (naming, error handling, interface placement, etc.) live in a curated, project-annotated copy of the Go Code Review Comments: [go-code-review.md](go-code-review.md). The headline rule from there, since it comes up most:
 
-> **Declare an interface in the package that *uses* it, not the one that implements it; constructors return concrete structs.** Place it by what keeps the import graph clean — consumer-side when the consumer wouldn't otherwise import the implementer (e.g. `service`'s provisioner interfaces), producer-side when the consumer already imports it (e.g. `repository.AuthRepositoryDAO`). Don't write `Interface`+`Impl` pairs "for mocking." See [go-code-review.md](go-code-review.md#interface-placement-the-rule-we-care-about-most) for the full heuristic.
+> **Declare an interface in the package that *uses* it, not the one that implements it; constructors return concrete structs.** Place it by what keeps the import graph clean — consumer-side when the consumer wouldn't otherwise import the implementer (e.g. `service`'s provisioner interfaces). Even when the consumer already imports the implementer (coupling-neutral), prefer a narrow interface scoped to that consumer over one shared `*DAO` contract — e.g. `internal/server`'s `membershipReader` / `tenantAccessChecker` over the old `repository.AuthRepositoryDAO`. Don't write `Interface`+`Impl` pairs "for mocking." See [go-code-review.md](go-code-review.md#interface-placement-the-rule-we-care-about-most) for the full heuristic.
 
 ## Test as you go
 

--- a/backend/internal/repository/auth.go
+++ b/backend/internal/repository/auth.go
@@ -14,12 +14,6 @@ type AuthRepository struct {
 	db *gorm.DB
 }
 
-type AuthRepositoryDAO interface {
-	HasAction(userID, tenantCode, orgCode, actionCode string) (bool, error)
-	HasTenantAccess(userID, tenantCode string) (bool, error)
-	GetMemberships(userID string) ([]types.TenantMembership, error)
-}
-
 func NewAuthRepository(db *gorm.DB) *AuthRepository {
 	if db == nil {
 		log.Print("AuthRepository: db is nil")

--- a/backend/internal/server/handlers_auth.go
+++ b/backend/internal/server/handlers_auth.go
@@ -4,9 +4,15 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
+	"github.com/radiant-network/radiant-api/internal/types"
 	"github.com/radiant-network/radiant-api/internal/utils"
 )
+
+// membershipReader returns a caller's tenant memberships. GetMeHandler needs only this
+// slice of the auth repository.
+type membershipReader interface {
+	GetMemberships(userID string) ([]types.TenantMembership, error)
+}
 
 // GetMeHandler
 // @Summary Get the caller's effective authorization
@@ -21,7 +27,7 @@ import (
 // @Failure 401 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /auth/me [get]
-func GetMeHandler(repo repository.AuthRepositoryDAO, auth utils.Auth) gin.HandlerFunc {
+func GetMeHandler(repo membershipReader, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, err := auth.RetrieveUserIdFromToken(c)
 		if err != nil {

--- a/backend/internal/server/handlers_auth_test.go
+++ b/backend/internal/server/handlers_auth_test.go
@@ -19,10 +19,6 @@ type mockAuthRepository struct {
 	tenantErr       error
 }
 
-func (m *mockAuthRepository) HasAction(email, tenantCode, orgCode, actionCode string) (bool, error) {
-	return false, nil
-}
-
 func (m *mockAuthRepository) HasTenantAccess(email, tenantCode string) (bool, error) {
 	return m.hasTenantAccess, m.tenantErr
 }

--- a/backend/internal/server/middlewares.go
+++ b/backend/internal/server/middlewares.go
@@ -4,13 +4,18 @@ import (
 	"fmt"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/utils"
 )
 
 // TenantContextKey is the gin context key under which RequireTenantAccess stores the
 // resolved tenant code for downstream handlers.
 const TenantContextKey = "tenant"
+
+// tenantAccessChecker reports whether a caller may access a tenant. RequireTenantAccess
+// needs only this slice of the auth repository.
+type tenantAccessChecker interface {
+	HasTenantAccess(userID, tenantCode string) (bool, error)
+}
 
 // RequireTenantAccess gates tenant-scoped routes (`/:tenant/...`). It always reads the
 // `tenant` path param and stores the resolved tenant code in the request context. When
@@ -20,7 +25,7 @@ const TenantContextKey = "tenant"
 // enforce is wired from TENANT_ENFORCEMENT_ENABLED so the path-prefix routing can be
 // deployed before users are backfilled into user_role: with enforcement off, routing and
 // context still work but nobody is locked out. Flip it on once the backfill lands.
-func RequireTenantAccess(auth utils.Auth, repo repository.AuthRepositoryDAO, enforce bool) gin.HandlerFunc {
+func RequireTenantAccess(auth utils.Auth, repo tenantAccessChecker, enforce bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tenant := c.Param("tenant")
 


### PR DESCRIPTION
## 📌 Context

SJRA-1576 — structural tech-debt cleanup (no behavior change), surfaced during review of SJRA-1474 / PR #1373.

Repository data-access interfaces (`*DAO`) were declared on the **producer** side (`internal/repository`) and consumed by `internal/server` handlers. The project's own style rule (`backend/.claude/rules/go-code-review.md`) — *"accept interfaces, return structs; declare the narrow interface in the package that uses it"* — prefers consumer-side interfaces and discourages `Interface`+`Impl` pairs that exist mainly "for mocking" or preemptively.

This PR applies that convention to **`AuthRepository` and its handlers only**. The audit of the other ~30 `*DAO` interfaces is left for a follow-up.

## 📝 Changes

- **Removed the producer-side `repository.AuthRepositoryDAO`** interface (`internal/repository/auth.go`). The struct, constructor, and all methods (incl. the still-tested concrete `HasAction`) are unchanged.
- **Added two narrow, unexported consumer-side interfaces in `internal/server`**, each scoped to exactly one consumer:
  - `membershipReader` (just `GetMemberships`) beside `GetMeHandler` — `handlers_auth.go`
  - `tenantAccessChecker` (just `HasTenantAccess`) beside `RequireTenantAccess` — `middlewares.go`
- **Dropped the preemptive `HasAction` from the contract** — no handler consumed it. Trimmed the matching stub from the hand-written `mockAuthRepository` in tests.
- Wiring in `cmd/api/main.go` is unchanged: `*AuthRepository` satisfies both narrow interfaces structurally.
- **Updated the style-rule docs** (`go-code-review.md`, `universal.md`) which previously cited `AuthRepositoryDAO` as the "coupling-neutral, producer side is fine" example: sharpened to *coupling-neutral means either placement is allowed, but still prefer a narrow per-consumer slice over one shared fat contract*.

## ☑️ TO-DOs

- [ ] Follow-up: audit the remaining `*DAO` interfaces (cases, variants, documents, …) for the same treatment.

## 🧪 Tests

No new tests — purely structural, behavior-preserving. Existing coverage exercises the change through the narrowed interfaces + trimmed mock.

```
cd backend
go build ./...
go test ./internal/server/...       # ok
go test ./internal/repository/...    # ok
```

Both packages pass. The concrete `HasAction` repository tests still pass, confirming dropping it from the contract didn't remove the method.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1576](https://d3b.atlassian.net/browse/SJRA-1576)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- No behavior change, no route change, no migration — only interface placement.
- `*AuthRepository` is never assigned to the narrow interfaces explicitly; conformance is checked at the handler call sites in `cmd/api/main.go` (a method rename would surface as a build error there).
- The `go vet` "unkeyed fields" warnings in the occurrence handlers are pre-existing and untouched by this PR.

[SJRA-1576]: https://d3b.atlassian.net/browse/SJRA-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ