### PR TITLE
refactor: SJRA-1576 consumer-side interfaces for interpretations, exomiser and terms

### DIFF
--- a/backend/cmd/api/interpretations_integration_test.go
+++ b/backend/cmd/api/interpretations_integration_test.go
@@ -90,7 +90,7 @@ func Test_GetInterpretationGermlineWithPartialContent(t *testing.T) {
 	})
 }
 
-func assertGetInterpretationGermline(t *testing.T, repo repository.InterpretationsDAO, termsRepo repository.TermsDAO, caseId string, sequencingId string, locusId string, transcriptId string, status int, expected string) {
+func assertGetInterpretationGermline(t *testing.T, repo *repository.InterpretationsRepository, termsRepo *repository.TermsRepository, caseId string, sequencingId string, locusId string, transcriptId string, status int, expected string) {
 	router := gin.Default()
 	router.GET("/:tenant/interpretations/v2/germline/:case_id/:sequencing_id/:locus_id/:transcript_id", server.GetInterpretationGermline(repo, termsRepo))
 
@@ -104,7 +104,7 @@ func assertGetInterpretationGermline(t *testing.T, repo repository.Interpretatio
 	}
 }
 
-func assertPostInterpretationGermline(t *testing.T, repo repository.InterpretationsDAO, caseId string, sequencingId string, locusId string, transcriptId string, status int, interpretation *types.InterpretationGermline, expected string) *types.InterpretationGermline {
+func assertPostInterpretationGermline(t *testing.T, repo *repository.InterpretationsRepository, caseId string, sequencingId string, locusId string, transcriptId string, status int, interpretation *types.InterpretationGermline, expected string) *types.InterpretationGermline {
 	router := gin.Default()
 	router.POST("/:tenant/interpretations/v2/germline/:case_id/:sequencing_id/:locus_id/:transcript_id", server.PostInterpretationGermline(repo))
 
@@ -172,7 +172,7 @@ func Test_GetInterpretationSomaticWithPartialContent(t *testing.T) {
 	})
 }
 
-func assertGetInterpretationSomatic(t *testing.T, repo repository.InterpretationsDAO, terms repository.TermsDAO, caseId string, sequencingId string, locusId string, transcriptId string, status int, expected string) *types.InterpretationSomatic {
+func assertGetInterpretationSomatic(t *testing.T, repo *repository.InterpretationsRepository, terms *MockTermsRepository, caseId string, sequencingId string, locusId string, transcriptId string, status int, expected string) *types.InterpretationSomatic {
 	router := gin.Default()
 	router.GET("/:tenant/interpretations/v2/somatic/:case_id/:sequencing_id/:locus_id/:transcript_id", server.GetInterpretationSomatic(repo, terms))
 
@@ -192,7 +192,7 @@ func assertGetInterpretationSomatic(t *testing.T, repo repository.Interpretation
 	return nil
 }
 
-func assertPostInterpretationSomatic(t *testing.T, repo repository.InterpretationsDAO, caseId string, sequencingId string, locusId string, transcriptId string, status int, interpretation *types.InterpretationSomatic, expected string) *types.InterpretationSomatic {
+func assertPostInterpretationSomatic(t *testing.T, repo *repository.InterpretationsRepository, caseId string, sequencingId string, locusId string, transcriptId string, status int, interpretation *types.InterpretationSomatic, expected string) *types.InterpretationSomatic {
 	router := gin.Default()
 	router.POST("/:tenant/interpretations/v2/somatic/:case_id/:sequencing_id/:locus_id/:transcript_id", server.PostInterpretationSomatic(repo))
 
@@ -233,7 +233,7 @@ func Test_SearchGermline(t *testing.T) {
 	})
 }
 
-func assertSearchInterpretationGermline(t *testing.T, repo repository.InterpretationsDAO, queryParams string, status int, count int) {
+func assertSearchInterpretationGermline(t *testing.T, repo *repository.InterpretationsRepository, queryParams string, status int, count int) {
 	router := gin.Default()
 	router.GET("/:tenant/interpretations/germline", server.SearchInterpretationGermline(repo))
 
@@ -269,7 +269,7 @@ func Test_SearchSomatic(t *testing.T) {
 	})
 }
 
-func assertSearchInterpretationSomatic(t *testing.T, repo repository.InterpretationsDAO, queryParams string, status int, count int) {
+func assertSearchInterpretationSomatic(t *testing.T, repo *repository.InterpretationsRepository, queryParams string, status int, count int) {
 	router := gin.Default()
 	router.GET("/:tenant/interpretations/somatic", server.SearchInterpretationSomatic(repo))
 

--- a/backend/internal/repository/exomiser.go
+++ b/backend/internal/repository/exomiser.go
@@ -15,11 +15,6 @@ type ExomiserRepository struct {
 	db *gorm.DB
 }
 
-type ExomiserDAO interface {
-	GetExomiser(locusId int) ([]Exomiser, error)
-	GetExomiserACMGClassificationCounts(locusId int) (map[string]int, error)
-}
-
 func NewExomiserRepository(db *gorm.DB) *ExomiserRepository {
 	if db == nil {
 		log.Print("ExomiserRepository: db is nil")

--- a/backend/internal/repository/interpretations.go
+++ b/backend/internal/repository/interpretations.go
@@ -20,17 +20,6 @@ type InterpretationsRepository struct {
 	pubmedClient client.PubmedClientService
 }
 
-type InterpretationsDAO interface {
-	FirstGermline(caseId string, sequencingId string, locusId string, transcriptId string) (*types.InterpretationGermline, error)
-	CreateOrUpdateGermline(interpretation *types.InterpretationGermline) error
-	SearchGermline(analysisId []string, patientId []string, variantHash []string) ([]*types.InterpretationGermline, error)
-	FirstSomatic(caseId string, sequencingId string, locusId string, transcriptId string) (*types.InterpretationSomatic, error)
-	CreateOrUpdateSomatic(interpretation *types.InterpretationSomatic) error
-	SearchSomatic(analysisId []string, patientId []string, variantHash []string) ([]*types.InterpretationSomatic, error)
-	RetrieveGermlineInterpretationClassificationCounts(locusId int) (types.JsonMap[string, int], error)
-	RetrieveSomaticInterpretationClassificationCounts(locusId int) (types.JsonMap[string, int], error)
-}
-
 func NewInterpretationsRepository(db *gorm.DB, pubmedClient client.PubmedClientService) *InterpretationsRepository {
 	if db == nil {
 		log.Fatal("InterpretationsRepository: db is nil")

--- a/backend/internal/repository/terms.go
+++ b/backend/internal/repository/terms.go
@@ -15,11 +15,6 @@ type TermsRepository struct {
 	db *gorm.DB
 }
 
-type TermsDAO interface {
-	GetTermAutoComplete(termsTable string, input string, limit int) (*[]types.AutoCompleteTerm, error)
-	GetTermNameById(termsTable string, id string) (*string, error)
-}
-
 func NewTermsRepository(db *gorm.DB) *TermsRepository {
 	if db == nil {
 		log.Print("TermsRepository: db is nil")

--- a/backend/internal/server/handlers.go
+++ b/backend/internal/server/handlers.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 )
 
@@ -68,6 +67,10 @@ func GetUserSet(repo userSetReader) gin.HandlerFunc {
 	}
 }
 
+type termAutoCompleter interface {
+	GetTermAutoComplete(termsTable string, input string, limit int) (*[]types.AutoCompleteTerm, error)
+}
+
 // GetMondoTermAutoComplete handles retrieving mondo terms by autocomplete
 // @Summary Get AutoCompleteTerm list of matching input string with highlighted
 // @Id mondoTermAutoComplete
@@ -83,7 +86,7 @@ func GetUserSet(repo userSetReader) gin.HandlerFunc {
 // @Failure 403 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/mondo/autocomplete [get]
-func GetMondoTermAutoComplete(repo repository.TermsDAO) gin.HandlerFunc {
+func GetMondoTermAutoComplete(repo termAutoCompleter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		prefix := c.Query("prefix")
 		limit, err := strconv.Atoi(c.Query("limit"))
@@ -114,7 +117,7 @@ func GetMondoTermAutoComplete(repo repository.TermsDAO) gin.HandlerFunc {
 // @Failure 403 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/hpo/autocomplete [get]
-func GetHPOTermAutoComplete(repo repository.TermsDAO) gin.HandlerFunc {
+func GetHPOTermAutoComplete(repo termAutoCompleter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		prefix := c.Query("prefix")
 		limit, err := strconv.Atoi(c.Query("limit"))

--- a/backend/internal/server/handlers_germline_snv_occurrences.go
+++ b/backend/internal/server/handlers_germline_snv_occurrences.go
@@ -5,12 +5,19 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 )
 
 type facetsReader interface {
 	GetFacets(facetNames []string) ([]types.Facet, error)
+}
+
+type exomiserClassificationCountsReader interface {
+	GetExomiserACMGClassificationCounts(locusId int) (map[string]int, error)
+}
+
+type germlineInterpretationCountsReader interface {
+	RetrieveGermlineInterpretationClassificationCounts(locusId int) (types.JsonMap[string, int], error)
 }
 
 type germlineSNVOccurrencesReader interface {
@@ -329,7 +336,7 @@ func OccurrencesGermlineSNVStatisticsHandler(repo germlineSNVOccurrencesReader) 
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/germline/snv/{case_id}/{seq_id}/{task_id}/{locus_id}/expanded [get]
-func GetExpandedGermlineSNVOccurrence(repo germlineSNVOccurrencesReader, exomiserRepo repository.ExomiserDAO, interpretationRepo repository.InterpretationsDAO) gin.HandlerFunc {
+func GetExpandedGermlineSNVOccurrence(repo germlineSNVOccurrencesReader, exomiserRepo exomiserClassificationCountsReader, interpretationRepo germlineInterpretationCountsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseId, errSeq := strconv.Atoi(c.Param("case_id"))
 		if errSeq != nil {

--- a/backend/internal/server/handlers_interpretations.go
+++ b/backend/internal/server/handlers_interpretations.go
@@ -6,10 +6,22 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/radiant-network/radiant-api/internal/client"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 	"github.com/tbaehler/gin-keycloak/pkg/ginkeycloak"
 )
+
+type interpretationsStore interface {
+	FirstGermline(caseId string, sequencingId string, locusId string, transcriptId string) (*types.InterpretationGermline, error)
+	CreateOrUpdateGermline(interpretation *types.InterpretationGermline) error
+	SearchGermline(analysisId []string, patientId []string, variantHash []string) ([]*types.InterpretationGermline, error)
+	FirstSomatic(caseId string, sequencingId string, locusId string, transcriptId string) (*types.InterpretationSomatic, error)
+	CreateOrUpdateSomatic(interpretation *types.InterpretationSomatic) error
+	SearchSomatic(analysisId []string, patientId []string, variantHash []string) ([]*types.InterpretationSomatic, error)
+}
+
+type termNameReader interface {
+	GetTermNameById(termsTable string, id string) (*string, error)
+}
 
 func extractInterpretationParams(c *gin.Context) (string, string, string, string) {
 	sequencingId := c.Param("sequencing_id")
@@ -88,7 +100,7 @@ func getInterpretationStatus(interpretation *types.InterpretationCommon) int {
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/interpretations/germline/{sequencing_id}/{locus_id}/{transcript_id} [get]
-func GetInterpretationGermlineDeprecated(repo repository.InterpretationsDAO) gin.HandlerFunc {
+func GetInterpretationGermlineDeprecated(repo interpretationsStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseId, sequencingId, locusId, transcriptId := extractInterpretationParams(c)
 		interpretation, err := repo.FirstGermline(caseId, sequencingId, locusId, transcriptId)
@@ -123,7 +135,7 @@ func GetInterpretationGermlineDeprecated(repo repository.InterpretationsDAO) gin
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/interpretations/v2/germline/{case_id}/{sequencing_id}/{locus_id}/{transcript_id} [get]
-func GetInterpretationGermline(repo repository.InterpretationsDAO, termsRepo repository.TermsDAO) gin.HandlerFunc {
+func GetInterpretationGermline(repo interpretationsStore, termsRepo termNameReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseId, sequencingId, locusId, transcriptId := extractInterpretationParams(c)
 		interpretation, err := repo.FirstGermline(caseId, sequencingId, locusId, transcriptId)
@@ -169,7 +181,7 @@ func GetInterpretationGermline(repo repository.InterpretationsDAO, termsRepo rep
 // @Failure 403 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/interpretations/germline/{sequencing_id}/{locus_id}/{transcript_id} [post]
-func PostInterpretationGermlineDeprecated(repo repository.InterpretationsDAO) gin.HandlerFunc {
+func PostInterpretationGermlineDeprecated(repo interpretationsStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
 		interpretation := &types.InterpretationGermline{}
@@ -213,7 +225,7 @@ func PostInterpretationGermlineDeprecated(repo repository.InterpretationsDAO) gi
 // @Failure 403 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/interpretations/v2/germline/{case_id}/{sequencing_id}/{locus_id}/{transcript_id} [post]
-func PostInterpretationGermline(repo repository.InterpretationsDAO) gin.HandlerFunc {
+func PostInterpretationGermline(repo interpretationsStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
 		interpretation := &types.InterpretationGermline{}
@@ -256,7 +268,7 @@ func PostInterpretationGermline(repo repository.InterpretationsDAO) gin.HandlerF
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/interpretations/somatic/{sequencing_id}/{locus_id}/{transcript_id} [get]
-func GetInterpretationSomaticDeprecated(repo repository.InterpretationsDAO) gin.HandlerFunc {
+func GetInterpretationSomaticDeprecated(repo interpretationsStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseId, sequencingId, locusId, transcriptId := extractInterpretationParams(c)
 		interpretation, err := repo.FirstSomatic(caseId, sequencingId, locusId, transcriptId)
@@ -291,7 +303,7 @@ func GetInterpretationSomaticDeprecated(repo repository.InterpretationsDAO) gin.
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/interpretations/v2/somatic/{case_id}/{sequencing_id}/{locus_id}/{transcript_id} [get]
-func GetInterpretationSomatic(repo repository.InterpretationsDAO, termsRepo repository.TermsDAO) gin.HandlerFunc {
+func GetInterpretationSomatic(repo interpretationsStore, termsRepo termNameReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseId, sequencingId, locusId, transcriptId := extractInterpretationParams(c)
 		interpretation, err := repo.FirstSomatic(caseId, sequencingId, locusId, transcriptId)
@@ -337,7 +349,7 @@ func GetInterpretationSomatic(repo repository.InterpretationsDAO, termsRepo repo
 // @Failure 403 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/interpretations/somatic/{sequencing_id}/{locus_id}/{transcript_id} [post]
-func PostInterpretationSomaticDeprecated(repo repository.InterpretationsDAO) gin.HandlerFunc {
+func PostInterpretationSomaticDeprecated(repo interpretationsStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		interpretation := &types.InterpretationSomatic{}
 		err := c.BindJSON(interpretation)
@@ -380,7 +392,7 @@ func PostInterpretationSomaticDeprecated(repo repository.InterpretationsDAO) gin
 // @Failure 403 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/interpretations/v2/somatic/{case_id}/{sequencing_id}/{locus_id}/{transcript_id} [post]
-func PostInterpretationSomatic(repo repository.InterpretationsDAO) gin.HandlerFunc {
+func PostInterpretationSomatic(repo interpretationsStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		interpretation := &types.InterpretationSomatic{}
 		err := c.BindJSON(interpretation)
@@ -455,7 +467,7 @@ func GetPubmedCitation(pubmedClient client.PubmedClientService) gin.HandlerFunc 
 // @Failure 500 {object} types.ApiError
 // @Param tenant path string true "Tenant code"
 // @Router /{tenant}/interpretations/germline [get]
-func SearchInterpretationGermline(repo repository.InterpretationsDAO) gin.HandlerFunc {
+func SearchInterpretationGermline(repo interpretationsStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		analysisIds := extractArrayQueryParam(c, "analysis_id")
 		patientIds := extractArrayQueryParam(c, "patient_id")
@@ -485,7 +497,7 @@ func SearchInterpretationGermline(repo repository.InterpretationsDAO) gin.Handle
 // @Failure 500 {object} types.ApiError
 // @Param tenant path string true "Tenant code"
 // @Router /{tenant}/interpretations/somatic [get]
-func SearchInterpretationSomatic(repo repository.InterpretationsDAO) gin.HandlerFunc {
+func SearchInterpretationSomatic(repo interpretationsStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		analysisIds := extractArrayQueryParam(c, "analysis_id")
 		patientIds := extractArrayQueryParam(c, "patient_id")

--- a/backend/internal/server/handlers_somatic_snv_occurrences.go
+++ b/backend/internal/server/handlers_somatic_snv_occurrences.go
@@ -5,9 +5,12 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 )
+
+type somaticInterpretationCountsReader interface {
+	RetrieveSomaticInterpretationClassificationCounts(locusId int) (types.JsonMap[string, int], error)
+}
 
 type somaticSNVOccurrencesReader interface {
 	GetOccurrences(caseId int, seqId int, taskId int, userFilter types.ListQuery) ([]types.SomaticSNVOccurrence, error)
@@ -325,7 +328,7 @@ func OccurrencesSomaticSNVStatisticsHandler(repo somaticSNVOccurrencesReader) gi
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/occurrences/somatic/snv/{case_id}/{seq_id}/{task_id}/{locus_id}/expanded [get]
-func GetExpandedSomaticSNVOccurrence(repo somaticSNVOccurrencesReader, interpretationRepo repository.InterpretationsDAO) gin.HandlerFunc {
+func GetExpandedSomaticSNVOccurrence(repo somaticSNVOccurrencesReader, interpretationRepo somaticInterpretationCountsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		caseId, errSeq := strconv.Atoi(c.Param("case_id"))
 		if errSeq != nil {

--- a/backend/internal/server/handlers_variants.go
+++ b/backend/internal/server/handlers_variants.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/radiant-network/radiant-api/internal/repository"
 	"github.com/radiant-network/radiant-api/internal/types"
 )
 
@@ -82,7 +81,7 @@ func GetGermlineVariantHeader(repo variantsReader) gin.HandlerFunc {
 // @Failure 404 {object} types.ApiError
 // @Failure 500 {object} types.ApiError
 // @Router /{tenant}/variants/germline/{locus_id}/overview [get]
-func GetGermlineVariantOverview(repo variantsReader, exomiserRepository repository.ExomiserDAO, interpretationRepo repository.InterpretationsDAO) gin.HandlerFunc {
+func GetGermlineVariantOverview(repo variantsReader, exomiserRepository exomiserClassificationCountsReader, interpretationRepo germlineInterpretationCountsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		locusID, err := strconv.Atoi(c.Param("locus_id"))
 		if err != nil {


### PR DESCRIPTION
## 📌 Context

Part 5 of the SJRA-1576 refactor that replaces producer-side exported `repository.*DAO` interfaces with **narrow, unexported, consumer-side** interfaces declared in the package that uses them (per `backend/.claude/rules/go-code-review.md` interface-placement guidance). Constructors keep returning concrete `*XxxRepository` structs; existing concretes/mocks satisfy the new interfaces structurally.

This slice covers the three **server-only, cross-file** DAOs — `InterpretationsDAO`, `ExomiserDAO`, `TermsDAO` — which are consumed only by `internal/server` (nothing in `internal/batchval` / `cmd/worker`), so it does not touch `batchval`. After this PR, **14 `*DAO` interfaces remain**.

## 📝 Changes

- Added narrow consumer-side interfaces in `internal/server`:
  - `interpretationsStore` (6 CRUD/search methods) + `termNameReader` — `handlers_interpretations.go`
  - `termAutoCompleter` — `handlers.go`
  - `exomiserClassificationCountsReader` + `germlineInterpretationCountsReader` — `handlers_germline_snv_occurrences.go` (shared with `handlers_variants.go` via the same-package "one declaration in the canonical owner" rule)
  - `somaticInterpretationCountsReader` — `handlers_somatic_snv_occurrences.go`
- Retyped all handler signatures to the new interfaces; dropped the now-unused `repository` import from all **5** handler files.
- Deleted the three producer-side `*DAO` interface declarations from `internal/repository/` (`interpretations.go`, `exomiser.go`, `terms.go`); kept all structs/constructors and the `type Exomiser = types.Exomiser` alias.
- Dropped `ExomiserDAO.GetExomiser` — no consumer invoked it.
- `cmd/api/interpretations_integration_test.go`: retyped the 6 helpers to concrete `*repository.InterpretationsRepository`, and the two terms params to their respective concrete types (`*repository.TermsRepository` / `*MockTermsRepository`).

## ☑️ TO-DOs

- [ ] None

## 🧪 Tests

No behavioral change — pure type-level refactor; existing tests cover the handlers. Verified locally:

- `go build ./...` and `go build ./cmd/...` — clean
- `go vet ./internal/server/` and `go vet ./cmd/api/` — clean apart from pre-existing `types.Count{...}` unkeyed-literal warnings (unrelated)
- `go test ./internal/server/ ./internal/batchval/` — pass

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1576](https://d3b.atlassian.net/browse/SJRA-1576)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- Continues the convention established in Parts 1–4: `Reader`/`Checker` suffix for read-only interfaces, `Store` for CRUD; methods limited to exactly what each consumer file calls (dead contract methods dropped).
- `exomiserClassificationCountsReader` / `germlineInterpretationCountsReader` are declared once in `handlers_germline_snv_occurrences.go` and reused by `handlers_variants.go` (same package, identical method use) — same pattern as the existing `facetsReader`.
- Integration-test helpers in `cmd/api` take concrete repository types (unexported server interfaces aren't importable there) — same approach as Part 4.
- The pre-existing `go vet` `types.Count` unkeyed-literal warnings are not introduced by this PR.

[SJRA-1576]: https://d3b.atlassian.net/browse/SJRA-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ