### PR TITLE
refactor: SJRA-1576 consumer-side interfaces for batchval repositories

### DIFF
--- a/backend/.claude/skills/add-endpoint/SKILL.md
+++ b/backend/.claude/skills/add-endpoint/SKILL.md
@@ -38,14 +38,13 @@ Goal: the data model the endpoint will return is defined, and the DB supports it
 
 ## Step 2 — Repository layer + tests
 
-Goal: a tested DAO method that returns the data the handler will serve.
+Goal: a tested repository method that returns the data the handler will serve.
 
 1. **Pick the right file** in `backend/internal/repository/`:
    - StarRocks-backed repos for cases/variants/genes/etc.
    - PostgreSQL-backed repos for tasks/patients/sequencing/notes/preferences/etc.
-2. **Interface + impl**:
-   - Add the method signature to the existing `XxxDAO` interface in the file.
-   - Implement it on the repository struct. Use GORM (`r.db.Table(...).Where(...).Find(...)`) — match the style of nearby methods.
+2. **Implementation**:
+   - Implement the method on the concrete repository struct (`*XxxRepository`). There is no producer-side `XxxDAO` interface to update — consumers declare their own narrow interface (see Step 3); the concrete method satisfies it for free. Use GORM (`r.db.Table(...).Where(...).Find(...)`) — match the style of nearby methods.
    - Wrap returned errors with `fmt.Errorf("... %w", err)` (project convention).
    - Filter explicitly — never trust caller-side checks. For occurrence-style queries, **always include the partition filter** (`part = ?`) when one applies.
 3. **Tests** in the sibling `*_test.go`:
@@ -57,11 +56,11 @@ Goal: a tested DAO method that returns the data the handler will serve.
 
 ## Step 3 — Handler + tests
 
-Goal: an HTTP handler that parses inputs, calls the DAO, and returns the response.
+Goal: an HTTP handler that parses inputs, calls the repository, and returns the response.
 
 1. **Handler file** in `backend/internal/server/`:
    - Group by resource — extend an existing `handlers_<resource>.go` if one exists, otherwise create one (lowercase, snake_case).
-   - Signature: `func HandlerName(repo repository.XxxDAO) gin.HandlerFunc { return func(c *gin.Context) { ... } }`.
+   - Signature: `func HandlerName(repo xxxReader) gin.HandlerFunc { return func(c *gin.Context) { ... } }`, where `xxxReader` is a **narrow, unexported interface declared in this handler file** listing only the repository methods this handler calls (consumer-side interface placement — see `.claude/rules/go-code-review.md`). Name it for the operation: `Reader` suffix for read-only, `Store` for CRUD/writes. The constructor returns the concrete `*repository.XxxRepository`, which satisfies it for free; `cmd/api` wiring passes the concrete value. Don't reference a `repository.XxxDAO` interface — those no longer exist.
    - Parse path params with `strconv.Atoi(c.Param("..."))`; query with `c.Query("...")`; body with `c.ShouldBindJSON(&dto)`.
    - Use the project's error helpers: `HandleNotFoundError`, `HandleValidationError`, `HandleError` (in `internal/server/errors.go`).
    - Coerce nil slices to `[]T{}` before returning so JSON shows `[]` not `null`.
@@ -81,7 +80,7 @@ Goal: an HTTP handler that parses inputs, calls the DAO, and returns the respons
    // @Router /path/{param} [get]
    ```
 3. **Handler unit tests** in `handlers_<resource>_test.go`:
-   - Build a small mock that implements the DAO interface (return zero values for methods you don't exercise).
+   - Build a small mock that implements the handler's narrow interface (the `xxxReader`/`xxxStore` from Step 3), returning zero values for methods you don't exercise.
    - Cases: happy path, empty result, repo error → 500, each missing/invalid input → 400 or 404, sort/shape assertions on the JSON.
    - Use `httptest.NewRecorder` + `gin.CreateTestContext` per existing handler tests.
 
@@ -153,7 +152,7 @@ Goal: confirm the change compiles and passes against the **whole** backend, not 
 cd backend && make test
 ```
 
-Package-scoped tests can miss cross-package breakage. The most common case: adding a method to a DAO interface satisfied by mocks in other packages (e.g. `cmd/worker`'s test mocks also implement `TaskDAO`). The package you edited compiles, but the consumer package breaks. `make test` is the only thing that catches this consistently.
+Package-scoped tests can miss cross-package breakage. The most common case: a repository method is consumed via a shared interface field (e.g. `batchval.BatchValidationContext`'s reader/store fields) that `cmd/worker` also calls methods on — widening or renaming what that field needs can break a mock in the other package. The package you edited compiles, but the consumer package breaks. `make test` is the only thing that catches this consistently.
 
 If a test fails:
 - **Reproducible failure** in the package you touched → fix the code or test.

--- a/backend/cmd/worker/patient_validation.go
+++ b/backend/cmd/worker/patient_validation.go
@@ -224,7 +224,11 @@ func persistBatchAndPatientRecords(db *gorm.DB, batch *types.Batch, records []*P
 	})
 }
 
-func insertPatientRecords(records []*PatientValidationRecord, repo repository.PatientsDAO) error {
+type patientStore interface {
+	CreatePatient(newPatient *types.Patient) error
+}
+
+func insertPatientRecords(records []*PatientValidationRecord, repo patientStore) error {
 	for _, record := range records {
 		if !record.Skipped {
 			patient := types.Patient{

--- a/backend/cmd/worker/sample_validation.go
+++ b/backend/cmd/worker/sample_validation.go
@@ -180,7 +180,11 @@ func persistBatchAndSampleRecords(db *gorm.DB, batch *types.Batch, records []*Sa
 	})
 }
 
-func insertSampleRecords(records []*SampleValidationRecord, repo repository.SamplesDAO) error {
+type sampleStore interface {
+	CreateSample(newSample *types.Sample) (*types.Sample, error)
+}
+
+func insertSampleRecords(records []*SampleValidationRecord, repo sampleStore) error {
 	createdSamples := make(map[SampleKey]int)
 
 	for _, record := range records {

--- a/backend/internal/batchval/cache_test.go
+++ b/backend/internal/batchval/cache_test.go
@@ -11,7 +11,6 @@ import (
 
 // Mock repositories
 type mockOrgRepo struct {
-	repository.OrganizationDAO
 	GetByCodeFunc func(code string) (*types.Organization, error)
 }
 
@@ -20,7 +19,6 @@ func (m *mockOrgRepo) GetOrganizationByCode(code string) (*types.Organization, e
 }
 
 type mockSampleRepo struct {
-	repository.SamplesDAO
 	GetByIdFunc                                func(id int) (*types.Sample, error)
 	GetSampleByOrgCodeAndSubmitterSampleIdFunc func(orgCode string, submitterSampleId string) (*types.Sample, error)
 }
@@ -33,7 +31,6 @@ func (m *mockSampleRepo) GetSampleByOrgCodeAndSubmitterSampleId(orgCode string, 
 }
 
 type mockValueSetsRepo struct {
-	repository.ValueSetsDAO
 	GetCodesFunc func(vsType repository.ValueSetType) ([]string, error)
 }
 
@@ -42,7 +39,6 @@ func (m *mockValueSetsRepo) GetCodes(vsType repository.ValueSetType) ([]string, 
 }
 
 type mockProjectRepo struct {
-	repository.ProjectDAO
 	GetByCodeFunc func(code string) (*types.Project, error)
 }
 
@@ -63,7 +59,6 @@ func (m *mockCasesRepo) GetCaseBySubmitterCaseIdAndProjectId(submitterCaseId str
 }
 
 type mockPatientRepo struct {
-	repository.PatientsDAO
 	GetByOrgAndSubmitterFunc func(orgCode string, submitterPatientId string) (*types.Patient, error)
 }
 

--- a/backend/internal/batchval/context.go
+++ b/backend/internal/batchval/context.go
@@ -32,19 +32,43 @@ type taskReader interface {
 	GetTaskHasDocumentByDocumentId(documentId int) ([]*types.TaskHasDocument, error)
 }
 
+type familyStore interface {
+	CreateFamily(family *types.Family) error
+}
+
+type organizationReader interface {
+	GetOrganizationByCode(organizationCode string) (*types.Organization, error)
+}
+
+type patientReader interface {
+	GetPatientByOrgCodeAndSubmitterPatientId(organizationCode string, submitterPatientId string) (*types.Patient, error)
+}
+
+type projectReader interface {
+	GetProjectByCode(code string) (*types.Project, error)
+}
+
+type sampleReader interface {
+	GetSampleById(id int) (*types.Sample, error)
+	GetSampleByOrgCodeAndSubmitterSampleId(organizationCode string, submitterSampleId string) (*types.Sample, error)
+}
+
+type valueSetsReader interface {
+	GetCodes(vsType repository.ValueSetType) ([]string, error)
+}
+
 type BatchValidationContext struct {
 	BatchRepo     batchProcessor
 	CasesRepo     casesReader
 	DocRepo       documentsReader
-	FamilyRepo    repository.FamilyDAO
-	ObsCat        repository.ObservationCategoricalDAO
-	OrgRepo       repository.OrganizationDAO
-	PatientRepo   repository.PatientsDAO
-	ProjectRepo   repository.ProjectDAO
-	SampleRepo    repository.SamplesDAO
+	FamilyRepo    familyStore
+	OrgRepo       organizationReader
+	PatientRepo   patientReader
+	ProjectRepo   projectReader
+	SampleRepo    sampleReader
 	SeqExpRepo    sequencingExperimentReader
 	TaskRepo      taskReader
-	ValueSetsRepo repository.ValueSetsDAO
+	ValueSetsRepo valueSetsReader
 	S3FS          utils.FileMetadataGetter
 }
 
@@ -66,7 +90,6 @@ func NewBatchValidationContext(db *gorm.DB) (*BatchValidationContext, error) {
 		CasesRepo:     repository.NewCasesRepository(db),
 		DocRepo:       repository.NewDocumentsRepository(db),
 		FamilyRepo:    repository.NewFamilyRepository(db),
-		ObsCat:        repository.NewObservationCategoricalRepository(db),
 		TaskRepo:      repository.NewTaskRepository(db),
 		S3FS:          s3fs,
 	}, nil

--- a/backend/internal/repository/family.go
+++ b/backend/internal/repository/family.go
@@ -15,11 +15,6 @@ type FamilyRepository struct {
 	db *gorm.DB
 }
 
-type FamilyDAO interface {
-	GetFamilyById(familyId int) (*Family, error)
-	CreateFamily(family *Family) error
-}
-
 func NewFamilyRepository(db *gorm.DB) *FamilyRepository {
 	if db == nil {
 		log.Print("FamilyRepository: db is nil")

--- a/backend/internal/repository/family_history.go
+++ b/backend/internal/repository/family_history.go
@@ -15,11 +15,6 @@ type FamilyHistoryRepository struct {
 	db *gorm.DB
 }
 
-type FamilyHistoryDAO interface {
-	GetById(familyHistoryId int) (*FamilyHistory, error)
-	CreateFamilyHistory(familyHistory *FamilyHistory) error
-}
-
 func NewFamilyHistoryRepository(db *gorm.DB) *FamilyHistoryRepository {
 	if db == nil {
 		log.Print("FamilyHistoryRepository: db is nil")

--- a/backend/internal/repository/obs_categorical.go
+++ b/backend/internal/repository/obs_categorical.go
@@ -15,11 +15,6 @@ type ObservationCategoricalRepository struct {
 	db *gorm.DB
 }
 
-type ObservationCategoricalDAO interface {
-	GetById(obsId int) (*ObservationCategorical, error)
-	CreateObservationCategorical(observation *ObservationCategorical) error
-}
-
 func NewObservationCategoricalRepository(db *gorm.DB) *ObservationCategoricalRepository {
 	if db == nil {
 		log.Print("ObservationCategoricalRepository: db is nil")

--- a/backend/internal/repository/obs_string.go
+++ b/backend/internal/repository/obs_string.go
@@ -15,11 +15,6 @@ type ObservationStringRepository struct {
 	db *gorm.DB
 }
 
-type ObservationStringDAO interface {
-	GetById(obsId int) (*ObservationString, error)
-	CreateObservationString(observation *ObservationString) error
-}
-
 func NewObservationStringRepository(db *gorm.DB) *ObservationStringRepository {
 	if db == nil {
 		log.Print("ObservationStringRepository: db is nil")

--- a/backend/internal/repository/organizations.go
+++ b/backend/internal/repository/organizations.go
@@ -12,10 +12,6 @@ type OrganizationRepository struct {
 	db *gorm.DB
 }
 
-type OrganizationDAO interface {
-	GetOrganizationByCode(organizationCode string) (*types.Organization, error)
-}
-
 func NewOrganizationRepository(db *gorm.DB) *OrganizationRepository {
 	return &OrganizationRepository{db: db}
 }

--- a/backend/internal/repository/patients.go
+++ b/backend/internal/repository/patients.go
@@ -14,11 +14,6 @@ type PatientsRepository struct {
 	db *gorm.DB
 }
 
-type PatientsDAO interface {
-	GetPatientByOrgCodeAndSubmitterPatientId(organizationCode string, submitterPatientId string) (*Patient, error)
-	CreatePatient(newPatient *Patient) error
-}
-
 func NewPatientsRepository(db *gorm.DB) *PatientsRepository {
 	return &PatientsRepository{db: db}
 }

--- a/backend/internal/repository/project.go
+++ b/backend/internal/repository/project.go
@@ -13,10 +13,6 @@ type ProjectRepository struct {
 	db *gorm.DB
 }
 
-type ProjectDAO interface {
-	GetProjectByCode(code string) (*Project, error)
-}
-
 func NewProjectRepository(db *gorm.DB) *ProjectRepository {
 	return &ProjectRepository{db: db}
 }

--- a/backend/internal/repository/samples.go
+++ b/backend/internal/repository/samples.go
@@ -14,13 +14,6 @@ type SamplesRepository struct {
 	db *gorm.DB
 }
 
-type SamplesDAO interface {
-	GetSampleById(id int) (*Sample, error)
-	GetSampleByOrgCodeAndSubmitterSampleId(organizationCode string, submitterSampleId string) (*Sample, error)
-	CreateSample(newSample *Sample) (*Sample, error)
-	GetTypeCodes() ([]string, error)
-}
-
 func NewSamplesRepository(db *gorm.DB) *SamplesRepository {
 	return &SamplesRepository{db: db}
 }

--- a/backend/internal/repository/value_sets.go
+++ b/backend/internal/repository/value_sets.go
@@ -36,10 +36,6 @@ const (
 	ValueSetTaskType                 ValueSetType = "task_type"
 )
 
-type ValueSetsDAO interface {
-	GetCodes(vsType ValueSetType) ([]string, error)
-}
-
 type ValueSetsRepository struct {
 	db       *gorm.DB
 	tableMap map[ValueSetType]string


### PR DESCRIPTION
# SJRA-1576 consumer-side interfaces for batchval repositories

## 📌 Context

Final slice of the SJRA-1576 refactor (Parts 1–6 already merged to `main`). It deletes the
producer-side exported `repository.*DAO` interfaces and replaces them with narrow, unexported,
consumer-side interfaces declared in the package that uses them. Constructors keep returning
concrete `*XxxRepository` structs; mocks satisfy the new interfaces structurally.

This part covers the 9 remaining `*DAO` interfaces, all consumed by `internal/batchval` and/or
`cmd/worker` (none by `internal/server`). After this PR, `grep -rn 'repository\.[A-Za-z]*DAO'
backend/ --include='*.go'` returns zero.

## 📝 Changes

- **`internal/batchval/context.go`**: added 6 consumer-side interfaces — `familyStore`
  (`CreateFamily`), `organizationReader`, `patientReader`, `projectReader`, `sampleReader`,
  `valueSetsReader` — and retyped the matching `BatchValidationContext` fields. Removed the dead
  `ObsCat` field (assigned but never read; ObsCategorical persistence runs through `cmd/worker`'s
  concrete `StorageContext.ObsCatRepo`).
- **`cmd/worker`**: `PatientsDAO`/`SamplesDAO` are cross-consumer — batchval reads (getters) while
  a `cmd/worker` insert func creates. Added local `patientStore` (`patient_validation.go`) and
  `sampleStore` (`sample_validation.go`) interfaces for the insert funcs.
- **`internal/repository/`**: deleted the 9 `*DAO` interface blocks (`family`, `family_history`,
  `organizations`, `patients`, `obs_string`, `project`, `samples`, `value_sets`,
  `obs_categorical`). `FamilyHistoryDAO`/`ObservationStringDAO`/`ObservationCategoricalDAO` had no
  interface consumers (cmd/worker uses concrete types). Concrete repos and their methods are
  untouched (incl. `SamplesRepository.GetTypeCodes`, which has no production consumer but follows
  the `AuthRepository.HasAction` precedent of keeping the concrete method).
- **`internal/batchval/cache_test.go`**: dropped the embedded `repository.XxxDAO` from the 5 mocks
  (`mockOrgRepo`, `mockSampleRepo`, `mockValueSetsRepo`, `mockProjectRepo`, `mockPatientRepo`) —
  each already declares the methods its narrow field interface needs.
- **`add-endpoint` skill** (`backend/.claude/skills/add-endpoint/SKILL.md`): aligned with the new
  convention — handlers declare a narrow consumer-side interface (`xxxReader`/`xxxStore`) instead
  of referencing the now-deleted `repository.XxxDAO`.

## ☑️ TO-DOs

- [ ]

## 🧪 Tests

No behavior change — pure interface relocation. Verified:

- `go build ./...` — clean
- `go vet ./internal/batchval/ ./cmd/worker/` — clean
- `go test ./internal/batchval/ ./cmd/worker/` — green
- `grep -rn 'repository\.[A-Za-z]*DAO' backend/ --include='*.go'` — empty (refactor goal met)

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1576](https://d3b.atlassian.net/browse/SJRA-1576)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- No `cmd/worker` test changes needed: those mocks define methods directly (no DAO embed) and are
  only assigned to context fields — narrowing an interface can only make satisfaction easier.
- `context.go` and the two `cmd/worker` files keep their `repository` import (constructors +
  `repository.ValueSetType`).

[SJRA-1576]: https://d3b.atlassian.net/browse/SJRA-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ