### PR TITLE
fix: SJRA-1638 createuser uses email as username and sets a temporary password

### DIFF
--- a/backend/cmd/createuser/main.go
+++ b/backend/cmd/createuser/main.go
@@ -3,6 +3,9 @@
 //
 //	go run ./cmd/createuser -email carol@demo.org -first Carol -last Demo \
 //	    -grant tenant_a:ORG_A1:geneticist -grant tenant_b:*:geneticist
+//
+// The realm is configured with email-as-username, so the email is sent as the
+// Keycloak username verbatim — the CLI never derives a separate username.
 package main
 
 import (
@@ -42,12 +45,11 @@ func (g *grantList) Set(value string) error {
 
 func main() {
 	var (
-		email    = flag.String("email", "", "user email (PK); required")
-		username = flag.String("username", "", "Keycloak username (defaults to the local part of -email)")
-		first    = flag.String("first", "", "first name")
-		last     = flag.String("last", "", "last name")
-		prompt   = flag.Bool("p", false, "prompt for the user password (masked); ignored if USER_PASSWORD is set")
-		grants   grantList
+		email  = flag.String("email", "", "user email (PK and Keycloak username); required")
+		first  = flag.String("first", "", "first name")
+		last   = flag.String("last", "", "last name")
+		prompt = flag.Bool("p", false, "prompt for the user password (masked); ignored if USER_PASSWORD is set")
+		grants grantList
 	)
 	flag.Var(&grants, "grant", "tenant:org:role grant; repeatable")
 	flag.Parse()
@@ -66,12 +68,9 @@ func main() {
 		log.Fatalf("createuser: %v", err)
 	}
 
-	name := *username
-	if name == "" {
-		name = strings.SplitN(*email, "@", 2)[0]
-	}
+	// The realm uses email-as-username, so the email is the Keycloak username.
 	in := types.UserInput{
-		Username: name, Email: *email, FirstName: *first, LastName: *last,
+		Username: *email, Email: *email, FirstName: *first, LastName: *last,
 		Password: password, Grants: grants,
 	}
 

--- a/backend/internal/client/admin_keycloak.go
+++ b/backend/internal/client/admin_keycloak.go
@@ -62,9 +62,11 @@ type keycloakUser struct {
 // is exactly the `sub` claim of any token it later mints. Idempotent: an existing
 // user is updated in place.
 //
-// password is optional: a non-empty value is (re)set as a permanent password; an
-// empty value skips the password step entirely, for realms that delegate
-// authentication to an external IdP and therefore have no local credential.
+// password is optional: a non-empty value is (re)set as a temporary password —
+// Keycloak adds the UPDATE_PASSWORD required action so the user must choose their
+// own password at first login. An empty value skips the password step entirely,
+// for realms that delegate authentication to an external IdP and therefore have no
+// local credential.
 //
 // firstName/lastName are sent non-empty by callers because the Keycloak
 // user-profile feature otherwise injects a VERIFY_PROFILE required action that
@@ -202,7 +204,9 @@ func (c *KeycloakAdminClient) updateUser(ctx context.Context, token, id string, 
 
 func (c *KeycloakAdminClient) resetPassword(ctx context.Context, token, id, password string) error {
 	endpoint := fmt.Sprintf("%s/admin/realms/%s/users/%s/reset-password", c.cfg.BaseURL, c.cfg.Realm, id)
-	cred := map[string]any{"type": "password", "value": password, "temporary": false}
+	// temporary:true makes Keycloak add the UPDATE_PASSWORD required action, forcing
+	// the user to set their own password at first login.
+	cred := map[string]any{"type": "password", "value": password, "temporary": true}
 	status, body, err := c.adminRequest(ctx, http.MethodPut, endpoint, token, cred)
 	if err != nil {
 		return err

--- a/backend/internal/client/admin_keycloak_test.go
+++ b/backend/internal/client/admin_keycloak_test.go
@@ -23,6 +23,8 @@ type fakeKeycloak struct {
 	created         int
 	updated         int
 	passwordSets    int
+
+	lastPasswordTemporary bool // "temporary" field of the last reset-password credential
 }
 
 func newFakeKeycloak(realm string) *fakeKeycloak {
@@ -75,6 +77,9 @@ func (f *fakeKeycloak) server() *httptest.Server {
 	mux.HandleFunc(usersPath+"/", func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/reset-password") {
 			f.passwordSets++
+			var cred map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&cred)
+			f.lastPasswordTemporary, _ = cred["temporary"].(bool)
 		} else {
 			f.updated++
 		}
@@ -102,6 +107,18 @@ func Test_KeycloakAdminClient_UpsertUser_CreatesNewUserAndReturnsSub(t *testing.
 	assert.Equal(t, 1, fake.created)
 	assert.Equal(t, 0, fake.updated)
 	assert.Equal(t, 1, fake.passwordSets)
+}
+
+func Test_KeycloakAdminClient_UpsertUser_ForcesPasswordResetOnFirstLogin(t *testing.T) {
+	fake := newFakeKeycloak("CQDG")
+	srv := fake.server()
+	defer srv.Close()
+
+	_, err := fake.client(srv.URL).UpsertUser(context.Background(), "alice", "alice@demo.org", "Alice", "Demo", "pw")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, fake.passwordSets)
+	assert.True(t, fake.lastPasswordTemporary, "a set password is temporary so Keycloak forces a reset at first login")
 }
 
 func Test_KeycloakAdminClient_UpsertUser_SkipsPasswordWhenEmpty(t *testing.T) {


### PR DESCRIPTION
# fix: SJRA-1638 createuser uses email as username and sets a temporary password

## 📌 Context

The `createuser` CLI failed against our Keycloak realm, which is configured with **email-as-username**:

```
createuser: provision "jecos2@email.me": keycloak: upsert user "jecos2": user "jecos2" not found after create
```

The CLI inferred a username from the email's local part (`jecos2`), but the realm stores the username as the full email, so the post-create lookup by `username=jecos2` found nothing.

Separately, when the CLI sets an initial password it should not be permanent — an admin-provisioned user should choose their own password at first login.

## 📝 Changes

- **Username = email.** `cmd/createuser` no longer infers a username; it sends the email as the Keycloak username. Removed the now-meaningless `-username` flag.
- **Temporary password.** `KeycloakAdminClient.resetPassword` now posts the credential with `temporary: true`, so Keycloak adds the `UPDATE_PASSWORD` required action and forces a password change on first login. The empty-password (external-IdP) path is unchanged — `resetPassword` still only runs when a password is set.
- Updated `UpsertUser` doc comment and the `createuser` package doc accordingly.
- Note: the repeatable `-grant tenant:org:role` flag already existed and was not changed — e.g. `-grant "radiant:*:geneticist" -grant "radiant:*:data_manager"`.

## ☑️ TO-DOs

- [ ] None

## 🧪 Tests

- Added `Test_KeycloakAdminClient_UpsertUser_ForcesPasswordResetOnFirstLogin` (asserts the reset-password credential carries `temporary: true`); the fake Keycloak now captures that field.
- `go test ./internal/client/... ./cmd/createuser/...`, `make fmt`, `make lint` all clean.
- Manual: `USER_PASSWORD='Temp123!' go run ./cmd/createuser -email jecos2@email.me -first Je -last Cos -grant "radiant:*:geneticist"` provisions the user (username == email) and the user shows an `Update Password` required action in Keycloak.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1638](https://d3b.atlassian.net/browse/SJRA-1638)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- Blast radius of the `temporary: true` change is limited to the createuser CLI — it's the only caller of `UpsertUser`/`ProvisionUser`, there is no admin HTTP endpoint, and no backend test performs ROPC user-password login.
- The Ranger `{tenant}_user` role must already exist (the client treats a missing role as an error by design). Open question: should the compose stack seed these roles automatically?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SJRA-1638]: https://d3b.atlassian.net/browse/SJRA-1638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ