### PR TITLE
fix: SJRA-1587 fail-fast on missing DB TLS in production

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -21,6 +21,7 @@ KEYCLOAK_ADMIN_PASS=admin
 STARROCKS_JWT_JWKS_URL=http://keycloak:8080/realms/CQDG/protocol/openid-connect/certs
 STARROCKS_JWT_REQUIRED_ISSUER=http://localhost:8080/realms/CQDG
 STARROCKS_JWT_REQUIRED_AUDIENCE=radiant
+REQUIRE_DB_TLS=false
 
 PUBMED_BASE_URL=https://api.ncbi.nlm.nih.gov
 RADIANT_AUTHORIZATION_PROVIDER=keycloak

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -124,6 +124,7 @@ Copy `.env.template` → `.env`. Key variables:
 | `DB_HOST/PORT/NAME/USERNAME/PASSWORD` | StarRocks | localhost:9030 |
 | `DB_SSL_CA` | Path to CA bundle to enable TLS to StarRocks; unset = plaintext | — |
 | `PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD` | PostgreSQL | localhost:5432 |
+| `REQUIRE_DB_TLS` | Fail fast at startup if a DB connection wouldn't be encrypted. When `true`, requires `DB_SSL_CA` set (or `DB_SSL_MODE=true`/`skip-verify`) **and** `PGSSLMODE` ∈ {`require`,`verify-ca`,`verify-full`}; otherwise the process exits. Off by default so local dev (plaintext) is unaffected; set `true` in prod manifests. Asserted in `internal/database/tls.go`. | false |
 | `API_PORT` | API listen port | 8090 |
 | `KEYCLOAK_HOST/REALM/CLIENT` | Keycloak | localhost:8080 |
 | `TENANT_ENFORCEMENT_ENABLED` | Enforce tenant membership on `/{tenant}/*` routes (403 on cross-tenant). Off by default so routing can ship before `user_role` is backfilled; set `true` once it is. | false |

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -274,6 +274,10 @@ func main() {
 	flag.Parse()
 	defer glog.Flush()
 
+	if err := database.AssertTLSRequirement(); err != nil {
+		log.Fatal(err)
+	}
+
 	database.MigrateWithEnvDefault()
 
 	// Initialize database connection

--- a/backend/cmd/createuser/main.go
+++ b/backend/cmd/createuser/main.go
@@ -115,6 +115,9 @@ func promptPassword() (string, error) {
 // godotenv/autoload). Against the compose stack, set DB_SSL_MODE=skip-verify so the
 // StarRocks connection uses TLS without cert validation (the stack enables SSL).
 func buildDeps() (service.AdminDeps, error) {
+	if err := database.AssertTLSRequirement(); err != nil {
+		return service.AdminDeps{}, err
+	}
 	pg, err := database.NewPostgresDB()
 	if err != nil {
 		return service.AdminDeps{}, fmt.Errorf("connect postgres: %w", err)

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -28,6 +28,10 @@ func main() {
 	flag.Parse()
 	defer glog.Flush()
 
+	if err := database.AssertTLSRequirement(); err != nil {
+		glog.Fatalf("%v", err)
+	}
+
 	pollIntervalStr := utils.GetEnvOrDefault("POLL_INTERVAL_MS", "1000")
 	pollInterval, pollIntervalErr := strconv.Atoi(pollIntervalStr)
 	if pollIntervalErr != nil {

--- a/backend/internal/database/tls.go
+++ b/backend/internal/database/tls.go
@@ -1,0 +1,69 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/radiant-network/radiant-api/internal/utils"
+)
+
+// requireDBTLSEnv gates the startup TLS assertion. It is off by default so local
+// development is unaffected; production manifests should set it to true.
+const requireDBTLSEnv = "REQUIRE_DB_TLS"
+
+// AssertTLSRequirement fails fast when REQUIRE_DB_TLS is set but the StarRocks or
+// PostgreSQL connection would not be encrypted. It reads the same package-level
+// env vars the connection helpers use (DB_SSL_CA, DB_SSL_MODE, PGSSLMODE) and must
+// be called before any database connection is opened (including migrations).
+// When the gate is unset/false it is a no-op and returns nil.
+func AssertTLSRequirement() error {
+	if !utils.GetBoolEnvOrDefault(requireDBTLSEnv, false) {
+		return nil
+	}
+	return tlsRequirementError(dbSSLCA, dbSSLMode, dbPgSSLMode)
+}
+
+// tlsRequirementError reports every database whose configuration would permit a
+// plaintext connection, aggregated into a single error so an operator sees all the
+// problems to fix at once. It returns nil when both connections are guaranteed encrypted.
+func tlsRequirementError(starrocksCA, starrocksMode, pgSSLMode string) error {
+	var problems []string
+	if !starrocksTLSSecure(starrocksCA, starrocksMode) {
+		problems = append(problems, "StarRocks: set DB_SSL_CA (recommended) or DB_SSL_MODE to true/skip-verify")
+	}
+	if !postgresTLSSecure(pgSSLMode) {
+		problems = append(problems, "Postgres: set PGSSLMODE to require, verify-ca, or verify-full")
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s is set but database TLS is not configured: %s", requireDBTLSEnv, strings.Join(problems, "; "))
+}
+
+// starrocksTLSSecure reports whether the StarRocks connection is guaranteed to be
+// encrypted. A CA bundle (caPath) enables verified TLS; the "true" and "skip-verify"
+// modes also force TLS. The plaintext modes ("", "false", "disable") and "preferred"
+// (which silently falls back to plaintext when the server doesn't offer TLS) are insecure.
+func starrocksTLSSecure(caPath, sslMode string) bool {
+	if caPath != "" {
+		return true
+	}
+	switch sslMode {
+	case "true", "skip-verify":
+		return true
+	default:
+		return false
+	}
+}
+
+// postgresTLSSecure reports whether the PostgreSQL connection is guaranteed to be
+// encrypted. Only require, verify-ca, and verify-full enforce TLS; the default (unset),
+// disable, allow, and prefer all permit a plaintext fallback.
+func postgresTLSSecure(sslMode string) bool {
+	switch sslMode {
+	case "require", "verify-ca", "verify-full":
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/database/tls_test.go
+++ b/backend/internal/database/tls_test.go
@@ -1,0 +1,90 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_starrocksTLSSecure_CASet_Secure(t *testing.T) {
+	assert.True(t, starrocksTLSSecure("/etc/ssl/ca.pem", ""))
+}
+
+func Test_starrocksTLSSecure_TrueMode_Secure(t *testing.T) {
+	assert.True(t, starrocksTLSSecure("", "true"))
+}
+
+func Test_starrocksTLSSecure_SkipVerifyMode_Secure(t *testing.T) {
+	assert.True(t, starrocksTLSSecure("", "skip-verify"))
+}
+
+func Test_starrocksTLSSecure_EmptyMode_Insecure(t *testing.T) {
+	assert.False(t, starrocksTLSSecure("", ""))
+}
+
+func Test_starrocksTLSSecure_FalseMode_Insecure(t *testing.T) {
+	assert.False(t, starrocksTLSSecure("", "false"))
+}
+
+func Test_starrocksTLSSecure_DisableMode_Insecure(t *testing.T) {
+	assert.False(t, starrocksTLSSecure("", "disable"))
+}
+
+func Test_starrocksTLSSecure_PreferredMode_Insecure(t *testing.T) {
+	assert.False(t, starrocksTLSSecure("", "preferred"))
+}
+
+func Test_postgresTLSSecure_Require_Secure(t *testing.T) {
+	assert.True(t, postgresTLSSecure("require"))
+}
+
+func Test_postgresTLSSecure_VerifyCA_Secure(t *testing.T) {
+	assert.True(t, postgresTLSSecure("verify-ca"))
+}
+
+func Test_postgresTLSSecure_VerifyFull_Secure(t *testing.T) {
+	assert.True(t, postgresTLSSecure("verify-full"))
+}
+
+func Test_postgresTLSSecure_Empty_Insecure(t *testing.T) {
+	assert.False(t, postgresTLSSecure(""))
+}
+
+func Test_postgresTLSSecure_Disable_Insecure(t *testing.T) {
+	assert.False(t, postgresTLSSecure("disable"))
+}
+
+func Test_postgresTLSSecure_Allow_Insecure(t *testing.T) {
+	assert.False(t, postgresTLSSecure("allow"))
+}
+
+func Test_postgresTLSSecure_Prefer_Insecure(t *testing.T) {
+	assert.False(t, postgresTLSSecure("prefer"))
+}
+
+func Test_tlsRequirementError_BothSecure_NoError(t *testing.T) {
+	assert.NoError(t, tlsRequirementError("/etc/ssl/ca.pem", "", "require"))
+}
+
+func Test_tlsRequirementError_StarrocksInsecure_MentionsStarrocksOnly(t *testing.T) {
+	err := tlsRequirementError("", "disable", "require")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "StarRocks")
+	assert.NotContains(t, err.Error(), "Postgres")
+}
+
+func Test_tlsRequirementError_PostgresInsecure_MentionsPostgresOnly(t *testing.T) {
+	err := tlsRequirementError("/etc/ssl/ca.pem", "", "disable")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Postgres")
+	assert.NotContains(t, err.Error(), "StarRocks")
+}
+
+func Test_tlsRequirementError_BothInsecure_MentionsBoth(t *testing.T) {
+	err := tlsRequirementError("", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "StarRocks")
+	assert.Contains(t, err.Error(), "Postgres")
+	assert.Contains(t, err.Error(), requireDBTLSEnv)
+}


### PR DESCRIPTION
## 📌 Context

StarRocks (`DB_SSL_CA` / `DB_SSL_MODE`) and Postgres (`PGSSLMODE`) default to **plaintext** and TLS is silently opt-in when unset (`internal/database/`). For a PII/genomic platform, a misconfigured production deploy would connect in cleartext with no signal.

This PR (SJRA-1587, P0 — Security/correctness) adds a startup assertion gated by a new `REQUIRE_DB_TLS` env var that **fails fast** when TLS isn't configured — without changing local-dev defaults (gate is off by default).

## 📝 Changes

- **New `backend/internal/database/tls.go`** — `AssertTLSRequirement()`: a no-op unless `REQUIRE_DB_TLS=true`, otherwise it verifies both DB connections would be encrypted and returns an aggregated error listing every misconfigured DB at once.
  - Rule = connection must be **guaranteed encrypted**: StarRocks secure if `DB_SSL_CA` is set (recommended) or `DB_SSL_MODE` ∈ {`true`, `skip-verify`}; Postgres secure if `PGSSLMODE` ∈ {`require`, `verify-ca`, `verify-full`}. Rejects `preferred`/`prefer`/`allow`/`disable`/empty, which all permit a plaintext fallback.
  - Reuses the existing `utils.GetBoolEnvOrDefault` gate helper (same pattern as `TENANT_ENFORCEMENT_ENABLED`).
- **Wired into all three entrypoints, before any connection is opened** (including migrations, which also open a plaintext PG connection):
  - `cmd/api/main.go` — before `MigrateWithEnvDefault()`, `log.Fatal` on error.
  - `cmd/worker/main.go` — top of `main`, `glog.Fatalf`.
  - `cmd/createuser/main.go` — top of `buildDeps`, returns the error (reported by the existing `log.Fatalf`).
- **Docs/config** — added `REQUIRE_DB_TLS` to the `backend/CLAUDE.md` config table and `backend/.env.template` (defaults to `false`).

## ☑️ TO-DOs

- [ ] Set `REQUIRE_DB_TLS=true` in production manifests (separate ops change; out of scope here).

## 🧪 Tests

New `backend/internal/database/tls_test.go` — 18 explicit `Test_Subject_Case` unit tests (no DB/env needed) covering both predicates' secure/insecure branches (incl. empty-input edge) and the aggregated-error cases (StarRocks-only, Postgres-only, both).

```bash
cd backend
go build ./...
go test ./internal/database/
```

All pass; `go vet` clean on touched packages.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1587](https://d3b.atlassian.net/browse/SJRA-1587)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Strictness decision:** the rule requires *encryption*, not necessarily full server verification — i.e. `skip-verify` (StarRocks) and `require` (Postgres) are accepted. Tightening to verification-only (`DB_SSL_CA` / `verify-full`) is a one-line change to the two predicates if preferred.
- Gate defaults to `false`, so local dev (which uses `PGSSLMODE=disable`) is unaffected. Note that with the gate on, the local default would intentionally fail the assertion.

[SJRA-1587]: https://d3b.atlassian.net/browse/SJRA-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ