### PR TITLE
fix(backend): SJRA-1612 bump pgx and grpc for security advisories

### DIFF
--- a/backend/.claude/rules/go-code-review.md
+++ b/backend/.claude/rules/go-code-review.md
@@ -146,6 +146,8 @@ References: [Code Review Comments §Interfaces](https://go.dev/wiki/CodeReviewCo
 - **Gofmt/goimports:** always run them; they settle indentation, alignment, and import order.
   Run `make fmt` to apply gofmt and `make lint` to run golangci-lint before you finish. CI
   runs the same golangci-lint config (`backend/.golangci.yml`) and fails on unformatted code
-  (the `gofmt` formatter) or any finding from `errcheck`, `govet`, `ineffassign`, `staticcheck`,
-  or `unused`. A pre-commit hook also runs gofmt on staged Go files.
+  (the `gofmt` formatter) or any finding from `bodyclose`, `errcheck`, `gosec`, `govet`,
+  `ineffassign`, `staticcheck`, or `unused`. `make lint` runs `go vet` (via the `govet`
+  linter), so there's no need to run `go vet ./...` separately. A pre-commit hook also runs
+  gofmt on staged Go files.
 - **Line length:** no hard limit — break for readability/semantics, not to hit a column count.

--- a/backend/.claude/rules/universal.md
+++ b/backend/.claude/rules/universal.md
@@ -37,7 +37,7 @@ A green build is the bar for advancing. For each workflow step:
 - Run `go build ./...` and confirm it's clean.
 - Run the tests for the package you just touched.
 - If you added a new test, run it explicitly so the framework can't silently skip it.
-- Run `make fmt` (gofmt) and `make lint` (golangci-lint) and confirm both are clean — CI runs the same golangci-lint config and fails on unformatted code or any lint finding.
+- Run `make fmt` (gofmt) and `make lint` (golangci-lint) and confirm both are clean — CI runs the same golangci-lint config and fails on unformatted code or any lint finding. `make lint` includes `go vet` (via the `govet` linter), so there's no need to run `go vet ./...` separately.
 
 Skipping this and reporting "done" produces work that compiles in your head but not in the repo.
 

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -3,7 +3,9 @@ version: "2"
 linters:
   default: none
   enable:
+    - bodyclose
     - errcheck
+    - gosec
     - govet
     - ineffassign
     - staticcheck
@@ -13,9 +15,24 @@ linters:
     rules:
       # Test files and shared test infrastructure: tolerate unchecked setup/teardown
       # errors (os.Setenv, db.Exec cleanups, response Close, json.Unmarshal in asserts).
+      # gosec joins for the same reason — test fixtures legitimately use math/rand
+      # (G404), intentional cleanup db.Exec without error checks (G104), SQL built over
+      # trusted table names (G201/G204), and reading test-data files by path (G304).
       - path: (_test\.go|test/testutils/)
         linters:
           - errcheck
+          - gosec
+      # bodyclose in integration tests: response bodies aren't closed since the test
+      # process tears down right after asserting; no leak that outlives the test.
+      - path: _test\.go
+        linters:
+          - bodyclose
+      # scripts/ is build-time codegen tooling (OpenAPI spec generation), not runtime
+      # server code: reading a spec path (G304) and writing generated output (G306)
+      # operate on trusted, developer-controlled paths, not attacker input.
+      - path: scripts/
+        linters:
+          - gosec
       # Test files commonly reuse `err` across helper-built fixtures that cannot fail;
       # the err-overwrite pattern is benign there. It trips both ineffassign and
       # staticcheck's SA4006 ("value never used"); SA4006 stays strict in non-test code.

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -97,8 +97,9 @@ func StartHealthProbe(db *gorm.DB) {
 	})
 
 	srv := &http.Server{
-		Addr:    ":" + port,
-		Handler: mux,
+		Addr:              ":" + port,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.6.0 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
@@ -135,7 +135,7 @@ require (
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
-	google.golang.org/grpc v1.79.1 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/go-jose/go-jose.v2 v2.6.3 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -922,8 +922,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
-github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -1821,8 +1821,8 @@ google.golang.org/grpc v1.52.0/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5v
 google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwSMQpw=
 google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
 google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
-google.golang.org/grpc v1.79.1 h1:zGhSi45ODB9/p3VAawt9a+O/MULLl9dpizzNNpq7flY=
-google.golang.org/grpc v1.79.1/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/backend/internal/client/admin_keycloak.go
+++ b/backend/internal/client/admin_keycloak.go
@@ -156,12 +156,12 @@ func (c *KeycloakAdminClient) adminToken(ctx context.Context) (string, error) {
 func (c *KeycloakAdminClient) findUserID(ctx context.Context, token, username string) (string, error) {
 	endpoint := fmt.Sprintf("%s/admin/realms/%s/users?username=%s&exact=true",
 		c.cfg.BaseURL, c.cfg.Realm, url.QueryEscape(username))
-	resp, body, err := c.adminRequest(ctx, http.MethodGet, endpoint, token, nil)
+	status, body, err := c.adminRequest(ctx, http.MethodGet, endpoint, token, nil)
 	if err != nil {
 		return "", err
 	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("find user %q failed: HTTP %d: %s", username, resp.StatusCode, string(body))
+	if status != http.StatusOK {
+		return "", fmt.Errorf("find user %q failed: HTTP %d: %s", username, status, string(body))
 	}
 	var users []keycloakUser
 	if err := json.Unmarshal(body, &users); err != nil {
@@ -178,24 +178,24 @@ func (c *KeycloakAdminClient) findUserID(ctx context.Context, token, username st
 
 func (c *KeycloakAdminClient) createUser(ctx context.Context, token string, user keycloakUser) error {
 	endpoint := fmt.Sprintf("%s/admin/realms/%s/users", c.cfg.BaseURL, c.cfg.Realm)
-	resp, body, err := c.adminRequest(ctx, http.MethodPost, endpoint, token, user)
+	status, body, err := c.adminRequest(ctx, http.MethodPost, endpoint, token, user)
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusConflict {
-		return fmt.Errorf("create user %q failed: HTTP %d: %s", user.Username, resp.StatusCode, string(body))
+	if status != http.StatusCreated && status != http.StatusConflict {
+		return fmt.Errorf("create user %q failed: HTTP %d: %s", user.Username, status, string(body))
 	}
 	return nil
 }
 
 func (c *KeycloakAdminClient) updateUser(ctx context.Context, token, id string, user keycloakUser) error {
 	endpoint := fmt.Sprintf("%s/admin/realms/%s/users/%s", c.cfg.BaseURL, c.cfg.Realm, id)
-	resp, body, err := c.adminRequest(ctx, http.MethodPut, endpoint, token, user)
+	status, body, err := c.adminRequest(ctx, http.MethodPut, endpoint, token, user)
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("update user %q failed: HTTP %d: %s", user.Username, resp.StatusCode, string(body))
+	if status != http.StatusNoContent && status != http.StatusOK {
+		return fmt.Errorf("update user %q failed: HTTP %d: %s", user.Username, status, string(body))
 	}
 	return nil
 }
@@ -203,30 +203,31 @@ func (c *KeycloakAdminClient) updateUser(ctx context.Context, token, id string, 
 func (c *KeycloakAdminClient) resetPassword(ctx context.Context, token, id, password string) error {
 	endpoint := fmt.Sprintf("%s/admin/realms/%s/users/%s/reset-password", c.cfg.BaseURL, c.cfg.Realm, id)
 	cred := map[string]any{"type": "password", "value": password, "temporary": false}
-	resp, body, err := c.adminRequest(ctx, http.MethodPut, endpoint, token, cred)
+	status, body, err := c.adminRequest(ctx, http.MethodPut, endpoint, token, cred)
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("reset password failed: HTTP %d: %s", resp.StatusCode, string(body))
+	if status != http.StatusNoContent && status != http.StatusOK {
+		return fmt.Errorf("reset password failed: HTTP %d: %s", status, string(body))
 	}
 	return nil
 }
 
 // adminRequest issues a bearer-authenticated admin request, JSON-encoding body when
-// non-nil, and returns the response (body already drained) plus the raw body bytes.
-func (c *KeycloakAdminClient) adminRequest(ctx context.Context, method, endpoint, token string, body any) (*http.Response, []byte, error) {
+// non-nil, and returns the HTTP status code plus the raw body bytes. The response body
+// is fully read and closed before returning, so callers never hold an open body.
+func (c *KeycloakAdminClient) adminRequest(ctx context.Context, method, endpoint, token string, body any) (int, []byte, error) {
 	var reader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
 		if err != nil {
-			return nil, nil, err
+			return 0, nil, err
 		}
 		reader = bytes.NewReader(data)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	if body != nil {
@@ -234,12 +235,12 @@ func (c *KeycloakAdminClient) adminRequest(ctx context.Context, method, endpoint
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, err
 	}
-	return resp, data, nil
+	return resp.StatusCode, data, nil
 }

--- a/backend/internal/client/admin_ranger.go
+++ b/backend/internal/client/admin_ranger.go
@@ -61,13 +61,13 @@ func (c *RangerAdminClient) EnsureUser(ctx context.Context, name string) error {
 		"password":     pw,
 		"userRoleList": []string{"ROLE_USER"},
 	}
-	resp, payload, err := c.request(ctx, http.MethodPost, "/service/xusers/secure/users", body)
+	status, payload, err := c.request(ctx, http.MethodPost, "/service/xusers/secure/users", body)
 	if err != nil {
 		return err
 	}
 	// 200/201 = created; 400 = already exists -> both fine.
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusBadRequest {
-		return fmt.Errorf("ensure user %q: HTTP %d: %s", name, resp.StatusCode, string(payload))
+	if status != http.StatusOK && status != http.StatusCreated && status != http.StatusBadRequest {
+		return fmt.Errorf("ensure user %q: HTTP %d: %s", name, status, string(payload))
 	}
 	return nil
 }
@@ -99,12 +99,12 @@ type rangerRole struct {
 // existing members. The role must already exist, a missing role is an error.
 // Idempotent: a user already in the role is a no-op.
 func (c *RangerAdminClient) AddUserToRole(ctx context.Context, roleName, user string) error {
-	resp, payload, err := c.request(ctx, http.MethodGet, "/service/roles/roles/name/"+roleName, nil)
+	status, payload, err := c.request(ctx, http.MethodGet, "/service/roles/roles/name/"+roleName, nil)
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("get role %q: HTTP %d: %s", roleName, resp.StatusCode, string(payload))
+	if status != http.StatusOK {
+		return fmt.Errorf("get role %q: HTTP %d: %s", roleName, status, string(payload))
 	}
 	var role rangerRole
 	if err := json.Unmarshal(payload, &role); err != nil {
@@ -118,30 +118,31 @@ func (c *RangerAdminClient) AddUserToRole(ctx context.Context, roleName, user st
 	}
 	role.Users = append(role.Users, rangerRoleMember{Name: user, IsAdmin: false})
 
-	resp, payload, err = c.request(ctx, http.MethodPut, fmt.Sprintf("/service/roles/roles/%d", role.ID), role)
+	status, payload, err = c.request(ctx, http.MethodPut, fmt.Sprintf("/service/roles/roles/%d", role.ID), role)
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("update role %q: HTTP %d: %s", roleName, resp.StatusCode, string(payload))
+	if status != http.StatusOK && status != http.StatusCreated {
+		return fmt.Errorf("update role %q: HTTP %d: %s", roleName, status, string(payload))
 	}
 	return nil
 }
 
 // request issues a basic-auth request to Ranger, JSON-encoding body when non-nil,
-// and returns the response (body drained) plus the raw payload bytes.
-func (c *RangerAdminClient) request(ctx context.Context, method, path string, body any) (*http.Response, []byte, error) {
+// and returns the HTTP status code plus the raw payload bytes. The response body is
+// fully read and closed before returning, so callers never hold an open body.
+func (c *RangerAdminClient) request(ctx context.Context, method, path string, body any) (int, []byte, error) {
 	var reader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
 		if err != nil {
-			return nil, nil, err
+			return 0, nil, err
 		}
 		reader = bytes.NewReader(data)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, c.cfg.BaseURL+path, reader)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, err
 	}
 	req.Header.Set("Authorization", c.authHeader)
 	req.Header.Set("Accept", "application/json")
@@ -150,12 +151,12 @@ func (c *RangerAdminClient) request(ctx context.Context, method, path string, bo
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, err
 	}
-	return resp, data, nil
+	return resp.StatusCode, data, nil
 }

--- a/backend/internal/database/starrocks.go
+++ b/backend/internal/database/starrocks.go
@@ -32,7 +32,7 @@ func registerStarrocksTLS(caPath, configName, serverName string) (string, error)
 	if caPath == "" {
 		return "", nil
 	}
-	pem, err := os.ReadFile(caPath)
+	pem, err := os.ReadFile(caPath) //nolint:gosec // G304: caPath is the operator-configured DB_SSL_CA path, not attacker-controlled input.
 	if err != nil {
 		return "", fmt.Errorf("read DB_SSL_CA: %w", err)
 	}
@@ -41,6 +41,7 @@ func registerStarrocksTLS(caPath, configName, serverName string) (string, error)
 		return "", fmt.Errorf("parse DB_SSL_CA: no certs found in %s", caPath)
 	}
 	if err := gomysql.RegisterTLSConfig(configName, &tls.Config{
+		MinVersion: tls.VersionTLS12,
 		RootCAs:    pool,
 		ServerName: serverName,
 	}); err != nil {


### PR DESCRIPTION
## 📌 Context

Two strands of SJRA-1612 security work:

1. **Dependency advisories** — GitHub Dependabot reported open **critical** advisories against `backend/go.mod`. This PR bumps the affected (indirect) Go modules to patched versions.
2. **Static analysis** — enable security/resource linters in the backend (`gosec`, `bodyclose`) and fix the findings they surface.

## 📝 Changes

### Dependency bumps (`backend/go.mod` + `go.sum`)
- `github.com/jackc/pgx/v5` v5.6.0 → **v5.9.2** — fixes critical GHSA-9jj7-4m8r-rfcm (memory-safety) and incidentally clears low GHSA-j88v-2chj-qfwx (SQLi via dollar-quoted placeholder confusion). Pulled in via `gorm.io/driver/postgres`.
- `google.golang.org/grpc` v1.79.1 → **v1.79.3** — fixes critical GHSA-p77j-4mvh-x3m3 (authorization bypass via missing leading slash in `:path`). Test-only transitive dep via `testcontainers-go`.

### Linters + associated fixes (`backend/.golangci.yml` and sources)
- Enable **`gosec`** (security) and **`bodyclose`** (HTTP response body leaks) in `.golangci.yml`, with scoped exclusions for test files, `test/testutils/`, and build-time `scripts/` codegen (documented inline with rationale).
- Fixes for the findings:
  - `cmd/worker/main.go` — add `ReadHeaderTimeout` to the health-probe `http.Server` (G112, Slowloris).
  - `internal/database/starrocks.go` — set TLS `MinVersion: TLS 1.2` (G402); annotate the operator-configured CA-path read with `//nolint:gosec // G304`.
  - `internal/client/admin_keycloak.go`, `internal/client/admin_ranger.go` — close HTTP response bodies (bodyclose).
- Doc updates to `backend/.claude/rules/` reflecting the new linters.

## ☑️ TO-DOs

- [x] Decide handling for the two HIGH `github.com/docker/docker` alerts (GHSA-rg2x-37c3-w2rh, GHSA-x86f-5xw2-fm2r): **no patched release exists** (latest is the vulnerable v28.5.2). It's a test-only transitive dep (`testcontainers-go`) never compiled into the API binary — recommend dismissing the alerts as "test-only / no upstream fix available", or re-bump once Docker ships a fix.

## 🧪 Tests

- `go build ./...` — passes
- `make test` — 1174 tests pass, 1 skipped (also exercises the testcontainers/grpc chain)
- `golangci-lint` runs clean with the newly enabled `gosec`/`bodyclose` linters

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
SJRA-1612
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- All three advisory-affected modules are **indirect** deps; the dependency fix is a version bump in the `require ... // indirect` block plus `go mod tidy` (4 lines in `go.mod` + 8 in `go.sum`).
- The docker advisories are intentionally not addressed here — no upstream patch is available.
- Linter exclusions are intentionally narrow and each carries an inline rationale in `.golangci.yml`.


