### PR TITLE
fix: SJRA-1634 rewrite autocomplete gene query to avoid CN crash

### DIFF
--- a/backend/internal/repository/genes.go
+++ b/backend/internal/repository/genes.go
@@ -52,16 +52,19 @@ func mapToAutoCompleteGene(gene *Gene, input string) AutoCompleteGene {
 
 func (r *GenesRepository) GetGeneAutoComplete(prefix string, limit int) (*[]AutoCompleteGene, error) {
 
-	//SELECT gene_id, name, (case WHEN name LIKE 'F%' THEN 1 ELSE (CASE WHEN gene_id LIKE 'F%' THEN 2 ELSE (CASE WHEN array_length(array_filter(alias, x -> UPPER(x) LIKE 'F%')) > 0 THEN 3 ELSE 4 END) END) END) weight
+	// Alias match collapses the array to a string rather than array_filter(alias, x -> ...):
+	// a derived ARRAY crossing the ORDER BY exchange crashes the StarRocks 3.5.18 CN.
+	//SELECT gene_id, name, (case WHEN name LIKE 'F%' THEN 1 ELSE (CASE WHEN gene_id LIKE 'F%' THEN 2 ELSE (CASE WHEN UPPER(CONCAT('||', array_join(alias, '||'))) LIKE '%||F%' THEN 3 ELSE 4 END) END) END) weight
 	//FROM ensembl_gene
-	//WHERE UPPER(name) like 'F%' or UPPER(gene_id) like 'F%' or array_length(array_filter(alias, x -> UPPER(x) LIKE 'F%')) > 0
+	//WHERE UPPER(name) like 'F%' or UPPER(gene_id) like 'F%' or UPPER(CONCAT('||', array_join(alias, '||'))) LIKE '%||F%'
 	//ORDER BY weight ASC, name ASC
 	//LIMIT 10;
 
 	like := fmt.Sprintf("%s%%", strings.ToUpper(prefix))
+	aliasLike := fmt.Sprintf("%%||%s%%", strings.ToUpper(prefix))
 	tx := r.db.Table(types.EnsemblGeneTable.Name)
-	tx = tx.Select("gene_id, name, (case WHEN name LIKE ? THEN 1 ELSE (CASE WHEN gene_id LIKE ? THEN 2 ELSE (CASE WHEN array_length(array_filter(alias, x -> UPPER(x) LIKE ?)) > 0 THEN 3 ELSE 4 END) END) END) weight", like, like, like)
-	tx = tx.Where("UPPER(name) like ? or UPPER(gene_id) like ? or array_length(array_filter(alias, x -> UPPER(x) LIKE ?)) > 0", like, like, like)
+	tx = tx.Select("gene_id, name, (case WHEN name LIKE ? THEN 1 ELSE (CASE WHEN gene_id LIKE ? THEN 2 ELSE (CASE WHEN UPPER(CONCAT('||', array_join(alias, '||'))) LIKE ? THEN 3 ELSE 4 END) END) END) weight", like, like, aliasLike)
+	tx = tx.Where("UPPER(name) like ? or UPPER(gene_id) like ? or UPPER(CONCAT('||', array_join(alias, '||'))) LIKE ?", like, like, aliasLike)
 	tx = tx.Order("weight ASC, name ASC")
 	tx = tx.Limit(limit)
 

--- a/backend/internal/repository/genes_test.go
+++ b/backend/internal/repository/genes_test.go
@@ -58,6 +58,18 @@ func Test_GetGeneAutoComplete_FindOnAlias(t *testing.T) {
 	})
 }
 
+func Test_GetGeneAutoComplete_FindOnAliasNotFirst(t *testing.T) {
+	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
+		repo := NewGenesRepository(db)
+		// "ARMS1" is not the first element of CFH's alias array (["ARMD4","ARMS1",...]),
+		// so this exercises the ||-delimiter boundary of the collapsed-string match.
+		genes, err := repo.GetGeneAutoComplete("ARMS1", 10)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(*genes))
+		assert.Equal(t, "CFH", (*genes)[0].Source.Name)
+	})
+}
+
 func Test_GetGeneAutoComplete_WithLimit(t *testing.T) {
 	testutils.ParallelTestWithStarrocks(t, "simple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGenesRepository(db)


### PR DESCRIPTION
# fix: SJRA-1634 rewrite autocomplete gene query to avoid CN crash

## 📌 Context

The gene search (autocomplete) query could **crash a StarRocks compute node** with a SIGSEGV — taking the node offline (`Alive=false`), failing in-flight queries with "Backend node not found", and destabilizing the cluster under load. It reproduced deterministically with a single search; it was not a data, memory, or infra issue.

Root cause: the query used `array_filter(alias, x -> ...)`, which produces a *derived* `ARRAY`, then sorted on the result (`ORDER BY weight`). On StarRocks **3.5.18**, when a derived array crosses an *exchange* (the gather/shuffle between query stages, e.g. for `ORDER BY`), the chunk deserializer reads it without buffer-bounds checks → garbage offset → null deref → crash. The upstream guard (StarRocks PR #69481) was only backported to 4.0/4.1, **not** 3.5.x, so it can't be fixed by config — it has to be avoided at the query level.

## 📝 Changes

- `backend/internal/repository/genes.go` (`GetGeneAutoComplete`): rewrote the per-element alias test so no array crosses the exchange.
  - **Before:** `array_length(array_filter(alias, x -> UPPER(x) LIKE ?)) > 0`
  - **After:** `UPPER(CONCAT('||', array_join(alias, '||'))) LIKE ?` bound to `%||<TERM>%`
  - `array_join` collapses the alias array to a delimited string (`A||B||C`); the leading `||` + `%||<TERM>%` pattern matches when any element *starts with* the term — identical semantics, but everything stays scalar. NULL/empty aliases behave the same; ranking and result order are unchanged.
- Audit confirmed gene search was the **only** query in this class. `any_match` lambdas elsewhere are WHERE-only (predicate stays local to the scan), and `unnest` / `array_agg` / `array_contains` usages don't emit a derived array from a lambda — no other changes needed.

## ☑️ TO-DOs

- [ ] None

## 🧪 Tests

- Existing `Test_GetGeneAutoComplete*` repository tests pass unchanged, validating identical results and ranking — including `Test_GetGeneAutoComplete_FindOnAlias` (match via alias).
- Added `Test_GetGeneAutoComplete_FindOnAliasNotFirst` (searches a non-first alias element) to lock the `||`-delimiter boundary logic.
- `go build ./...` clean, `make fmt` applied, `make lint` → 0 issues.
- The rewritten query was validated on the live 3.5.18 cluster: no crash, identical results.

```bash
cd backend && go test ./internal/repository/ -run Test_GetGeneAutoComplete -v
```

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1634](https://d3b.atlassian.net/browse/SJRA-1634)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- This is a behavior-preserving crash fix; LIKE-metacharacter escaping was intentionally **not** added (the existing `name`/`gene_id` branches already pass input unescaped — escaping would be a separate behavior change).
- Longer term: moving to StarRocks 4.0 turns this class of bug from a node-killing crash into a recoverable query error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SJRA-1634]: https://d3b.atlassian.net/browse/SJRA-1634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ