### PR TITLE
fix(dep): SJRA-1614 override minimatch to 9 0 9

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15888,14 +15888,14 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,5 +54,8 @@
     "tw-animate-css": "^1.4.0",
     "universal-cookie": "^8.1.2",
     "zod": "^4.4.3"
+  },
+  "overrides": {
+    "minimatch@9.0.3": "9.0.9"
   }
 }


### PR DESCRIPTION
# fix(dep): SJRA-1614 override minimatch to 9 0 9

## 📌 Context

Dependabot alert on minimatch => https://github.com/radiant-network/radiant-portal/security/dependabot/150

## 📝 Changes

- overrides minimatch version because minimatch is a transitive dependency of ESLint

## 🧪 Tests



## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1614](https://d3b.atlassian.net/browse/SJRA-1614)<!-- End JIRA Issues -->


[SJRA-1614]: https://d3b.atlassian.net/browse/SJRA-1614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ