### PR TITLE
feat: SJRA-1626 Adjust Cypress tests related to recent changes

### DIFF
--- a/cypress/api/Batches/InvalidUUID.cy.ts
+++ b/cypress/api/Batches/InvalidUUID.cy.ts
@@ -18,10 +18,9 @@ describe('Batches - Invalid UUID', () => {
   });
 
   it('Return content', () => {
-    expect(response.body).to.have.all.keys('status', 'message', 'detail');
+    expect(response.body).to.have.all.keys('status', 'message');
     expect(response.body).to.include({
-      message: apiMessages.InternalServerError,
-      detail: apiMessages.InvalidBatchUUID('InvalidUUID'),
+      message: apiMessages.InternalServerError
     });
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -236,6 +236,7 @@ Cypress.Commands.add('showColumn', (column: string | RegExp) => {
   getSettingsCheckbox(column).click({ force: true });
   cy.get(CommonSelectors.logo).clickAndWait({ force: true }); // Close the popper
   cy.get(CommonSelectors.settingsPopper).should('not.exist');
+  cy.get(CommonSelectors.logo).clickAndWait({ force: true }); // Close the 'Columns' tooltip
   cy.waitWhileLoad(oneMinute);
 });
 


### PR DESCRIPTION
# feat: SJRA-1626 Adjust Cypress tests related to recent changes

## 📌 Context

Des changements récents ont modifié le comportement de l'application, ce qui a fait échouer certains tests Cypress. Ce PR ajuste ces tests afin qu'ils reflètent à nouveau le comportement attendu.

## 📝 Changes

- **`cypress/api/Batches/InvalidUUID.cy.ts`** : la réponse de l'API pour un UUID de batch invalide ne contient plus le champ `detail`. Le test attend maintenant uniquement les clés `status` et `message` (avec `message: InternalServerError`), et l'assertion sur `detail` (`InvalidBatchUUID`) a été retirée.
- **`cypress/support/commands.ts`** : ajout d'un clic supplémentaire sur le logo dans la commande `showColumn` pour fermer le tooltip « Columns » qui restait affiché après la fermeture du popper des paramètres.

## 🧪 Tests

- Tests Cypress ajustés et exécutés localement avec succès.
- La commande `showColumn`, utilisée par plusieurs specs, est désormais plus stable grâce à la fermeture du tooltip résiduel.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1626](https://d3b.atlassian.net/browse/SJRA-1626)<!-- End JIRA Issues -->

[SJRA-1626]: https://d3b.atlassian.net/browse/SJRA-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ