### PR TITLE
refactor: SJRA-1576 consumer-side interfaces for read-only occurrence/variant/gene DAOs

### DIFF
--- a/backend/internal/repository/genes.go
+++ b/backend/internal/repository/genes.go
@@ -19,11 +19,6 @@ type GenesRepository struct {
 	db *gorm.DB
 }
 
-type GenesDAO interface {
-	GetGeneAutoComplete(prefix string, limit int) (*[]AutoCompleteGene, error)
-	SearchGenes(inputs []string) (*[]GeneResult, error)
-}
-
 func NewGenesRepository(db *gorm.DB) *GenesRepository {
 	if db == nil {
 		log.Print("GenesRepository: db is nil")

--- a/backend/internal/repository/germline_cnv_occurrences.go
+++ b/backend/internal/repository/germline_cnv_occurrences.go
@@ -17,14 +17,6 @@ type GermlineCNVOccurrencesRepository struct {
 	db *gorm.DB
 }
 
-type GermlineCNVOccurrencesDAO interface {
-	GetOccurrences(caseId int, seqId int, taskId int, userFilter types.ListQuery) ([]GermlineCNVOccurrence, error)
-	CountOccurrences(caseId int, seqId int, taskId int, userFilter types.CountQuery) (int64, error)
-	AggregateOccurrences(caseId int, seqId int, taskId int, userQuery types.AggQuery) ([]Aggregation, error)
-	GetStatisticsOccurrences(caseId int, seqId int, taskId int, query types.StatisticsQuery) (*Statistics, error)
-	GetGenesOverlap(caseId int, seqId int, taskId int, cnvId int) ([]types.CNVGeneOverlap, error)
-}
-
 func NewGermlineCNVOccurrencesRepository(db *gorm.DB) *GermlineCNVOccurrencesRepository {
 	if db == nil {
 		log.Print("GermlineCNVOccurrencesRepository: db is nil")

--- a/backend/internal/repository/germline_snv_occurrences.go
+++ b/backend/internal/repository/germline_snv_occurrences.go
@@ -24,14 +24,6 @@ type GermlineSNVOccurrencesRepository struct {
 	db *gorm.DB
 }
 
-type GermlineSNVOccurrencesDAO interface {
-	GetOccurrences(caseId int, seqId int, taskId int, userFilter types.ListQuery) ([]GermlineSNVOccurrence, error)
-	CountOccurrences(caseId int, seqId int, taskId int, userQuery types.CountQuery) (int64, error)
-	AggregateOccurrences(caseId int, seqId int, taskId int, userQuery types.AggQuery) ([]Aggregation, error)
-	GetStatisticsOccurrences(caseId int, seqId int, taskId int, userQuery types.StatisticsQuery) (*Statistics, error)
-	GetExpandedOccurrence(caseId int, seqId int, taskId int, locusId int) (*ExpandedGermlineSNVOccurrence, error)
-}
-
 func NewGermlineSNVOccurrencesRepository(db *gorm.DB) *GermlineSNVOccurrencesRepository {
 	if db == nil {
 		log.Print("GermlineSNVOccurrencesRepository: db is nil")

--- a/backend/internal/repository/somatic_snv_occurrences.go
+++ b/backend/internal/repository/somatic_snv_occurrences.go
@@ -19,14 +19,6 @@ type SomaticSNVOccurrencesRepository struct {
 	db *gorm.DB
 }
 
-type SomaticSNVOccurrencesDAO interface {
-	GetOccurrences(caseId int, seqId int, taskId int, userFilter types.ListQuery) ([]SomaticSNVOccurrence, error)
-	CountOccurrences(caseId int, seqId int, taskId int, userQuery types.CountQuery) (int64, error)
-	AggregateOccurrences(caseId int, seqId int, taskId int, userQuery types.AggQuery) ([]Aggregation, error)
-	GetStatisticsOccurrences(caseId int, seqId int, taskId int, userQuery types.StatisticsQuery) (*Statistics, error)
-	GetExpandedOccurrence(caseId int, seqId int, taskId int, locusId int) (*ExpandedSomaticSNVOccurrence, error)
-}
-
 func NewSomaticSNVOccurrencesRepository(db *gorm.DB) *SomaticSNVOccurrencesRepository {
 	if db == nil {
 		log.Print("SomaticSNVOccurrencesRepository: db is nil")

--- a/backend/internal/repository/variants.go
+++ b/backend/internal/repository/variants.go
@@ -27,19 +27,6 @@ type VariantsRepository struct {
 	db *gorm.DB
 }
 
-type VariantsDAO interface {
-	GetVariantHeader(locusId int) (*VariantHeader, error)
-	GetVariantOverview(locusId int) (*VariantOverview, error)
-	GetVariantConsequences(locusId int) (*[]VariantConsequence, error)
-	GetVariantInterpretedCases(locusId int, userQuery types.ListQuery) (*[]VariantInterpretedCase, *int64, error)
-	GetVariantUninterpretedCases(locusId int, userQuery types.ListQuery) (*[]VariantUninterpretedCase, *int64, error)
-	GetVariantCasesCount(locusId int) (*VariantCasesCount, error)
-	GetVariantCasesFilters() (*VariantCasesFilters, error)
-	GetVariantExternalFrequencies(locusId int) (*VariantExternalFrequencies, error)
-	GetGermlineVariantGlobalInternalFrequencies(locusId int) (*types.InternalFrequencies, error)
-	GetGermlineVariantInternalFrequenciesSplitBy(locusId int, splitType types.SplitType) (*[]types.InternalFrequenciesSplitBy, error)
-}
-
 func NewVariantsRepository(db *gorm.DB) *VariantsRepository {
 	if db == nil {
 		log.Print("VariantsRepository: db is nil")

--- a/backend/internal/server/handlers_genes.go
+++ b/backend/internal/server/handlers_genes.go
@@ -5,9 +5,13 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 )
+
+type genesReader interface {
+	GetGeneAutoComplete(prefix string, limit int) (*[]types.AutoCompleteGene, error)
+	SearchGenes(inputs []string) (*[]types.GeneResult, error)
+}
 
 // GetGeneAutoCompleteHandler handles retrieving genes by autocomplete
 // @Summary Get types.AutoCompleteGene list of matching input string with highlighted
@@ -24,7 +28,7 @@ import (
 // @Failure 403 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/genes/autocomplete [get]
-func GetGeneAutoCompleteHandler(repo repository.GenesDAO) gin.HandlerFunc {
+func GetGeneAutoCompleteHandler(repo genesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		prefix := c.Query("prefix")
 		limit, err := strconv.Atoi(c.Query("limit"))
@@ -56,7 +60,7 @@ func GetGeneAutoCompleteHandler(repo repository.GenesDAO) gin.HandlerFunc {
 // @Failure 403 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/genes/search [post]
-func SearchGenesHandler(repo repository.GenesDAO) gin.HandlerFunc {
+func SearchGenesHandler(repo genesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body types.GeneSearchBody

--- a/backend/internal/server/handlers_germline_cnv_occurrences.go
+++ b/backend/internal/server/handlers_germline_cnv_occurrences.go
@@ -5,9 +5,16 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 )
+
+type germlineCNVOccurrencesReader interface {
+	GetOccurrences(caseId int, seqId int, taskId int, userFilter types.ListQuery) ([]types.GermlineCNVOccurrence, error)
+	CountOccurrences(caseId int, seqId int, taskId int, userFilter types.CountQuery) (int64, error)
+	AggregateOccurrences(caseId int, seqId int, taskId int, userQuery types.AggQuery) ([]types.Aggregation, error)
+	GetStatisticsOccurrences(caseId int, seqId int, taskId int, query types.StatisticsQuery) (*types.Statistics, error)
+	GetGenesOverlap(caseId int, seqId int, taskId int, cnvId int) ([]types.CNVGeneOverlap, error)
+}
 
 // OccurrencesGermlineCNVListHandler handles list of germline CNV occurrences
 // @Summary List germline CNV occurrences
@@ -29,7 +36,7 @@ import (
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/cnv/{case_id}/{seq_id}/{task_id}/list [post]
-func OccurrencesGermlineCNVListHandler(repo repository.GermlineCNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesGermlineCNVListHandler(repo germlineCNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body  types.ListBodyWithSqon
@@ -93,7 +100,7 @@ func OccurrencesGermlineCNVListHandler(repo repository.GermlineCNVOccurrencesDAO
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/cnv/{case_id}/{seq_id}/{task_id}/count [post]
-func OccurrencesGermlineCNVCountHandler(repo repository.GermlineCNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesGermlineCNVCountHandler(repo germlineCNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body  types.CountBodyWithSqon
@@ -156,7 +163,7 @@ func OccurrencesGermlineCNVCountHandler(repo repository.GermlineCNVOccurrencesDA
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/cnv/{case_id}/{seq_id}/{task_id}/aggregate [post]
-func OccurrencesGermlineCNVAggregateHandler(repo repository.GermlineCNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesGermlineCNVAggregateHandler(repo germlineCNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body  types.AggregationBodyWithSqon
@@ -219,7 +226,7 @@ func OccurrencesGermlineCNVAggregateHandler(repo repository.GermlineCNVOccurrenc
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/cnv/{case_id}/{seq_id}/{task_id}/statistics [post]
-func OccurrencesGermlineCNVStatisticsHandler(repo repository.GermlineCNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesGermlineCNVStatisticsHandler(repo germlineCNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body  types.StatisticsBodyWithSqon
@@ -280,7 +287,7 @@ func OccurrencesGermlineCNVStatisticsHandler(repo repository.GermlineCNVOccurren
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/cnv/{case_id}/{seq_id}/{task_id}/{cnv_id}/genes_overlap [get]
-func OccurrencesGermlineCNVGenesOverlapHandler(repo repository.GermlineCNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesGermlineCNVGenesOverlapHandler(repo germlineCNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseId, errSeq := strconv.Atoi(c.Param("case_id"))
 		if errSeq != nil {

--- a/backend/internal/server/handlers_germline_snv_occurrences.go
+++ b/backend/internal/server/handlers_germline_snv_occurrences.go
@@ -13,6 +13,14 @@ type facetsReader interface {
 	GetFacets(facetNames []string) ([]types.Facet, error)
 }
 
+type germlineSNVOccurrencesReader interface {
+	GetOccurrences(caseId int, seqId int, taskId int, userFilter types.ListQuery) ([]types.GermlineSNVOccurrence, error)
+	CountOccurrences(caseId int, seqId int, taskId int, userQuery types.CountQuery) (int64, error)
+	AggregateOccurrences(caseId int, seqId int, taskId int, userQuery types.AggQuery) ([]types.Aggregation, error)
+	GetStatisticsOccurrences(caseId int, seqId int, taskId int, userQuery types.StatisticsQuery) (*types.Statistics, error)
+	GetExpandedOccurrence(caseId int, seqId int, taskId int, locusId int) (*types.ExpandedGermlineSNVOccurrence, error)
+}
+
 // OccurrencesGermlineSNVListHandler handles list of germline SNV occurrences
 // @Summary List germline SNV occurrences
 // @Id listGermlineSNVOccurrences
@@ -33,7 +41,7 @@ type facetsReader interface {
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/snv/{case_id}/{seq_id}/{task_id}/list [post]
-func OccurrencesGermlineSNVListHandler(repo repository.GermlineSNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesGermlineSNVListHandler(repo germlineSNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body  types.ListBodyWithSqon
@@ -98,7 +106,7 @@ func OccurrencesGermlineSNVListHandler(repo repository.GermlineSNVOccurrencesDAO
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/snv/{case_id}/{seq_id}/{task_id}/count [post]
-func OccurrencesGermlineSNVCountHandler(repo repository.GermlineSNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesGermlineSNVCountHandler(repo germlineSNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body  types.CountBodyWithSqon
@@ -162,7 +170,7 @@ func OccurrencesGermlineSNVCountHandler(repo repository.GermlineSNVOccurrencesDA
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/snv/{case_id}/{seq_id}/{task_id}/aggregate [post]
-func OccurrencesGermlineSNVAggregateHandler(repo repository.GermlineSNVOccurrencesDAO, facetsRepo facetsReader) gin.HandlerFunc {
+func OccurrencesGermlineSNVAggregateHandler(repo germlineSNVOccurrencesReader, facetsRepo facetsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body       types.AggregationBodyWithSqon
@@ -260,7 +268,7 @@ func OccurrencesGermlineSNVAggregateHandler(repo repository.GermlineSNVOccurrenc
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/snv/{case_id}/{seq_id}/{task_id}/statistics [post]
-func OccurrencesGermlineSNVStatisticsHandler(repo repository.GermlineSNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesGermlineSNVStatisticsHandler(repo germlineSNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body  types.StatisticsBodyWithSqon
@@ -321,7 +329,7 @@ func OccurrencesGermlineSNVStatisticsHandler(repo repository.GermlineSNVOccurren
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/snv/{case_id}/{seq_id}/{task_id}/{locus_id}/expanded [get]
-func GetExpandedGermlineSNVOccurrence(repo repository.GermlineSNVOccurrencesDAO, exomiserRepo repository.ExomiserDAO, interpretationRepo repository.InterpretationsDAO) gin.HandlerFunc {
+func GetExpandedGermlineSNVOccurrence(repo germlineSNVOccurrencesReader, exomiserRepo repository.ExomiserDAO, interpretationRepo repository.InterpretationsDAO) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseId, errSeq := strconv.Atoi(c.Param("case_id"))
 		if errSeq != nil {

--- a/backend/internal/server/handlers_somatic_snv_occurrences.go
+++ b/backend/internal/server/handlers_somatic_snv_occurrences.go
@@ -9,6 +9,14 @@ import (
 	"github.com/radiant-network/radiant-api/internal/types"
 )
 
+type somaticSNVOccurrencesReader interface {
+	GetOccurrences(caseId int, seqId int, taskId int, userFilter types.ListQuery) ([]types.SomaticSNVOccurrence, error)
+	CountOccurrences(caseId int, seqId int, taskId int, userQuery types.CountQuery) (int64, error)
+	AggregateOccurrences(caseId int, seqId int, taskId int, userQuery types.AggQuery) ([]types.Aggregation, error)
+	GetStatisticsOccurrences(caseId int, seqId int, taskId int, userQuery types.StatisticsQuery) (*types.Statistics, error)
+	GetExpandedOccurrence(caseId int, seqId int, taskId int, locusId int) (*types.ExpandedSomaticSNVOccurrence, error)
+}
+
 // OccurrencesSomaticSNVListHandler handles list of somatic SNV occurrences
 // @Summary List somatic SNV occurrences
 // @Id listSomaticSNVOccurrences
@@ -29,7 +37,7 @@ import (
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/somatic/snv/{case_id}/{seq_id}/{task_id}/list [post]
-func OccurrencesSomaticSNVListHandler(repo repository.SomaticSNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesSomaticSNVListHandler(repo somaticSNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body  types.ListBodyWithSqon
@@ -94,7 +102,7 @@ func OccurrencesSomaticSNVListHandler(repo repository.SomaticSNVOccurrencesDAO) 
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/somatic/snv/{case_id}/{seq_id}/{task_id}/count [post]
-func OccurrencesSomaticSNVCountHandler(repo repository.SomaticSNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesSomaticSNVCountHandler(repo somaticSNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body  types.CountBodyWithSqon
@@ -158,7 +166,7 @@ func OccurrencesSomaticSNVCountHandler(repo repository.SomaticSNVOccurrencesDAO)
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/somatic/snv/{case_id}/{seq_id}/{task_id}/aggregate [post]
-func OccurrencesSomaticSNVAggregateHandler(repo repository.SomaticSNVOccurrencesDAO, facetsRepo facetsReader) gin.HandlerFunc {
+func OccurrencesSomaticSNVAggregateHandler(repo somaticSNVOccurrencesReader, facetsRepo facetsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body       types.AggregationBodyWithSqon
@@ -256,7 +264,7 @@ func OccurrencesSomaticSNVAggregateHandler(repo repository.SomaticSNVOccurrences
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/somatic/snv/{case_id}/{seq_id}/{task_id}/statistics [post]
-func OccurrencesSomaticSNVStatisticsHandler(repo repository.SomaticSNVOccurrencesDAO) gin.HandlerFunc {
+func OccurrencesSomaticSNVStatisticsHandler(repo somaticSNVOccurrencesReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body  types.StatisticsBodyWithSqon
@@ -317,7 +325,7 @@ func OccurrencesSomaticSNVStatisticsHandler(repo repository.SomaticSNVOccurrence
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/somatic/snv/{case_id}/{seq_id}/{task_id}/{locus_id}/expanded [get]
-func GetExpandedSomaticSNVOccurrence(repo repository.SomaticSNVOccurrencesDAO, interpretationRepo repository.InterpretationsDAO) gin.HandlerFunc {
+func GetExpandedSomaticSNVOccurrence(repo somaticSNVOccurrencesReader, interpretationRepo repository.InterpretationsDAO) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseId, errSeq := strconv.Atoi(c.Param("case_id"))
 		if errSeq != nil {

--- a/backend/internal/server/handlers_variants.go
+++ b/backend/internal/server/handlers_variants.go
@@ -19,6 +19,19 @@ type clinvarConditionsReader interface {
 	GetVariantClinvarConditions(locusId int) ([]types.ClinvarRCV, error)
 }
 
+type variantsReader interface {
+	GetVariantHeader(locusId int) (*types.VariantHeader, error)
+	GetVariantOverview(locusId int) (*types.VariantOverview, error)
+	GetVariantConsequences(locusId int) (*[]types.VariantConsequence, error)
+	GetVariantInterpretedCases(locusId int, userQuery types.ListQuery) (*[]types.VariantInterpretedCase, *int64, error)
+	GetVariantUninterpretedCases(locusId int, userQuery types.ListQuery) (*[]types.VariantUninterpretedCase, *int64, error)
+	GetVariantCasesCount(locusId int) (*types.VariantCasesCount, error)
+	GetVariantCasesFilters() (*types.VariantCasesFilters, error)
+	GetVariantExternalFrequencies(locusId int) (*types.VariantExternalFrequencies, error)
+	GetGermlineVariantGlobalInternalFrequencies(locusId int) (*types.InternalFrequencies, error)
+	GetGermlineVariantInternalFrequenciesSplitBy(locusId int, splitType types.SplitType) (*[]types.InternalFrequenciesSplitBy, error)
+}
+
 // GetGermlineVariantHeader handles retrieving a germline variant header by its locus
 // @Summary Get a germline VariantHeader
 // @Id getGermlineVariantHeader
@@ -34,7 +47,7 @@ type clinvarConditionsReader interface {
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/variants/germline/{locus_id}/header [get]
-func GetGermlineVariantHeader(repo repository.VariantsDAO) gin.HandlerFunc {
+func GetGermlineVariantHeader(repo variantsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		locusID, err := strconv.Atoi(c.Param("locus_id"))
 		if err != nil {
@@ -69,7 +82,7 @@ func GetGermlineVariantHeader(repo repository.VariantsDAO) gin.HandlerFunc {
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/variants/germline/{locus_id}/overview [get]
-func GetGermlineVariantOverview(repo repository.VariantsDAO, exomiserRepository repository.ExomiserDAO, interpretationRepo repository.InterpretationsDAO) gin.HandlerFunc {
+func GetGermlineVariantOverview(repo variantsReader, exomiserRepository repository.ExomiserDAO, interpretationRepo repository.InterpretationsDAO) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		locusID, err := strconv.Atoi(c.Param("locus_id"))
 		if err != nil {
@@ -125,7 +138,7 @@ func GetGermlineVariantOverview(repo repository.VariantsDAO, exomiserRepository 
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/variants/germline/{locus_id}/consequences [get]
-func GetGermlineVariantConsequences(repo repository.VariantsDAO) gin.HandlerFunc {
+func GetGermlineVariantConsequences(repo variantsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		locusID, err := strconv.Atoi(c.Param("locus_id"))
 		if err != nil {
@@ -162,7 +175,7 @@ func GetGermlineVariantConsequences(repo repository.VariantsDAO) gin.HandlerFunc
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/variants/germline/{locus_id}/cases/interpreted [post]
-func GetGermlineVariantInterpretedCases(repo repository.VariantsDAO) gin.HandlerFunc {
+func GetGermlineVariantInterpretedCases(repo variantsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		locusID, err := strconv.Atoi(c.Param("locus_id"))
 		if err != nil {
@@ -216,7 +229,7 @@ func GetGermlineVariantInterpretedCases(repo repository.VariantsDAO) gin.Handler
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/variants/germline/{locus_id}/cases/uninterpreted [post]
-func GetGermlineVariantUninterpretedCases(repo repository.VariantsDAO) gin.HandlerFunc {
+func GetGermlineVariantUninterpretedCases(repo variantsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		locusID, err := strconv.Atoi(c.Param("locus_id"))
 		if err != nil {
@@ -268,7 +281,7 @@ func GetGermlineVariantUninterpretedCases(repo repository.VariantsDAO) gin.Handl
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/variants/germline/{locus_id}/cases/count [get]
-func GetGermlineVariantCasesCount(repo repository.VariantsDAO) gin.HandlerFunc {
+func GetGermlineVariantCasesCount(repo variantsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		locusId, errLocus := strconv.Atoi(c.Param("locus_id"))
 		if errLocus != nil {
@@ -298,7 +311,7 @@ func GetGermlineVariantCasesCount(repo repository.VariantsDAO) gin.HandlerFunc {
 // @Failure 500 {object} types.ApiError
 // @Param tenant path string true "Tenant code"
 // @Router /{tenant}/variants/germline/cases/filters [get]
-func GetGermlineVariantCasesFilters(repo repository.VariantsDAO) gin.HandlerFunc {
+func GetGermlineVariantCasesFilters(repo variantsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		filters, err := repo.GetVariantCasesFilters()
 		if err != nil {
@@ -403,7 +416,7 @@ func GetGermlineVariantConditionsClinvar(repo clinvarConditionsReader) gin.Handl
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/variants/germline/{locus_id}/external_frequencies [get]
-func GetGermlineVariantExternalFrequenciesHandler(repo repository.VariantsDAO) gin.HandlerFunc {
+func GetGermlineVariantExternalFrequenciesHandler(repo variantsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		locusID, err := strconv.Atoi(c.Param("locus_id"))
 		if err != nil {
@@ -440,7 +453,7 @@ func GetGermlineVariantExternalFrequenciesHandler(repo repository.VariantsDAO) g
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/variants/germline/{locus_id}/internal_frequencies [get]
-func GetGermlineVariantInternalFrequenciesHandler(repo repository.VariantsDAO) gin.HandlerFunc {
+func GetGermlineVariantInternalFrequenciesHandler(repo variantsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var variantInternalFrequencies *types.VariantInternalFrequencies
 		var splitRows *[]types.InternalFrequenciesSplitBy
@@ -486,7 +499,7 @@ func GetGermlineVariantInternalFrequenciesHandler(repo repository.VariantsDAO) g
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/variants/germline/{locus_id}/internal_frequencies/global [get]
-func GetGermlineVariantGlobalInternalFrequenciesHandler(repo repository.VariantsDAO) gin.HandlerFunc {
+func GetGermlineVariantGlobalInternalFrequenciesHandler(repo variantsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var globalFrequencies *types.InternalFrequencies
 


### PR DESCRIPTION
## 📌 Context

Continuation of the SJRA-1576 refactor (after #1379 auth and #1380 single-method DAOs): replace producer-side exported `repository.*DAO` interfaces with **narrow, unexported, consumer-side** interfaces declared in the package that uses them ("Accept interfaces, return structs"; see `backend/.claude/rules/go-code-review.md`). Constructors keep returning concrete `*XxxRepository` structs, which satisfy the new interfaces structurally — so mocks and tests need no changes.

This slice covers the **5 read-only DAOs that each have a single consumer file** in `internal/server` and no `batchval` involvement — the cleanest remaining cases.

## 📝 Changes

- Delete `GenesDAO`, `GermlineSNVOccurrencesDAO`, `GermlineCNVOccurrencesDAO`, `SomaticSNVOccurrencesDAO`, `VariantsDAO` from `internal/repository/`.
- Add narrow consumer-side interfaces next to their handlers in `internal/server/`: `genesReader`, `germlineSNVOccurrencesReader`, `germlineCNVOccurrencesReader`, `somaticSNVOccurrencesReader`, `variantsReader`.
- Each interface carries only the methods its consumer calls and references canonical `types.*` names (the deleted DAOs used repo-local aliases).
- Drop the now-unused `repository` import from `handlers_genes.go` and `handlers_germline_cnv_occurrences.go`; the other three files keep it for as-yet-unmigrated DAO params (`ExomiserDAO`, `InterpretationsDAO`).

Remaining `*DAO` interfaces: **26 → 21**.

## ☑️ TO-DOs

- [ ] Follow-up slices: CRUD server DAOs (`SavedFilters`, `OccurrenceFlags`, `OccurrenceNotes`, `UserPreferences`), cross-file server DAOs (`Interpretations`, `Exomiser`, `Terms`), cross-consumer DAOs (server + batchval), and batchval-only DAOs.

## 🧪 Tests

No test changes required (structural satisfaction). Verified:
- `go build ./...` — clean
- `go vet ./internal/server/ ./cmd/api/ ./internal/repository/` — only pre-existing `types.Count` unkeyed-field warnings, unrelated to this change
- `go test ./internal/server/` — `ok`

## 🔗 Related Issues

SJRA-1576

## 👀 Notes for Reviewers

- Pure refactor — no behavior change. The `repo` handler parameters change type from `repository.XxxDAO` to the local interface; call sites are untouched.
- Interfaces are placed after imports / existing slice-1 interfaces, never between a `// @Router` swaggo block and its handler func (which would detach the annotation).