### PR TITLE
feat: SJRA-1636 Format cypress files to QA prettier config

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm run format:cypress
+npx lint-staged

--- a/cypress/api/Batches/InvalidUUID.cy.ts
+++ b/cypress/api/Batches/InvalidUUID.cy.ts
@@ -20,7 +20,7 @@ describe('Batches - Invalid UUID', () => {
   it('Return content', () => {
     expect(response.body).to.have.all.keys('status', 'message');
     expect(response.body).to.include({
-      message: apiMessages.InternalServerError
+      message: apiMessages.InternalServerError,
     });
   });
 });

--- a/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts
@@ -285,12 +285,15 @@ export const CaseEntity_Variants_SNV_Table = {
      * Yields 0 when no results are displayed.
      */
     getResultsCount(): Cypress.Chainable<number> {
-      return cy.get(CommonSelectors.tableIndexResult).invoke('text').then(text => {
-        const ofIndex = text.toLowerCase().indexOf(' of ');
-        if (ofIndex === -1) return 0;
-        const digits = text.substring(ofIndex + 4).replace(/\D/g, '');
-        return digits ? parseInt(digits, 10) : 0;
-      });
+      return cy
+        .get(CommonSelectors.tableIndexResult)
+        .invoke('text')
+        .then(text => {
+          const ofIndex = text.toLowerCase().indexOf(' of ');
+          if (ofIndex === -1) return 0;
+          const digits = text.substring(ofIndex + 4).replace(/\D/g, '');
+          return digits ? parseInt(digits, 10) : 0;
+        });
     },
     /**
      * Hides a specific column in the table.
@@ -588,16 +591,18 @@ export const CaseEntity_Variants_SNV_Table = {
      */
     shouldShowResultsCount(count: number | Cypress.Chainable<number>, beEqual: boolean = true) {
       const compare = (expected: number) => {
-        cy.get(CommonSelectors.tableIndexResult).invoke('text').should(text => {
-          const ofIndex = text.toLowerCase().indexOf(' of ');
-          const digits = ofIndex === -1 ? '' : text.substring(ofIndex + 4).replace(/\D/g, '');
-          const current = digits ? parseInt(digits, 10) : 0;
-          if (beEqual) {
-            expect(current).to.eq(expected);
-          } else {
-            expect(current).to.not.eq(expected);
-          }
-        });
+        cy.get(CommonSelectors.tableIndexResult)
+          .invoke('text')
+          .should(text => {
+            const ofIndex = text.toLowerCase().indexOf(' of ');
+            const digits = ofIndex === -1 ? '' : text.substring(ofIndex + 4).replace(/\D/g, '');
+            const current = digits ? parseInt(digits, 10) : 0;
+            if (beEqual) {
+              expect(current).to.eq(expected);
+            } else {
+              expect(current).to.not.eq(expected);
+            }
+          });
       };
       if (typeof count === 'number') {
         compare(count);


### PR DESCRIPTION
# feat: SJRA-1636 Format cypress files to QA prettier config

## 📌 Context

Uniformisation du formatage des fichiers Cypress selon la configuration Prettier de l'équipe QA. Le hook de pre-commit est également ajusté pour appliquer le formatage de façon ciblée sur les fichiers en cours de commit plutôt que sur l'ensemble des fichiers Cypress.

## 📝 Changes

- `.husky/pre-commit` : remplacement de `npm run format:cypress` par `npx lint-staged`, afin de ne formater que les fichiers en cours de commit (plus rapide et plus ciblé).
- `cypress/api/Batches/InvalidUUID.cy.ts` : ajout d'une virgule de fin (trailing comma) conforme à la config Prettier.
- `cypress/pom/pages/CaseEntity_Variants_SNV_Table.ts` : reformatage des chaînes d'appels (`getResultsCount` et `shouldShowResultsCount`) en style multiligne conforme à la config Prettier. Aucun changement de logique.

## 🧪 Tests

- Modifications purement liées au formatage et à l'outillage (pre-commit), sans impact sur la logique.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1636](https://d3b.atlassian.net/browse/SJRA-1636)<!-- End JIRA Issues -->

[SJRA-1636]: https://d3b.atlassian.net/browse/SJRA-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ