### PR TITLE
refactor: SJRA-1576 consumer-side Store interfaces for CRUD single-consumer DAOs

### DIFF
--- a/backend/cmd/api/occurrence_flags_integration_test.go
+++ b/backend/cmd/api/occurrence_flags_integration_test.go
@@ -16,7 +16,7 @@ import (
 
 func assertUpsertOccurrenceFlag(
 	t *testing.T,
-	repo repository.OccurrenceFlagsDAO,
+	repo *repository.OccurrenceFlagsRepository,
 	caseID, seqID, taskID, occurrenceID, flagType string,
 	expectedStatus int,
 ) {
@@ -37,7 +37,7 @@ func assertUpsertOccurrenceFlag(
 
 func assertDeleteOccurrenceFlag(
 	t *testing.T,
-	repo repository.OccurrenceFlagsDAO,
+	repo *repository.OccurrenceFlagsRepository,
 	caseID, seqID, taskID, occurrenceID string,
 	expectedStatus int,
 ) {

--- a/backend/cmd/api/occurrence_notes_integration_test.go
+++ b/backend/cmd/api/occurrence_notes_integration_test.go
@@ -19,7 +19,7 @@ import (
 
 const mockUserUUID = "11111111-1111-1111-1111-111111111111"
 
-func assertPostOccurrenceNote(t *testing.T, repo repository.OccurrenceNotesDAO, auth *testutils.MockAuth, body string, expectedStatus int) *types.OccurrenceNote {
+func assertPostOccurrenceNote(t *testing.T, repo *repository.OccurrenceNotesRepository, auth *testutils.MockAuth, body string, expectedStatus int) *types.OccurrenceNote {
 	t.Helper()
 	router := gin.Default()
 	router.POST("/:tenant/notes", server.PostOccurrenceNoteHandler(repo, auth))
@@ -39,7 +39,7 @@ func assertPostOccurrenceNote(t *testing.T, repo repository.OccurrenceNotesDAO, 
 	return nil
 }
 
-func assertPutOccurrenceNote(t *testing.T, repo repository.OccurrenceNotesDAO, auth *testutils.MockAuth, id string, body string, expectedStatus int) *types.OccurrenceNote {
+func assertPutOccurrenceNote(t *testing.T, repo *repository.OccurrenceNotesRepository, auth *testutils.MockAuth, id string, body string, expectedStatus int) *types.OccurrenceNote {
 	t.Helper()
 	router := gin.Default()
 	router.PUT("/:tenant/notes/:id", server.PutOccurrenceNoteHandler(repo, auth))
@@ -59,7 +59,7 @@ func assertPutOccurrenceNote(t *testing.T, repo repository.OccurrenceNotesDAO, a
 	return nil
 }
 
-func assertGetOccurrenceNotes(t *testing.T, repo repository.OccurrenceNotesDAO, caseID int, seqID int, taskID int, occurrenceID string, expectedStatus int) []types.OccurrenceNote {
+func assertGetOccurrenceNotes(t *testing.T, repo *repository.OccurrenceNotesRepository, caseID int, seqID int, taskID int, occurrenceID string, expectedStatus int) []types.OccurrenceNote {
 	t.Helper()
 	router := gin.Default()
 	router.GET("/:tenant/notes/:case_id/:seq_id/:task_id/:occurrence_id", server.GetOccurrenceNotesHandler(repo))
@@ -76,7 +76,7 @@ func assertGetOccurrenceNotes(t *testing.T, repo repository.OccurrenceNotesDAO, 
 	return notes
 }
 
-func assertGetOccurrenceNoteCount(t *testing.T, repo repository.OccurrenceNotesDAO, caseID int, seqID int, taskID int, occurrenceID string, expectedStatus int) int64 {
+func assertGetOccurrenceNoteCount(t *testing.T, repo *repository.OccurrenceNotesRepository, caseID int, seqID int, taskID int, occurrenceID string, expectedStatus int) int64 {
 	t.Helper()
 	router := gin.Default()
 	router.GET("/:tenant/notes/:case_id/:seq_id/:task_id/:occurrence_id/count", server.GetOccurrenceNoteCountHandler(repo))
@@ -93,7 +93,7 @@ func assertGetOccurrenceNoteCount(t *testing.T, repo repository.OccurrenceNotesD
 	return count.Count
 }
 
-func assertDeleteOccurrenceNote(t *testing.T, repo repository.OccurrenceNotesDAO, auth *testutils.MockAuth, id string, expectedStatus int) {
+func assertDeleteOccurrenceNote(t *testing.T, repo *repository.OccurrenceNotesRepository, auth *testutils.MockAuth, id string, expectedStatus int) {
 	t.Helper()
 	router := gin.Default()
 	router.DELETE("/:tenant/notes/:id", server.DeleteOccurrenceNoteHandler(repo, auth))

--- a/backend/cmd/api/saved_filters_integration_test.go
+++ b/backend/cmd/api/saved_filters_integration_test.go
@@ -17,7 +17,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func assertGetSavedFilterByIDHandler(t *testing.T, repo repository.SavedFiltersDAO, savedFilterId string, status int, expected string) {
+func assertGetSavedFilterByIDHandler(t *testing.T, repo *repository.SavedFiltersRepository, savedFilterId string, status int, expected string) {
 	router := gin.Default()
 	router.GET("/users/saved_filters/:saved_filter_id", server.GetSavedFilterByIDHandler(repo))
 
@@ -59,7 +59,7 @@ func Test_GetSavedFilterByIDHandler(t *testing.T) {
 	})
 }
 
-func assertGetSavedFiltersHandler(t *testing.T, repo repository.SavedFiltersDAO, auth utils.Auth, savedFilterType *types.SavedFilterType, status int, expected string) {
+func assertGetSavedFiltersHandler(t *testing.T, repo *repository.SavedFiltersRepository, auth utils.Auth, savedFilterType *types.SavedFilterType, status int, expected string) {
 	router := gin.Default()
 	router.GET("/users/saved_filters", server.GetSavedFiltersHandler(repo, auth))
 
@@ -140,7 +140,7 @@ func Test_GetSavedFiltersHandler_FilterOnType(t *testing.T) {
 	})
 }
 
-func assertPostSavedFilterHandler(t *testing.T, repo repository.SavedFiltersDAO, auth utils.Auth, body string, status int) {
+func assertPostSavedFilterHandler(t *testing.T, repo *repository.SavedFiltersRepository, auth utils.Auth, body string, status int) {
 	router := gin.Default()
 	router.POST("/users/saved_filters", server.PostSavedFilterHandler(repo, auth))
 
@@ -190,7 +190,7 @@ func Test_PostSavedFilterHandler_Success(t *testing.T) {
 	})
 }
 
-func assertPutSavedFilterHandler(t *testing.T, repo repository.SavedFiltersDAO, auth utils.Auth, savedFilterId string, body string, status int) {
+func assertPutSavedFilterHandler(t *testing.T, repo *repository.SavedFiltersRepository, auth utils.Auth, savedFilterId string, body string, status int) {
 	router := gin.Default()
 	router.PUT("/users/saved_filters/:saved_filter_id", server.PutSavedFilterHandler(repo, auth))
 
@@ -252,7 +252,7 @@ func Test_PutSavedFilterHandler_Success(t *testing.T) {
 	})
 }
 
-func assertDeleteSavedFilterHandler(t *testing.T, repo repository.SavedFiltersDAO, auth utils.Auth, savedFilterId string, status int) {
+func assertDeleteSavedFilterHandler(t *testing.T, repo *repository.SavedFiltersRepository, auth utils.Auth, savedFilterId string, status int) {
 	router := gin.Default()
 	router.DELETE("/users/saved_filters/:saved_filter_id", server.DeleteSavedFilterHandler(repo, auth))
 

--- a/backend/cmd/api/user_preferences_integration_test.go
+++ b/backend/cmd/api/user_preferences_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func assertGetUserPreferencesHandler(t *testing.T, repo repository.UserPreferencesDAO, auth utils.Auth, status int, key string, expected string) {
+func assertGetUserPreferencesHandler(t *testing.T, repo *repository.UserPreferencesRepository, auth utils.Auth, status int, key string, expected string) {
 	router := gin.Default()
 	router.GET("/users/preferences/:key", server.GetUserPreferencesHandler(repo, auth))
 
@@ -52,7 +52,7 @@ func Test_GetUserPreferencesHandler_Found(t *testing.T) {
 	})
 }
 
-func assertUpdateUserPreferencesHandler(t *testing.T, repo repository.UserPreferencesDAO, auth utils.Auth, body string, status int, key string, expected string) {
+func assertUpdateUserPreferencesHandler(t *testing.T, repo *repository.UserPreferencesRepository, auth utils.Auth, body string, status int, key string, expected string) {
 	router := gin.Default()
 	router.POST("/users/preferences/:key", server.UpdateUserPreferencesHandler(repo, auth))
 

--- a/backend/internal/repository/occurrence_flags.go
+++ b/backend/internal/repository/occurrence_flags.go
@@ -13,11 +13,6 @@ type OccurrenceFlagsRepository struct {
 	db *gorm.DB
 }
 
-type OccurrenceFlagsDAO interface {
-	Upsert(flag types.OccurrenceFlag) (*types.OccurrenceFlag, error)
-	Delete(caseID, seqID, taskID int, occurrenceID string) (int64, error)
-}
-
 func NewOccurrenceFlagsRepository(db *gorm.DB) *OccurrenceFlagsRepository {
 	if db == nil {
 		log.Fatal("OccurrenceFlagsRepository: db is nil")

--- a/backend/internal/repository/occurrence_notes.go
+++ b/backend/internal/repository/occurrence_notes.go
@@ -14,15 +14,6 @@ type OccurrenceNotesRepository struct {
 	db *gorm.DB
 }
 
-type OccurrenceNotesDAO interface {
-	Create(note types.OccurrenceNote) (*types.OccurrenceNote, error)
-	GetByID(id string) (*types.OccurrenceNote, error)
-	GetByOccurrence(caseID int, seqID int, taskID int, occurrenceID string) ([]types.OccurrenceNote, error)
-	CountByOccurrence(caseID int, seqID int, taskID int, occurrenceID string) (int, error)
-	Update(id string, content string) (*types.OccurrenceNote, error)
-	Delete(id string) error
-}
-
 func NewOccurrenceNotesRepository(db *gorm.DB) *OccurrenceNotesRepository {
 	if db == nil {
 		log.Fatal("OccurrenceNotesRepository: db is nil")

--- a/backend/internal/repository/saved_filters.go
+++ b/backend/internal/repository/saved_filters.go
@@ -18,14 +18,6 @@ type SavedFiltersRepository struct {
 	db *gorm.DB
 }
 
-type SavedFiltersDAO interface {
-	GetSavedFilterByID(savedFilterId string) (*SavedFilter, error)
-	GetSavedFiltersByUserID(userId string, savedFilterType string) (*[]SavedFilter, error)
-	CreateSavedFilter(savedFilterInput SavedFilterCreationInput, userId string) (*SavedFilter, error)
-	UpdateSavedFilter(savedFilterInput SavedFilterUpdateInput, savedFilterId string, userId string) (*SavedFilter, error)
-	DeleteSavedFilter(savedFilterId string, userId string) error
-}
-
 func NewSavedFiltersRepository(db *gorm.DB) *SavedFiltersRepository {
 	if db == nil {
 		log.Fatal("SavedFiltersRepository: db is nil")

--- a/backend/internal/repository/user_preferences.go
+++ b/backend/internal/repository/user_preferences.go
@@ -15,11 +15,6 @@ type UserPreferencesRepository struct {
 	db *gorm.DB
 }
 
-type UserPreferencesDAO interface {
-	GetUserPreferences(userId string, key string) (*types.JsonMap[string, interface{}], error)
-	UpdateUserPreferences(userId string, key string, content types.JsonMap[string, interface{}]) (*types.JsonMap[string, interface{}], error)
-}
-
 func NewUserPreferencesRepository(db *gorm.DB) *UserPreferencesRepository {
 	if db == nil {
 		log.Fatal("UserPreferencesRepository: db is nil")

--- a/backend/internal/server/handler_occurrence_flag.go
+++ b/backend/internal/server/handler_occurrence_flag.go
@@ -7,9 +7,13 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 )
+
+type occurrenceFlagsStore interface {
+	Upsert(flag types.OccurrenceFlag) (*types.OccurrenceFlag, error)
+	Delete(caseID, seqID, taskID int, occurrenceID string) (int64, error)
+}
 
 // UpsertOccurrenceFlagHandler
 // @Summary Set or change the flag on an occurrence
@@ -29,7 +33,7 @@ import (
 // @Failure 403 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/flags/{case_id}/{seq_id}/{task_id}/{occurrence_id} [post]
-func UpsertOccurrenceFlagHandler(repo repository.OccurrenceFlagsDAO) gin.HandlerFunc {
+func UpsertOccurrenceFlagHandler(repo occurrenceFlagsStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseID, err := strconv.Atoi(c.Param("case_id"))
 		if err != nil {
@@ -89,7 +93,7 @@ func UpsertOccurrenceFlagHandler(repo repository.OccurrenceFlagsDAO) gin.Handler
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/flags/{case_id}/{seq_id}/{task_id}/{occurrence_id} [delete]
-func DeleteOccurrenceFlagHandler(repo repository.OccurrenceFlagsDAO) gin.HandlerFunc {
+func DeleteOccurrenceFlagHandler(repo occurrenceFlagsStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseID, err := strconv.Atoi(c.Param("case_id"))
 		if err != nil {

--- a/backend/internal/server/handlers_occurrence_notes.go
+++ b/backend/internal/server/handlers_occurrence_notes.go
@@ -7,10 +7,18 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/microcosm-cc/bluemonday"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 	"github.com/radiant-network/radiant-api/internal/utils"
 )
+
+type occurrenceNotesStore interface {
+	Create(note types.OccurrenceNote) (*types.OccurrenceNote, error)
+	GetByID(id string) (*types.OccurrenceNote, error)
+	GetByOccurrence(caseID int, seqID int, taskID int, occurrenceID string) ([]types.OccurrenceNote, error)
+	CountByOccurrence(caseID int, seqID int, taskID int, occurrenceID string) (int, error)
+	Update(id string, content string) (*types.OccurrenceNote, error)
+	Delete(id string) error
+}
 
 var htmlPolicy = bluemonday.UGCPolicy()
 
@@ -38,7 +46,7 @@ func sanitizeNoteContent(content string, userID string) string {
 // @Failure 403 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/notes [post]
-func PostOccurrenceNoteHandler(repo repository.OccurrenceNotesDAO, auth utils.Auth) gin.HandlerFunc {
+func PostOccurrenceNoteHandler(repo occurrenceNotesStore, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var body types.CreateOccurrenceNoteInput
 		if err := c.ShouldBindJSON(&body); err != nil {
@@ -94,7 +102,7 @@ func PostOccurrenceNoteHandler(repo repository.OccurrenceNotesDAO, auth utils.Au
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/notes/{id} [put]
-func PutOccurrenceNoteHandler(repo repository.OccurrenceNotesDAO, auth utils.Auth) gin.HandlerFunc {
+func PutOccurrenceNoteHandler(repo occurrenceNotesStore, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
 
@@ -147,7 +155,7 @@ func PutOccurrenceNoteHandler(repo repository.OccurrenceNotesDAO, auth utils.Aut
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/notes/{id} [delete]
-func DeleteOccurrenceNoteHandler(repo repository.OccurrenceNotesDAO, auth utils.Auth) gin.HandlerFunc {
+func DeleteOccurrenceNoteHandler(repo occurrenceNotesStore, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
 
@@ -197,7 +205,7 @@ func DeleteOccurrenceNoteHandler(repo repository.OccurrenceNotesDAO, auth utils.
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/notes/{case_id}/{seq_id}/{task_id}/{occurrence_id}/count [get]
-func GetOccurrenceNoteCountHandler(repo repository.OccurrenceNotesDAO) gin.HandlerFunc {
+func GetOccurrenceNoteCountHandler(repo occurrenceNotesStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseID, err := strconv.Atoi(c.Param("case_id"))
 		if err != nil {
@@ -246,7 +254,7 @@ func GetOccurrenceNoteCountHandler(repo repository.OccurrenceNotesDAO) gin.Handl
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/notes/{case_id}/{seq_id}/{task_id}/{occurrence_id} [get]
-func GetOccurrenceNotesHandler(repo repository.OccurrenceNotesDAO) gin.HandlerFunc {
+func GetOccurrenceNotesHandler(repo occurrenceNotesStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseID, err := strconv.Atoi(c.Param("case_id"))
 		if err != nil {

--- a/backend/internal/server/handlers_saved_filters.go
+++ b/backend/internal/server/handlers_saved_filters.go
@@ -4,10 +4,17 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 	"github.com/radiant-network/radiant-api/internal/utils"
 )
+
+type savedFiltersStore interface {
+	GetSavedFilterByID(savedFilterId string) (*types.SavedFilter, error)
+	GetSavedFiltersByUserID(userId string, savedFilterType string) (*[]types.SavedFilter, error)
+	CreateSavedFilter(savedFilterInput types.SavedFilterCreationInput, userId string) (*types.SavedFilter, error)
+	UpdateSavedFilter(savedFilterInput types.SavedFilterUpdateInput, savedFilterId string, userId string) (*types.SavedFilter, error)
+	DeleteSavedFilter(savedFilterId string, userId string) error
+}
 
 // GetSavedFilterByIDHandler
 // @Summary Get saved filter by id
@@ -21,7 +28,7 @@ import (
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /users/saved_filters/{saved_filter_id} [get]
-func GetSavedFilterByIDHandler(repo repository.SavedFiltersDAO) gin.HandlerFunc {
+func GetSavedFilterByIDHandler(repo savedFiltersStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		savedFilterId := c.Param("saved_filter_id")
 		savedFilter, err := repo.GetSavedFilterByID(savedFilterId)
@@ -50,7 +57,7 @@ func GetSavedFilterByIDHandler(repo repository.SavedFiltersDAO) gin.HandlerFunc 
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /users/saved_filters [get]
-func GetSavedFiltersHandler(repo repository.SavedFiltersDAO, auth utils.Auth) gin.HandlerFunc {
+func GetSavedFiltersHandler(repo savedFiltersStore, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		savedFilterType := c.Query("type")
 		userId, err := auth.RetrieveUserIdFromToken(c)
@@ -83,7 +90,7 @@ func GetSavedFiltersHandler(repo repository.SavedFiltersDAO, auth utils.Auth) gi
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /users/saved_filters [post]
-func PostSavedFilterHandler(repo repository.SavedFiltersDAO, auth utils.Auth) gin.HandlerFunc {
+func PostSavedFilterHandler(repo savedFiltersStore, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body types.SavedFilterCreationInput
@@ -124,7 +131,7 @@ func PostSavedFilterHandler(repo repository.SavedFiltersDAO, auth utils.Auth) gi
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /users/saved_filters/{saved_filter_id} [put]
-func PutSavedFilterHandler(repo repository.SavedFiltersDAO, auth utils.Auth) gin.HandlerFunc {
+func PutSavedFilterHandler(repo savedFiltersStore, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body types.SavedFilterUpdateInput
@@ -172,7 +179,7 @@ func PutSavedFilterHandler(repo repository.SavedFiltersDAO, auth utils.Auth) gin
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /users/saved_filters/{saved_filter_id} [delete]
-func DeleteSavedFilterHandler(repo repository.SavedFiltersDAO, auth utils.Auth) gin.HandlerFunc {
+func DeleteSavedFilterHandler(repo savedFiltersStore, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userId, err := auth.RetrieveUserIdFromToken(c)
 		if err != nil {

--- a/backend/internal/server/handlers_user_preferences.go
+++ b/backend/internal/server/handlers_user_preferences.go
@@ -4,10 +4,14 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 	"github.com/radiant-network/radiant-api/internal/utils"
 )
+
+type userPreferencesStore interface {
+	GetUserPreferences(userId string, key string) (*types.JsonMap[string, interface{}], error)
+	UpdateUserPreferences(userId string, key string, content types.JsonMap[string, interface{}]) (*types.JsonMap[string, interface{}], error)
+}
 
 // GetUserPreferencesHandler
 // @Summary Get user preferences
@@ -21,7 +25,7 @@ import (
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /users/preferences/{key} [get]
-func GetUserPreferencesHandler(repo repository.UserPreferencesDAO, auth utils.Auth) gin.HandlerFunc {
+func GetUserPreferencesHandler(repo userPreferencesStore, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userId, err := auth.RetrieveUserIdFromToken(c)
 		if err != nil {
@@ -57,7 +61,7 @@ func GetUserPreferencesHandler(repo repository.UserPreferencesDAO, auth utils.Au
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /users/preferences/{key} [post]
-func UpdateUserPreferencesHandler(repo repository.UserPreferencesDAO, auth utils.Auth) gin.HandlerFunc {
+func UpdateUserPreferencesHandler(repo userPreferencesStore, auth utils.Auth) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var (
 			body types.JsonMap[string, interface{}]


### PR DESCRIPTION
## 📌 Context

Part 4 of the SJRA-1576 refactor that replaces producer-side exported `*DAO` interfaces in `internal/repository/` with **narrow, unexported, consumer-side** interfaces declared in the package that consumes them ("accept interfaces, return structs"). Constructors keep returning concrete `*XxxRepository` structs; mocks satisfy the new interfaces structurally, so no mock or test rewiring is needed.

This slice migrates the 4 **CRUD single-consumer** server DAOs — each used in exactly one handler file, with every method called. These are the first CRUD interfaces in the refactor, establishing the `Store` role-suffix naming convention for later CRUD slices (read-only interfaces keep `Reader`/`Checker`).

Builds on #1381 (Part 3, read-only single-consumer DAOs). After this slice, **17 `*DAO` interfaces remain** (down from 21).

## 📝 Changes

- Added 4 unexported consumer-side interfaces and retyped the handler signatures:
  - `SavedFiltersDAO` → `savedFiltersStore` (`handlers_saved_filters.go`)
  - `OccurrenceFlagsDAO` → `occurrenceFlagsStore` (`handler_occurrence_flag.go`)
  - `OccurrenceNotesDAO` → `occurrenceNotesStore` (`handlers_occurrence_notes.go`)
  - `UserPreferencesDAO` → `userPreferencesStore` (`handlers_user_preferences.go`)
- Dropped the now-unused `repository` import from all 4 handler files.
- Retyped the `cmd/api/*_integration_test.go` helpers to the concrete `*repository.XxxRepository` (the unexported server interfaces aren't importable from `cmd/api`).
- Deleted the 4 orphaned `*DAO` interface declarations from the repository package; concrete structs, constructors, methods, and `type X = types.X` aliases are untouched.

## ☑️ TO-DOs

- [ ] None — slice is self-contained.

## 🧪 Tests

No new tests required (pure interface-placement refactor; behaviour unchanged). Existing suites validated:

- `go build ./...` — clean
- `go test ./internal/server/ ./internal/batchval/` — pass

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1576](https://d3b.atlassian.net/browse/SJRA-1576)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- Naming convention decision: CRUD consumer interfaces use the `Store` suffix; read-only ones continue to use `Reader`/`Checker`.
- The interfaces reference canonical `types.*` names (not the repo-local `type X = types.X` aliases the deleted interfaces used).
- Pre-existing `go vet` `composites` warnings on `types.Count{...}` unkeyed literals are unrelated to this change.
- Scope was deliberately limited to the 4 CRUD single-consumer DAOs; cross-file server DAOs (`InterpretationsDAO`, `ExomiserDAO`, `TermsDAO`, `DocumentsDAO`) are deferred to a follow-up part.


[SJRA-1576]: https://d3b.atlassian.net/browse/SJRA-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ