### PR TITLE
feat(backend): SJRA-1591 add graceful shutdown to API and worker

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/radiant-network/radiant-api/internal/authorization"
@@ -292,9 +297,27 @@ func main() {
 		p = "8090"
 	}
 
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	r := setupRouter(dbStarrocks, dbPostgres)
-	err = r.Run(fmt.Sprintf(":%s", p))
-	if err != nil {
-		log.Fatal(err)
+	srv := &http.Server{Addr: fmt.Sprintf(":%s", p), Handler: r}
+
+	go func() {
+		glog.Infof("API server listening on :%s", p)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal(err)
+		}
+	}()
+
+	<-ctx.Done()
+	stop() // restore default signal handling so a second signal force-quits
+	glog.Info("Shutdown signal received, draining connections...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), utils.ShutdownTimeout())
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		glog.Errorf("API server shutdown error: %v", err)
 	}
+	glog.Info("API server shut down cleanly")
 }

--- a/backend/cmd/worker/case_patch_validation.go
+++ b/backend/cmd/worker/case_patch_validation.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -183,34 +185,41 @@ func validatePatchTasks(ctx *batchval.BatchValidationContext, cache *batchval.Ba
 // processPatchCaseBatch handles PATCH /cases/batch: it links existing
 // sequencing experiments to an existing case (case_has_sequencing_experiment). It never
 // creates the case — a missing case is CASE-012, a missing experiment is SEQ-007.
-func processPatchCaseBatch(ctx *batchval.BatchValidationContext, batch *types.Batch, db *gorm.DB) {
+func processPatchCaseBatch(ctx context.Context, bv *batchval.BatchValidationContext, batch *types.Batch, db *gorm.DB) error {
 	var patches []types.CaseBatchPatch
 	if err := json.Unmarshal([]byte(batch.Payload), &patches); err != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error unmarshalling patch_case batch: %v", err), ctx.BatchRepo)
-		return
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error unmarshalling patch_case batch: %v", err), bv.BatchRepo)
+		return nil
 	}
 
-	cache := batchval.NewBatchValidationCache(ctx)
+	cache := batchval.NewBatchValidationCache(bv)
 	var records []*PatchCaseValidationRecord
 	for i, p := range patches {
-		rec, err := validatePatchCaseRecord(ctx, cache, p, i)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		rec, err := validatePatchCaseRecord(bv, cache, p, i)
 		if err != nil {
-			batchval.ProcessUnexpectedError(batch, fmt.Errorf("error validating patch_case batch: %v", err), ctx.BatchRepo)
-			return
+			batchval.ProcessUnexpectedError(batch, fmt.Errorf("error validating patch_case batch: %v", err), bv.BatchRepo)
+			return nil
 		}
 		records = append(records, rec)
 	}
 
 	glog.Infof("Patch_case batch %v processed with %d records", batch.ID, len(records))
 
-	if err := persistBatchAndPatchCaseRecords(db, batch, records); err != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error processing patch_case batch records: %v", err), ctx.BatchRepo)
-		return
+	if err := persistBatchAndPatchCaseRecords(ctx, db, batch, records); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error processing patch_case batch records: %v", err), bv.BatchRepo)
+		return nil
 	}
+	return nil
 }
 
-func persistBatchAndPatchCaseRecords(db *gorm.DB, batch *types.Batch, records []*PatchCaseValidationRecord) error {
-	return db.Transaction(func(tx *gorm.DB) error {
+func persistBatchAndPatchCaseRecords(ctx context.Context, db *gorm.DB, batch *types.Batch, records []*PatchCaseValidationRecord) error {
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		batchRepo := repository.NewBatchRepository(tx)
 		rowsUpdated, err := batchval.UpdateBatch(batch, records, batchRepo)
 		if err != nil {

--- a/backend/cmd/worker/case_validation.go
+++ b/backend/cmd/worker/case_validation.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"slices"
@@ -1264,32 +1266,38 @@ func validateCaseRecord(
 	return cr, nil
 }
 
-func processCaseBatch(ctx *batchval.BatchValidationContext, batch *types.Batch, db *gorm.DB) {
+func processCaseBatch(ctx context.Context, bv *batchval.BatchValidationContext, batch *types.Batch, db *gorm.DB) error {
 	payload := []byte(batch.Payload)
 	var caseBatches []types.CaseBatch
 
 	if unexpectedErr := json.Unmarshal(payload, &caseBatches); unexpectedErr != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error unmarshalling case batch: %v", unexpectedErr), ctx.BatchRepo)
-		return
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error unmarshalling case batch: %v", unexpectedErr), bv.BatchRepo)
+		return nil
 	}
 
-	records, unexpectedErr := validateCaseBatch(ctx, caseBatches)
+	records, unexpectedErr := validateCaseBatch(ctx, bv, caseBatches)
 	if unexpectedErr != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error case batch validation: %v", unexpectedErr), ctx.BatchRepo)
-		return
+		if errors.Is(unexpectedErr, context.Canceled) {
+			return unexpectedErr
+		}
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error case batch validation: %v", unexpectedErr), bv.BatchRepo)
+		return nil
 	}
 
 	glog.Infof("Case batch %v processed with %d records", batch.ID, len(records))
 
-	err := persistBatchAndCaseRecords(db, batch, records)
-	if err != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error processing case batch records: %v", err), ctx.BatchRepo)
-		return
+	if err := persistBatchAndCaseRecords(ctx, db, batch, records); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error processing case batch records: %v", err), bv.BatchRepo)
+		return nil
 	}
+	return nil
 }
 
-func persistBatchAndCaseRecords(db *gorm.DB, batch *types.Batch, records []*CaseValidationRecord) error {
-	return db.Transaction(func(tx *gorm.DB) error {
+func persistBatchAndCaseRecords(ctx context.Context, db *gorm.DB, batch *types.Batch, records []*CaseValidationRecord) error {
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		batchRepo := repository.NewBatchRepository(tx)
 		txCtx := NewStorageContext(tx)
 		rowsUpdated, unexpectedErrUpdate := batchval.UpdateBatch(batch, records, batchRepo)
@@ -1596,19 +1604,22 @@ func persistTask(ctx *StorageContext, cr *CaseValidationRecord) error {
 	return nil
 }
 
-func validateCaseBatch(ctx *batchval.BatchValidationContext, cases []types.CaseBatch) ([]*CaseValidationRecord, error) {
+func validateCaseBatch(ctx context.Context, bv *batchval.BatchValidationContext, cases []types.CaseBatch) ([]*CaseValidationRecord, error) {
 	var records []*CaseValidationRecord
-	cache := batchval.NewBatchValidationCache(ctx)
+	cache := batchval.NewBatchValidationCache(bv)
 
 	visited := map[CaseKey]struct{}{}
 
 	for idx, c := range cases {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		key := CaseKey{
 			ProjectCode:     c.ProjectCode,
 			SubmitterCaseID: c.SubmitterCaseId,
 		}
 
-		record, err := validateCaseRecord(ctx, cache, c, idx)
+		record, err := validateCaseRecord(bv, cache, c, idx)
 		if err != nil {
 			return nil, fmt.Errorf("error during case validation: %v", err)
 		}

--- a/backend/cmd/worker/case_validation_test.go
+++ b/backend/cmd/worker/case_validation_test.go
@@ -2098,7 +2098,7 @@ func Test_validateCaseBatch_OK(t *testing.T) {
 		TaskRepo:      &mockRepo,
 	}
 
-	vr, err := validateCaseBatch(&mockContext, []types.CaseBatch{
+	vr, err := validateCaseBatch(t.Context(), &mockContext, []types.CaseBatch{
 		{
 			ProjectCode:                "PROJ-1",
 			AnalysisCode:               "WGA",
@@ -2196,7 +2196,7 @@ func Test_validateCaseBatch_Duplicates(t *testing.T) {
 		},
 	}
 
-	vr, err := validateCaseBatch(&mockContext, []types.CaseBatch{batch, batch})
+	vr, err := validateCaseBatch(t.Context(), &mockContext, []types.CaseBatch{batch, batch})
 	assert.NoError(t, err)
 	assert.Empty(t, vr[0].Infos)
 	assert.Empty(t, vr[0].Warnings)

--- a/backend/cmd/worker/integration_test.go
+++ b/backend/cmd/worker/integration_test.go
@@ -29,7 +29,7 @@ func insertPayloadAndProcessBatch(db *gorm.DB, payload string, status types.Batc
 		panic(fmt.Sprintf("failed to insert payload into table %v", initErr))
 	}
 	ctx, _ := batchval.NewBatchValidationContext(db)
-	processBatch(db, ctx)
+	processBatch(context.Background(), db, ctx)
 	return id
 }
 
@@ -72,7 +72,7 @@ func Test_ProcessBatch_Patient_Success_Dry_Run(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -124,7 +124,7 @@ func Test_ProcessBatch_Patient_Skipped(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -170,7 +170,7 @@ func Test_ProcessBatch_Patient_Errors(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -283,7 +283,7 @@ func Test_ProcessBatch_Patient_Success_Not_Dry_Run(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -333,7 +333,7 @@ func Test_ProcessBatch_Sample_Success_Dry_Run(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -381,7 +381,7 @@ func Test_ProcessBatch_Sample_Success_Not_Dry_Run(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -434,7 +434,7 @@ func Test_ProcessBatch_Sample_Already_Exists_Skipped(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -477,7 +477,7 @@ func Test_ProcessBatch_Sample_Existing_Different_Field_Warning(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -515,7 +515,7 @@ func Test_ProcessBatch_Sample_Patient_Not_Exist(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -551,7 +551,7 @@ func Test_ProcessBatch_Sample_Organization_Not_Exist(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -597,7 +597,7 @@ func Test_ProcessBatch_Sample_Parent_Sample_In_Batch(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -650,7 +650,7 @@ func Test_ProcessBatch_Sample_Parent_Sample_In_Db(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -703,7 +703,7 @@ func Test_ProcessBatch_Sample_Unknown_Parent_Sample(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -747,7 +747,7 @@ func Test_ProcessBatch_Sample_Invalid_Patient_For_Parent_Sample(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -792,7 +792,7 @@ func Test_ProcessBatch_Sample_Duplicate_In_Batch(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -829,7 +829,7 @@ func Test_ProcessBatch_Sample_Field_Too_Long(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -927,7 +927,7 @@ func Test_ProcessBatch_SequencingExperiment_Success_Dry_Run(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
@@ -987,7 +987,7 @@ func Test_ProcessBatch_SequencingExperiment_Success_Not_Dry_Run(t *testing.T) {
 		}
 		assert.Equal(t, int64(0), count)
 
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 		if err := db.Table("sequencing_experiment").Where("aliquot = ?", "ALIQUOT-12345").Count(&count).Error; err != nil {
 			t.Fatal("failed to count sequencing_experiment:", err)
 		}
@@ -1062,7 +1062,7 @@ func Test_ProcessBatch_SequencingExperiment_Info_Skipped(t *testing.T) {
 		assert.Equal(t, int64(0), count)
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 		if err := db.Table("sequencing_experiment").Where("aliquot = ?", "ALIQUOT-12345").Count(&count).Error; err != nil {
 			t.Fatal("failed to count sequencing_experiment:", err)
 		}
@@ -1076,7 +1076,7 @@ func Test_ProcessBatch_SequencingExperiment_Info_Skipped(t *testing.T) {
 			t.Fatal("failed to insert data:", initErr)
 		}
 
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 		if err := db.Table("sequencing_experiment").Where("aliquot = ?", "ALIQUOT-12345").Count(&count).Error; err != nil {
 			t.Fatal("failed to count sequencing_experiment:", err)
 		}
@@ -1134,7 +1134,7 @@ func Test_ProcessBatch_SequencingExperiment_Warning_Skipped(t *testing.T) {
 		assert.Equal(t, int64(0), count)
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 		if err := db.Table("sequencing_experiment").Where("aliquot = ?", "ALIQUOT-12345").Count(&count).Error; err != nil {
 			t.Fatal("failed to count sequencing_experiment:", err)
 		}
@@ -1166,7 +1166,7 @@ func Test_ProcessBatch_SequencingExperiment_Warning_Skipped(t *testing.T) {
 			t.Fatal("failed to insert data:", initErr)
 		}
 
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 		if err := db.Table("sequencing_experiment").Where("aliquot = ?", "ALIQUOT-12345").Count(&count).Error; err != nil {
 			t.Fatal("failed to count sequencing_experiment:", err)
 		}
@@ -1228,7 +1228,7 @@ func Test_ProcessBatch_SequencingExperiment_Errors(t *testing.T) {
 		assert.Equal(t, int64(0), count)
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 		if err := db.Table("sequencing_experiment").Where("aliquot = ?", "ALIQUOT-12345").Count(&count).Error; err != nil {
 			t.Fatal("failed to count sequencing_experiment:", err)
 		}
@@ -1286,7 +1286,7 @@ func Test_ProcessBatch_SequencingExperiment_Errors_InvalidOrgs(t *testing.T) {
 		assert.Equal(t, int64(0), count)
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 		if err := db.Table("sequencing_experiment").Where("aliquot = ?", "ALIQUOT-12345").Count(&count).Error; err != nil {
 			t.Fatal("failed to count sequencing_experiment:", err)
 		}
@@ -1358,7 +1358,7 @@ func Test_ProcessBatch_SequencingExperiment_DuplicateInBatch(t *testing.T) {
 		assert.Equal(t, int64(0), count)
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 		if err := db.Table("sequencing_experiment").Where("aliquot = ?", "ALIQUOT-12345").Count(&count).Error; err != nil {
 			t.Fatal("failed to count sequencing_experiment:", err)
 		}
@@ -1511,7 +1511,7 @@ func Test_ProcessBatch_Unsupported_Type(t *testing.T) {
 		}
 
 		context, _ := batchval.NewBatchValidationContext(db)
-		processBatch(db, context)
+		processBatch(t.Context(), db, context)
 
 		resultBatch := repository.Batch{}
 		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
+	"os/signal"
 	"strconv"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/golang/glog"
@@ -16,7 +21,7 @@ import (
 	"gorm.io/gorm"
 )
 
-var supportedProcessors = map[string]func(*batchval.BatchValidationContext, *types.Batch, *gorm.DB){
+var supportedProcessors = map[string]func(context.Context, *batchval.BatchValidationContext, *types.Batch, *gorm.DB) error{
 	types.PatientBatchType:              processPatientBatch,
 	types.SampleBatchType:               processSampleBatch,
 	types.SequencingExperimentBatchType: processSequencingExperimentBatch,
@@ -27,6 +32,9 @@ var supportedProcessors = map[string]func(*batchval.BatchValidationContext, *typ
 func main() {
 	flag.Parse()
 	defer glog.Flush()
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	pollIntervalStr := utils.GetEnvOrDefault("POLL_INTERVAL_MS", "1000")
 	pollInterval, pollIntervalErr := strconv.Atoi(pollIntervalStr)
@@ -39,23 +47,44 @@ func main() {
 		glog.Fatalf("Failed to initialize postgres database: %v", initDbErr)
 	}
 
-	context, err := batchval.NewBatchValidationContext(dbPostgres)
+	bv, err := batchval.NewBatchValidationContext(dbPostgres)
 	if err != nil {
 		glog.Fatalf("Failed to initialize batch validation context: %v", err)
 	}
 
-	StartHealthProbe(dbPostgres)
-	StartCleanUpWorker(dbPostgres)
+	var wg sync.WaitGroup
+	StartHealthProbe(ctx, &wg, dbPostgres)
+	StartCleanUpWorker(ctx, &wg, dbPostgres)
 
 	glog.Info("Worker started...")
+	runPollLoop(ctx, dbPostgres, bv, time.Duration(pollInterval)*time.Millisecond)
+
+	// Wait for the background goroutines (health probe, cleanup worker) to stop before exiting.
+	wg.Wait()
+	glog.Info("Worker shut down cleanly")
+}
+
+// runPollLoop claims and processes batches until ctx is cancelled. It checks ctx before claiming a
+// new batch (so a shutdown signal stops it taking on more work); processBatch itself requeues an
+// interrupted in-flight batch back to PENDING.
+func runPollLoop(ctx context.Context, db *gorm.DB, bv *batchval.BatchValidationContext, pollInterval time.Duration) {
 	for {
-		processBatch(dbPostgres, context)
-		time.Sleep(time.Duration(pollInterval) * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		processBatch(ctx, db, bv)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(pollInterval):
+		}
 	}
 }
 
-func processBatch(db *gorm.DB, ctx *batchval.BatchValidationContext) {
-	nextBatch, err := ctx.BatchRepo.ClaimNextBatch()
+func processBatch(ctx context.Context, db *gorm.DB, bv *batchval.BatchValidationContext) {
+	nextBatch, err := bv.BatchRepo.ClaimNextBatch()
 	if err != nil {
 		glog.Errorf("Error claiming next batch: %v", err)
 		return
@@ -68,14 +97,21 @@ func processBatch(db *gorm.DB, ctx *batchval.BatchValidationContext) {
 	processFn, ok := supportedProcessors[nextBatch.BatchType]
 	if !ok {
 		err = fmt.Errorf("batch type %v not supported", nextBatch.BatchType)
-		batchval.ProcessUnexpectedError(nextBatch, err, ctx.BatchRepo)
+		batchval.ProcessUnexpectedError(nextBatch, err, bv.BatchRepo)
 		return
 	}
 
-	processFn(ctx, nextBatch, db)
+	// On a graceful shutdown the processor aborts before committing and returns context.Canceled;
+	// release the claim back to PENDING so the batch is reprocessed cleanly instead of left RUNNING.
+	if procErr := processFn(ctx, bv, nextBatch, db); errors.Is(procErr, context.Canceled) {
+		glog.Infof("Shutdown during batch %v; releasing it back to PENDING", nextBatch.ID)
+		if _, relErr := bv.BatchRepo.ReleaseBatch(nextBatch.ID); relErr != nil {
+			glog.Errorf("Failed to release batch %v: %v", nextBatch.ID, relErr)
+		}
+	}
 }
 
-func StartHealthProbe(db *gorm.DB) {
+func StartHealthProbe(ctx context.Context, wg *sync.WaitGroup, db *gorm.DB) {
 	port := utils.GetEnvOrDefault("PROBE_PORT", "9999")
 	if _, err := strconv.Atoi(port); err != nil {
 		glog.Fatalf("Probe port defined in env var PROBE_PORT (%v) must be an integer ", port)
@@ -101,17 +137,32 @@ func StartHealthProbe(db *gorm.DB) {
 		Handler: mux,
 	}
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		glog.Infof("Starting health probe on :%s", port)
 
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			glog.Fatalf("Failed to start health probe: %v", err)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			glog.Errorf("Health probe stopped unexpectedly: %v", err)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), utils.ShutdownTimeout())
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			glog.Errorf("Health probe shutdown error: %v", err)
 		}
 	}()
 }
 
-func StartCleanUpWorker(db *gorm.DB) {
+func StartCleanUpWorker(ctx context.Context, wg *sync.WaitGroup, db *gorm.DB) {
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		cleanUpIntervalPollHourStr := utils.GetEnvOrDefault("CLEAN_UP_INTERVAL_POLL_HOUR", "24")
 		pollInterval, pollIntervalErr := strconv.Atoi(cleanUpIntervalPollHourStr)
 		if pollIntervalErr != nil {
@@ -125,15 +176,20 @@ func StartCleanUpWorker(db *gorm.DB) {
 		ticker := time.NewTicker(duration)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			glog.Info("Clean up worker started...")
-			batchRepo := repository.NewBatchRepository(db)
-			rowUpdated, err := batchRepo.UpdateStuckBatch()
-			if err != nil {
-				glog.Errorf("Error executing batch clean up: %v", err)
+		for {
+			select {
+			case <-ctx.Done():
 				return
+			case <-ticker.C:
+				glog.Info("Clean up worker started...")
+				batchRepo := repository.NewBatchRepository(db)
+				rowUpdated, err := batchRepo.UpdateStuckBatch()
+				if err != nil {
+					glog.Errorf("Error executing batch clean up: %v", err)
+					continue
+				}
+				glog.Info("Stuck batches updated: ", rowUpdated)
 			}
-			glog.Info("Stuck batches updated: ", rowUpdated)
 		}
 	}()
 }

--- a/backend/cmd/worker/main_test.go
+++ b/backend/cmd/worker/main_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/radiant-network/radiant-api/internal/batchval"
+	"github.com/radiant-network/radiant-api/internal/repository"
+	"github.com/radiant-network/radiant-api/internal/types"
+	"github.com/radiant-network/radiant-api/test/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeBatchRepo satisfies the (unexported) batchProcessor interface used by
+// BatchValidationContext.BatchRepo, returning no work so the poll loop spins without a DB.
+type fakeBatchRepo struct{}
+
+func (fakeBatchRepo) ClaimNextBatch() (*types.Batch, error)  { return nil, nil }
+func (fakeBatchRepo) UpdateBatch(types.Batch) (int64, error) { return 1, nil }
+func (fakeBatchRepo) ReleaseBatch(string) (int64, error)     { return 1, nil }
+
+func waitWithTimeout(t *testing.T, wg *sync.WaitGroup, d time.Duration, name string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("%s did not stop within %v after context cancellation", name, d)
+	}
+}
+
+func Test_runPollLoop_StopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	bv := &batchval.BatchValidationContext{BatchRepo: fakeBatchRepo{}}
+
+	done := make(chan struct{})
+	go func() {
+		runPollLoop(ctx, nil, bv, 10*time.Millisecond)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runPollLoop did not return after context cancellation")
+	}
+}
+
+func Test_StartCleanUpWorker_StopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	StartCleanUpWorker(ctx, &wg, nil) // db is only touched on a tick, which never fires here
+	cancel()
+	waitWithTimeout(t, &wg, 2*time.Second, "clean-up worker")
+}
+
+func Test_StartHealthProbe_ShutsDownOnContextCancel(t *testing.T) {
+	t.Setenv("PROBE_PORT", "0") // random free port; the handler is never hit so db can be nil
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	StartHealthProbe(ctx, &wg, nil)
+	cancel()
+	waitWithTimeout(t, &wg, 5*time.Second, "health probe")
+}
+
+// Test_processBatch_RequeuesInflightBatchOnCancel verifies the JIRA acceptance criterion: when the
+// shutdown context is cancelled while a batch is in flight, the claimed batch is released back to
+// PENDING (started_on cleared) and nothing is persisted, so it can be reprocessed cleanly.
+func Test_processBatch_RequeuesInflightBatchOnCancel(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.ExclusivePostgres}, func(t *testing.T, env *testutils.Env) {
+		db := env.Postgres
+
+		payload := `[{"submitter_patient_id":"REQUEUE-1","submitter_patient_id_type":"mrn","patient_organization_code":"CHUSJ","sex_code":"female","life_status_code":"alive","date_of_birth":"2010-05-15"}]`
+		var id string
+		// created_on far in the past so ClaimNextBatch (oldest-first) picks this batch.
+		insertErr := db.Raw(`
+			INSERT INTO batch (payload, status, batch_type, dry_run, username, created_on)
+			VALUES (?, 'PENDING', ?, true, 'user-requeue', '2000-01-01')
+			RETURNING id;
+		`, payload, types.PatientBatchType).Scan(&id).Error
+		if insertErr != nil {
+			t.Fatal("failed to insert batch:", insertErr)
+		}
+
+		// Context already cancelled: the batch is claimed (→ RUNNING) then the processor aborts at
+		// the first validation checkpoint and returns context.Canceled, triggering the requeue.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		bv := &batchval.BatchValidationContext{BatchRepo: repository.NewBatchRepository(db)}
+		processBatch(ctx, db, bv)
+
+		result := types.Batch{}
+		db.Table("batch").Where("id = ?", id).Scan(&result)
+		assert.Equal(t, types.BatchStatusPending, result.Status)
+		assert.Nil(t, result.StartedOn)
+
+		var patientCount int64
+		db.Table("patient").Where("submitter_patient_id = ?", "REQUEUE-1").Count(&patientCount)
+		assert.Equal(t, int64(0), patientCount)
+	})
+}

--- a/backend/cmd/worker/patient_validation.go
+++ b/backend/cmd/worker/patient_validation.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"slices"
@@ -178,32 +180,38 @@ func validateIsDifferentExistingPatientField[T comparable](
 	return false
 }
 
-func processPatientBatch(ctx *batchval.BatchValidationContext, batch *types.Batch, db *gorm.DB) {
+func processPatientBatch(ctx context.Context, bv *batchval.BatchValidationContext, batch *types.Batch, db *gorm.DB) error {
 	payload := []byte(batch.Payload)
 	var patients []types.PatientBatch
 
 	if unexpectedErr := json.Unmarshal(payload, &patients); unexpectedErr != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error unmarshalling patient batch: %v", unexpectedErr), ctx.BatchRepo)
-		return
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error unmarshalling patient batch: %v", unexpectedErr), bv.BatchRepo)
+		return nil
 	}
 
-	records, unexpectedErr := validatePatientsBatch(ctx, patients)
+	records, unexpectedErr := validatePatientsBatch(ctx, bv, patients)
 	if unexpectedErr != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error patient batch validation: %v", unexpectedErr), ctx.BatchRepo)
-		return
+		if errors.Is(unexpectedErr, context.Canceled) {
+			return unexpectedErr
+		}
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error patient batch validation: %v", unexpectedErr), bv.BatchRepo)
+		return nil
 	}
 
 	glog.Infof("Patient batch %v processed with %d records", batch.ID, len(records))
 
-	err := persistBatchAndPatientRecords(db, batch, records)
-	if err != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error processing patient batch records: %v", err), ctx.BatchRepo)
-		return
+	if err := persistBatchAndPatientRecords(ctx, db, batch, records); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error processing patient batch records: %v", err), bv.BatchRepo)
+		return nil
 	}
+	return nil
 }
 
-func persistBatchAndPatientRecords(db *gorm.DB, batch *types.Batch, records []*PatientValidationRecord) error {
-	return db.Transaction(func(tx *gorm.DB) error {
+func persistBatchAndPatientRecords(ctx context.Context, db *gorm.DB, batch *types.Batch, records []*PatientValidationRecord) error {
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		txRepoPatient := repository.NewPatientsRepository(tx)
 		txRepoBatch := repository.NewBatchRepository(tx)
 		rowsUpdated, unexpectedErrUpdate := batchval.UpdateBatch(batch, records, txRepoBatch)
@@ -254,12 +262,15 @@ func insertPatientRecords(records []*PatientValidationRecord, repo patientStore)
 	return nil
 }
 
-func validatePatientsBatch(ctx *batchval.BatchValidationContext, patients []types.PatientBatch) ([]*PatientValidationRecord, error) {
+func validatePatientsBatch(ctx context.Context, bv *batchval.BatchValidationContext, patients []types.PatientBatch) ([]*PatientValidationRecord, error) {
 	var records []*PatientValidationRecord
-	cache := batchval.NewBatchValidationCache(ctx)
+	cache := batchval.NewBatchValidationCache(bv)
 	seenPatients := map[batchval.PatientKey]struct{}{}
 	for index, patient := range patients {
-		record, err := validatePatientRecord(ctx, cache, patient, index, seenPatients)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		record, err := validatePatientRecord(bv, cache, patient, index, seenPatients)
 		if err != nil {
 			return nil, fmt.Errorf("error during patient validation: %v", err)
 		}

--- a/backend/cmd/worker/patient_validation_test.go
+++ b/backend/cmd/worker/patient_validation_test.go
@@ -392,7 +392,7 @@ func Test_Persist_Batch_And_Patient_Records_Rollback_On_Error(t *testing.T) {
 			},
 		}
 
-		err := persistBatchAndPatientRecords(db, &batch, patientRecords)
+		err := persistBatchAndPatientRecords(t.Context(), db, &batch, patientRecords)
 		if assert.NotNil(t, err) {
 			assert.Contains(t, err.Error(), "violates foreign key constraint")
 		}

--- a/backend/cmd/worker/sample_validation.go
+++ b/backend/cmd/worker/sample_validation.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -133,33 +135,39 @@ func validateIsDifferentExistingSampleField[T comparable](
 	return false
 }
 
-func processSampleBatch(ctx *batchval.BatchValidationContext, batch *types.Batch, db *gorm.DB) {
+func processSampleBatch(ctx context.Context, bv *batchval.BatchValidationContext, batch *types.Batch, db *gorm.DB) error {
 	payload := []byte(batch.Payload)
 	var samplesbatch []types.SampleBatch
-	cache := batchval.NewBatchValidationCache(ctx)
+	cache := batchval.NewBatchValidationCache(bv)
 
 	if unexpectedErr := json.Unmarshal(payload, &samplesbatch); unexpectedErr != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error unmarshalling sample batch: %v", unexpectedErr), ctx.BatchRepo)
-		return
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error unmarshalling sample batch: %v", unexpectedErr), bv.BatchRepo)
+		return nil
 	}
 
-	records, unexpectedErr := validateSamplesBatch(ctx, cache, samplesbatch)
+	records, unexpectedErr := validateSamplesBatch(ctx, bv, cache, samplesbatch)
 	if unexpectedErr != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error sample batch validation: %v", unexpectedErr), ctx.BatchRepo)
-		return
+		if errors.Is(unexpectedErr, context.Canceled) {
+			return unexpectedErr
+		}
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error sample batch validation: %v", unexpectedErr), bv.BatchRepo)
+		return nil
 	}
 
 	glog.Infof("Sample batch %v processed with %d records", batch.ID, len(records))
 
-	err := persistBatchAndSampleRecords(db, batch, records)
-	if err != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error processing sample batch records: %v", err), ctx.BatchRepo)
-		return
+	if err := persistBatchAndSampleRecords(ctx, db, batch, records); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error processing sample batch records: %v", err), bv.BatchRepo)
+		return nil
 	}
+	return nil
 }
 
-func persistBatchAndSampleRecords(db *gorm.DB, batch *types.Batch, records []*SampleValidationRecord) error {
-	return db.Transaction(func(tx *gorm.DB) error {
+func persistBatchAndSampleRecords(ctx context.Context, db *gorm.DB, batch *types.Batch, records []*SampleValidationRecord) error {
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		txRepoSample := repository.NewSamplesRepository(tx)
 		txRepoBatch := repository.NewBatchRepository(tx)
 		rowsUpdated, unexpectedErrUpdate := batchval.UpdateBatch(batch, records, txRepoBatch)
@@ -317,15 +325,18 @@ func (r *SampleValidationRecord) validateHistologyCode() error {
 	return nil
 }
 
-func validateSamplesBatch(ctx *batchval.BatchValidationContext, cache *batchval.BatchValidationCache, samples []types.SampleBatch) ([]*SampleValidationRecord, error) {
+func validateSamplesBatch(ctx context.Context, bv *batchval.BatchValidationContext, cache *batchval.BatchValidationCache, samples []types.SampleBatch) ([]*SampleValidationRecord, error) {
 	records := make([]*SampleValidationRecord, 0, len(samples))
 	samplesMap := samplesMap(samples)
 	seenSamples := make(map[SampleKey]struct{})
 
 	for index, sample := range samples {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		record := &SampleValidationRecord{
 			BaseValidationRecord: batchval.BaseValidationRecord{
-				Context: ctx,
+				Context: bv,
 				Cache:   cache,
 				Index:   index,
 			},

--- a/backend/cmd/worker/sample_validation_test.go
+++ b/backend/cmd/worker/sample_validation_test.go
@@ -319,7 +319,7 @@ func Test_ValidateSamplesBatch(t *testing.T) {
 		{SubmitterSampleId: "P-BATCH2", SampleOrganizationCode: "CHUSJ", PatientOrganizationCode: "CHUSJ", SubmitterPatientId: "P1", TypeCode: "dna", HistologyCode: "normal"},                                     // 7. The grandparent for S3
 	}
 
-	records, err := validateSamplesBatch(mockContext, cache, samples)
+	records, err := validateSamplesBatch(t.Context(), mockContext, cache, samples)
 	assert.NoError(t, err)
 	assert.Len(t, records, 7) // Updated from 6 to 7 to include P-BATCH2
 

--- a/backend/cmd/worker/sequencing_experiment_validation.go
+++ b/backend/cmd/worker/sequencing_experiment_validation.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -272,32 +274,38 @@ func verifyIsDifferentField[T comparable](left T, right T, r *SequencingExperime
 	return true
 }
 
-func processSequencingExperimentBatch(ctx *batchval.BatchValidationContext, batch *types.Batch, db *gorm.DB) {
+func processSequencingExperimentBatch(ctx context.Context, bv *batchval.BatchValidationContext, batch *types.Batch, db *gorm.DB) error {
 	payload := []byte(batch.Payload)
 	var experimentsBatch []types.SequencingExperimentBatch
 
 	if unexpectedErr := json.Unmarshal(payload, &experimentsBatch); unexpectedErr != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error unmarshalling sequencing experiment batch: %v", unexpectedErr), ctx.BatchRepo)
-		return
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error unmarshalling sequencing experiment batch: %v", unexpectedErr), bv.BatchRepo)
+		return nil
 	}
 
-	records, unexpectedErr := validateSequencingExperimentBatch(ctx, experimentsBatch)
+	records, unexpectedErr := validateSequencingExperimentBatch(ctx, bv, experimentsBatch)
 	if unexpectedErr != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error sequencing experiment batch validation: %v", unexpectedErr), ctx.BatchRepo)
-		return
+		if errors.Is(unexpectedErr, context.Canceled) {
+			return unexpectedErr
+		}
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error sequencing experiment batch validation: %v", unexpectedErr), bv.BatchRepo)
+		return nil
 	}
 
 	glog.Infof("Sequencing experiment batch %v processed with %d records", batch.ID, len(records))
 
-	err := persistBatchAndSequencingExperimentRecords(db, batch, records)
-	if err != nil {
-		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error processing sequencing experiment batch records: %v", err), ctx.BatchRepo)
-		return
+	if err := persistBatchAndSequencingExperimentRecords(ctx, db, batch, records); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
+		batchval.ProcessUnexpectedError(batch, fmt.Errorf("error processing sequencing experiment batch records: %v", err), bv.BatchRepo)
+		return nil
 	}
+	return nil
 }
 
-func persistBatchAndSequencingExperimentRecords(db *gorm.DB, batch *types.Batch, records []*SequencingExperimentValidationRecord) error {
-	return db.Transaction(func(tx *gorm.DB) error {
+func persistBatchAndSequencingExperimentRecords(ctx context.Context, db *gorm.DB, batch *types.Batch, records []*SequencingExperimentValidationRecord) error {
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		txRepoSeqExp := repository.NewSequencingExperimentRepository(tx)
 		txRepoBatch := repository.NewBatchRepository(tx)
 		rowsUpdated, unexpectedErrUpdate := batchval.UpdateBatch(batch, records, txRepoBatch)
@@ -358,18 +366,21 @@ func insertSequencingExperimentRecords(records []*SequencingExperimentValidation
 	return nil
 }
 
-func validateSequencingExperimentBatch(ctx *batchval.BatchValidationContext, seqExps []types.SequencingExperimentBatch) ([]*SequencingExperimentValidationRecord, error) {
+func validateSequencingExperimentBatch(ctx context.Context, bv *batchval.BatchValidationContext, seqExps []types.SequencingExperimentBatch) ([]*SequencingExperimentValidationRecord, error) {
 	var records []*SequencingExperimentValidationRecord
 	visited := map[batchval.SequencingExperimentKey]struct{}{}
-	cache := batchval.NewBatchValidationCache(ctx)
+	cache := batchval.NewBatchValidationCache(bv)
 
 	for index, seqExp := range seqExps {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		key := batchval.SequencingExperimentKey{
 			SampleOrganizationCode: seqExp.SampleOrganizationCode,
 			SubmitterSampleId:      seqExp.SubmitterSampleId.String(),
 			Aliquot:                seqExp.Aliquot.String(),
 		}
-		record, err := validateSequencingExperimentRecord(ctx, cache, seqExp, index)
+		record, err := validateSequencingExperimentRecord(bv, cache, seqExp, index)
 		if err != nil {
 			return nil, fmt.Errorf("error during sequencing experiment validation: %v", err)
 		}

--- a/backend/cmd/worker/sequencing_experiment_validation_test.go
+++ b/backend/cmd/worker/sequencing_experiment_validation_test.go
@@ -500,7 +500,7 @@ func Test_ValidateSequencingExperimentBatch_DuplicateInBatch_AddsError(t *testin
 		ValueSetsRepo: &mockValueSetsDAO{},
 	}
 
-	records, err := validateSequencingExperimentBatch(mockContext, []types.SequencingExperimentBatch{seq1, seq2})
+	records, err := validateSequencingExperimentBatch(t.Context(), mockContext, []types.SequencingExperimentBatch{seq1, seq2})
 
 	assert.NoError(t, err)
 	assert.Len(t, records, 2)

--- a/backend/internal/batchval/context.go
+++ b/backend/internal/batchval/context.go
@@ -10,6 +10,7 @@ import (
 type batchProcessor interface {
 	ClaimNextBatch() (*types.Batch, error)
 	UpdateBatch(batch types.Batch) (int64, error)
+	ReleaseBatch(batchId string) (int64, error)
 }
 
 type casesReader interface {

--- a/backend/internal/repository/batch.go
+++ b/backend/internal/repository/batch.go
@@ -99,6 +99,20 @@ func (r *BatchRepository) ClaimNextBatch() (*Batch, error) {
 	return &batch, nil
 }
 
+// ReleaseBatch resets an in-flight (RUNNING) batch back to PENDING and clears started_on, so a
+// graceful shutdown can requeue the batch instead of abandoning it. The status = 'RUNNING' guard
+// makes it a no-op once a batch has committed to SUCCESS or ERROR. It runs on the repository's
+// default (background) context so it isn't aborted by the cancelled shutdown context.
+func (r *BatchRepository) ReleaseBatch(batchId string) (int64, error) {
+	result := r.db.Table(types.BatchTable.Name).
+		Where("id = ? AND status = ?", batchId, types.BatchStatusRunning).
+		Updates(map[string]any{"status": types.BatchStatusPending, "started_on": nil})
+	if result.Error != nil {
+		return 0, fmt.Errorf("error releasing batch %v: %w", batchId, result.Error)
+	}
+	return result.RowsAffected, nil
+}
+
 func (r *BatchRepository) UpdateStuckBatch() (int64, error) {
 	result := r.db.Table(types.BatchTable.Name)
 	result = result.Where("status = ?", types.BatchStatusRunning)

--- a/backend/internal/repository/batch_test.go
+++ b/backend/internal/repository/batch_test.go
@@ -146,6 +146,58 @@ func Test_UpdateBatch(t *testing.T) {
 	})
 }
 
+func Test_ReleaseBatch_ResetsRunningToPending(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+		db := env.Postgres
+		repo := NewBatchRepository(db)
+
+		var id string
+		initErr := db.Raw(`
+			INSERT INTO batch (payload, status, batch_type, dry_run, username, created_on, started_on)
+			VALUES ('{}', ?, 'patient', true, 'user-release', '2025-10-09', now())
+			RETURNING id;
+		`, types.BatchStatusRunning).Scan(&id).Error
+		if initErr != nil {
+			t.Fatal("failed to insert data:", initErr)
+		}
+
+		rowsUpdated, err := repo.ReleaseBatch(id)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 1, rowsUpdated)
+
+		resultBatch := Batch{}
+		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
+		assert.Equal(t, types.BatchStatusPending, resultBatch.Status)
+		assert.Nil(t, resultBatch.StartedOn)
+	})
+}
+
+func Test_ReleaseBatch_IgnoresNonRunning(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+		db := env.Postgres
+		repo := NewBatchRepository(db)
+
+		var id string
+		initErr := db.Raw(`
+			INSERT INTO batch (payload, status, batch_type, dry_run, username, created_on, started_on)
+			VALUES ('{}', ?, 'patient', true, 'user-release', '2025-10-09', now())
+			RETURNING id;
+		`, types.BatchStatusSuccess).Scan(&id).Error
+		if initErr != nil {
+			t.Fatal("failed to insert data:", initErr)
+		}
+
+		rowsUpdated, err := repo.ReleaseBatch(id)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 0, rowsUpdated)
+
+		resultBatch := Batch{}
+		db.Table("batch").Where("id = ?", id).Scan(&resultBatch)
+		assert.Equal(t, types.BatchStatusSuccess, resultBatch.Status)
+		assert.NotNil(t, resultBatch.StartedOn)
+	})
+}
+
 func Test_UpdateStuckBatch(t *testing.T) {
 	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)

--- a/backend/internal/utils/env.go
+++ b/backend/internal/utils/env.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 )
 
 // GetEnvOrDefault retrieves the value of the environment variable named by the key.
@@ -31,6 +32,18 @@ func GetBoolEnvOrDefault(key string, fallback bool) bool {
 		return fallback
 	}
 	return parsed
+}
+
+// ShutdownTimeout returns the graceful-shutdown grace period from SHUTDOWN_TIMEOUT_SECONDS
+// (default 30s). If the variable is set but not a valid integer, the default is used.
+func ShutdownTimeout() time.Duration {
+	const defaultSeconds = 30
+	secs, err := strconv.Atoi(GetEnvOrDefault("SHUTDOWN_TIMEOUT_SECONDS", strconv.Itoa(defaultSeconds)))
+	if err != nil {
+		log.Printf("WARN: environment variable SHUTDOWN_TIMEOUT_SECONDS is not a valid integer; using default %ds", defaultSeconds)
+		return defaultSeconds * time.Second
+	}
+	return time.Duration(secs) * time.Second
 }
 
 // GetEnvOrPanic retrieves the value of the environment variable named by the key.

--- a/backend/internal/utils/env_test.go
+++ b/backend/internal/utils/env_test.go
@@ -3,7 +3,29 @@ package utils
 import (
 	"os"
 	"testing"
+	"time"
 )
+
+func Test_ShutdownTimeout_Default(t *testing.T) {
+	os.Unsetenv("SHUTDOWN_TIMEOUT_SECONDS")
+	if got := ShutdownTimeout(); got != 30*time.Second {
+		t.Errorf("ShutdownTimeout() unset = %v; want %v", got, 30*time.Second)
+	}
+}
+
+func Test_ShutdownTimeout_Override(t *testing.T) {
+	t.Setenv("SHUTDOWN_TIMEOUT_SECONDS", "5")
+	if got := ShutdownTimeout(); got != 5*time.Second {
+		t.Errorf("ShutdownTimeout()=5 = %v; want %v", got, 5*time.Second)
+	}
+}
+
+func Test_ShutdownTimeout_InvalidFallsBackToDefault(t *testing.T) {
+	t.Setenv("SHUTDOWN_TIMEOUT_SECONDS", "not-a-number")
+	if got := ShutdownTimeout(); got != 30*time.Second {
+		t.Errorf("ShutdownTimeout()=invalid = %v; want %v", got, 30*time.Second)
+	}
+}
 
 func Test_GetEnvOrDefault_Exists(t *testing.T) {
 	key := "TEST_ENV_KEY_EXISTS"


### PR DESCRIPTION
# SJRA-1591 — Graceful shutdown for API and worker

## 📌 Context

Both Go binaries terminate abruptly on SIGTERM/SIGINT, which breaks clean k8s rollouts:
- **API** used Gin's blocking `r.Run()` with no `http.Server.Shutdown` — in-flight requests were dropped.
- **Worker** was `for { processBatch(); time.Sleep() }` with no signal handling; its health-probe server and cleanup ticker never stopped, and a claimed batch could be abandoned mid-flight (left `RUNNING` until the 24h stuck-batch cleanup flips it to `ERROR`).

This adds `signal.NotifyContext(SIGTERM/SIGINT)` to both, threads the context into the worker poll loop, and shuts the HTTP servers down with `Shutdown(ctx)`.

## 📝 Changes

- **API** (`cmd/api/main.go`): replaced `r.Run()` with an explicit `http.Server` started in a goroutine + signal-driven `srv.Shutdown(ctx)` to drain connections.
- **Worker** (`cmd/worker/main.go`): signal context + `sync.WaitGroup`; extracted `runPollLoop` (stops claiming on shutdown); ctx-aware `StartHealthProbe` (graceful `Shutdown`) and `StartCleanUpWorker` (`select` on `ctx.Done()`); `wg.Wait()` before exit.
- **In-flight batch requeue (cooperative cancellation):** `context.Context` threaded through all 5 processors → their validation loops (per-record `ctx.Err()` checkpoints) → `db.WithContext(ctx).Transaction(...)`. On cancellation the processor returns `context.Canceled` and `processBatch` calls the new `BatchRepository.ReleaseBatch` to reset the batch `RUNNING → PENDING` (clearing `started_on`), so it's re-claimed and reprocessed cleanly — no abandoned batch, no double-insert (transaction rolls back atomically).
- `ReleaseBatch` added to the consumer-side `batchProcessor` interface in `internal/batchval`.
- `utils.ShutdownTimeout()` (`SHUTDOWN_TIMEOUT_SECONDS`, default 30s), shared by both cmds.

## ☑️ TO-DOs

- [x] Manual SIGTERM verification against a running stack (automated tests cover the requeue path).

## 🧪 Tests

- `internal/repository`: `Test_ReleaseBatch_ResetsRunningToPending`, `Test_ReleaseBatch_IgnoresNonRunning`.
- `internal/utils`: `Test_ShutdownTimeout_Default` / `_Override` / `_InvalidFallsBackToDefault`.
- `cmd/worker` (`main_test.go`): `Test_runPollLoop_StopsOnContextCancel`, `Test_StartCleanUpWorker_StopsOnContextCancel`, `Test_StartHealthProbe_ShutsDownOnContextCancel`, and `Test_processBatch_RequeuesInflightBatchOnCancel` (asserts the batch returns to PENDING with `started_on` NULL and nothing persisted).
- Existing worker processor/integration suites updated for the new signatures and pass.
- `go build ./...`, `make lint` (0 issues), and `go vet ./...` all clean.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1591](https://d3b.atlassian.net/browse/SJRA-1591)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Design choice:** the worker finishes nothing it can't commit — on shutdown it aborts at the next validation checkpoint and requeues, rather than letting a long batch blow past the k8s grace period. `UpdateStuckBatch` stays as the last-resort backstop for hard kills (SIGKILL/OOM).
- The `*batchval.BatchValidationContext` param was renamed `ctx` → `bv` in the processors to free `ctx` for `context.Context` (Go convention: context is the first param named `ctx`).

[SJRA-1591]: https://d3b.atlassian.net/browse/SJRA-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ