### PR TITLE
feat: SJRA-1590 structured GORM logging

### DIFF
--- a/backend/internal/database/postgres.go
+++ b/backend/internal/database/postgres.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	_ "github.com/joho/godotenv/autoload"
+	"github.com/radiant-network/radiant-api/internal/observability"
 )
 
 var (
@@ -36,7 +37,7 @@ func NewPostgresDB() (*gorm.DB, error) {
 	if dbPgSSLCert != "" {
 		dsn += fmt.Sprintf(" sslrootcert=%s", dbPgSSLCert)
 	}
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: observability.NewGormLogger("postgres")})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/database/starrocks.go
+++ b/backend/internal/database/starrocks.go
@@ -12,6 +12,7 @@ import (
 
 	gomysql "github.com/go-sql-driver/mysql"
 	_ "github.com/joho/godotenv/autoload"
+	"github.com/radiant-network/radiant-api/internal/observability"
 )
 
 var (
@@ -76,7 +77,7 @@ func NewStarrocksDB() (*gorm.DB, error) {
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?interpolateParams=true&parseTime=true%s",
 		dbUserName, dbPassword, dbHost, dbPort, dbName, tlsParam)
-	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{Logger: observability.NewGormLogger("starrocks")})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/observability/gorm_logger.go
+++ b/backend/internal/observability/gorm_logger.go
@@ -1,0 +1,128 @@
+package observability
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/radiant-network/radiant-api/internal/utils"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// defaultSlowQueryThreshold is the elapsed-time bar above which a query is logged as slow.
+const defaultSlowQueryThreshold = 200 * time.Millisecond
+
+// gormLogger adapts GORM's logger.Interface onto slog so database diagnostics are emitted
+// as structured JSON like the rest of the backend, instead of GORM's default plain-text
+// lines written straight to stdout.
+type gormLogger struct {
+	db                   string
+	slowThreshold        time.Duration
+	ignoreRecordNotFound bool
+	parameterizedQueries bool
+}
+
+// NewGormLogger returns a GORM logger that writes structured slog records. dbName labels
+// every line with the database it came from ("postgres" / "starrocks"). The slow-query
+// threshold is read from DB_SLOW_QUERY_THRESHOLD_MS (default 200ms). SQL is always logged
+// with placeholders rather than interpolated values (see ParamsFilter) so patient and
+// clinical identifiers never reach the logs.
+func NewGormLogger(dbName string) logger.Interface {
+	return gormLogger{
+		db:                   dbName,
+		slowThreshold:        slowQueryThreshold(),
+		ignoreRecordNotFound: true,
+		parameterizedQueries: true,
+	}
+}
+
+// slowQueryThreshold resolves the slow-query bar from DB_SLOW_QUERY_THRESHOLD_MS, falling
+// back to the default for an unset, non-integer, or non-positive value.
+func slowQueryThreshold() time.Duration {
+	ms, err := strconv.Atoi(utils.GetEnvOrDefault("DB_SLOW_QUERY_THRESHOLD_MS", "200"))
+	if err != nil || ms <= 0 {
+		return defaultSlowQueryThreshold
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// LogMode returns the logger unchanged: verbosity is governed by LOG_LEVEL through slog,
+// not by GORM's own level.
+func (l gormLogger) LogMode(logger.LogLevel) logger.Interface { return l }
+
+func (l gormLogger) Info(ctx context.Context, msg string, data ...any) {
+	slog.InfoContext(ctx, gormMessage(msg, data...), slog.String("db", l.db))
+}
+
+func (l gormLogger) Warn(ctx context.Context, msg string, data ...any) {
+	slog.WarnContext(ctx, gormMessage(msg, data...), slog.String("db", l.db))
+}
+
+func (l gormLogger) Error(ctx context.Context, msg string, data ...any) {
+	slog.ErrorContext(ctx, gormMessage(msg, data...), slog.String("db", l.db))
+}
+
+// gormMessage renders GORM's printf-style diagnostic message, guarding the no-args case so
+// a literal message isn't mangled by fmt verbs it doesn't contain.
+func gormMessage(msg string, data ...any) string {
+	if len(data) == 0 {
+		return msg
+	}
+	return fmt.Sprintf(msg, data...)
+}
+
+// Trace logs one record per executed SQL statement.
+//
+// Query errors are logged at DEBUG, not ERROR, on purpose: the request boundary
+// (server.HandleError) owns the single authoritative error log, so logging the same
+// failure here too would double-count it. DEBUG keeps the SQL recoverable when
+// investigating. Slow queries are logged at WARN; every other query at DEBUG (silent
+// unless LOG_LEVEL=debug). The level is resolved before fc() is called so the SQL string
+// is not built (via Dialector.Explain) for records that will be dropped — this runs on
+// every query.
+func (l gormLogger) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
+	elapsed := time.Since(begin)
+	isError := err != nil && (!l.ignoreRecordNotFound || !errors.Is(err, gorm.ErrRecordNotFound))
+	isSlow := l.slowThreshold > 0 && elapsed > l.slowThreshold
+
+	level := slog.LevelDebug
+	msg := "gorm query"
+	switch {
+	case isError:
+		msg = "gorm query failed"
+	case isSlow:
+		level, msg = slog.LevelWarn, "gorm slow query"
+	}
+
+	if !slog.Default().Enabled(ctx, level) {
+		return
+	}
+
+	sql, rows := fc()
+	attrs := []slog.Attr{
+		slog.String("db", l.db),
+		slog.String("sql", sql),
+		slog.Int64("rows", rows),
+		slog.Int64("elapsed_ms", elapsed.Milliseconds()),
+	}
+	if isError {
+		attrs = append(attrs, slog.Any("error", err))
+	} else if isSlow {
+		attrs = append(attrs, slog.Int64("threshold_ms", l.slowThreshold.Milliseconds()))
+	}
+	slog.LogAttrs(ctx, level, msg, attrs...)
+}
+
+// ParamsFilter implements gorm.ParamsFilter. Returning nil params makes GORM render the
+// logged SQL with placeholders instead of interpolating the actual bound values, keeping
+// PII out of the logs.
+func (l gormLogger) ParamsFilter(_ context.Context, sql string, params ...any) (string, []any) {
+	if l.parameterizedQueries {
+		return sql, nil
+	}
+	return sql, params
+}

--- a/backend/internal/observability/gorm_logger_test.go
+++ b/backend/internal/observability/gorm_logger_test.go
@@ -1,0 +1,144 @@
+package observability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// captureLogs redirects the default slog logger to a JSON buffer at the given level for
+// the duration of the test, returning the buffer and a restore func.
+func captureLogs(t *testing.T, level slog.Level) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: level})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+func testGormLogger() gormLogger {
+	return gormLogger{
+		db:                   "postgres",
+		slowThreshold:        200 * time.Millisecond,
+		ignoreRecordNotFound: true,
+		parameterizedQueries: true,
+	}
+}
+
+func fakeQuery(sql string, rows int64) func() (string, int64) {
+	return func() (string, int64) { return sql, rows }
+}
+
+func Test_GormLogger_SlowQueryLogsWarn(t *testing.T) {
+	buf := captureLogs(t, slog.LevelInfo)
+	l := testGormLogger()
+
+	begin := time.Now().Add(-300 * time.Millisecond)
+	l.Trace(context.Background(), begin, fakeQuery("SELECT * FROM cases WHERE id = $1", 30), nil)
+
+	var line map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &line))
+	assert.Equal(t, "WARN", line["level"])
+	assert.Equal(t, "gorm slow query", line["msg"])
+	assert.Equal(t, "postgres", line["db"])
+	assert.Equal(t, "SELECT * FROM cases WHERE id = $1", line["sql"])
+	assert.Equal(t, float64(30), line["rows"])
+	assert.GreaterOrEqual(t, line["elapsed_ms"], float64(200))
+	assert.Equal(t, float64(200), line["threshold_ms"])
+}
+
+func Test_GormLogger_FastQuerySilentAtInfo(t *testing.T) {
+	buf := captureLogs(t, slog.LevelInfo)
+	l := testGormLogger()
+
+	l.Trace(context.Background(), time.Now(), fakeQuery("SELECT 1", 1), nil)
+
+	assert.Empty(t, buf.String(), "a fast query should produce no output at INFO level")
+}
+
+func Test_GormLogger_FastQueryLogsDebugWhenEnabled(t *testing.T) {
+	buf := captureLogs(t, slog.LevelDebug)
+	l := testGormLogger()
+
+	l.Trace(context.Background(), time.Now(), fakeQuery("SELECT 1", 1), nil)
+
+	var line map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &line))
+	assert.Equal(t, "DEBUG", line["level"])
+	assert.Equal(t, "gorm query", line["msg"])
+}
+
+func Test_GormLogger_QueryErrorLogsDebugNotError(t *testing.T) {
+	buf := captureLogs(t, slog.LevelDebug)
+	l := testGormLogger()
+
+	l.Trace(context.Background(), time.Now(), fakeQuery("SELECT 1", 0), errors.New("connection refused"))
+
+	var line map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &line))
+	// Errors are logged at DEBUG, never ERROR/WARN — the request boundary owns the
+	// authoritative error log (no double-logging).
+	assert.Equal(t, "DEBUG", line["level"])
+	assert.Equal(t, "gorm query failed", line["msg"])
+	assert.Equal(t, "connection refused", line["error"])
+}
+
+func Test_GormLogger_QueryErrorSilentAtInfo(t *testing.T) {
+	buf := captureLogs(t, slog.LevelInfo)
+	l := testGormLogger()
+
+	l.Trace(context.Background(), time.Now(), fakeQuery("SELECT 1", 0), errors.New("boom"))
+
+	assert.Empty(t, buf.String(), "query errors are DEBUG, so silent at INFO; the boundary logs them")
+}
+
+func Test_GormLogger_RecordNotFoundSuppressed(t *testing.T) {
+	buf := captureLogs(t, slog.LevelInfo)
+	l := testGormLogger()
+
+	l.Trace(context.Background(), time.Now(), fakeQuery("SELECT 1", 0), gorm.ErrRecordNotFound)
+
+	assert.Empty(t, buf.String(), "ErrRecordNotFound is not an error condition and must not log as failure")
+}
+
+func Test_GormLogger_ParamsFilterStripsValuesWhenParameterized(t *testing.T) {
+	l := testGormLogger()
+	sql, params := l.ParamsFilter(context.Background(), "SELECT * FROM patient WHERE id = $1", "secret-mrn")
+	assert.Equal(t, "SELECT * FROM patient WHERE id = $1", sql)
+	assert.Nil(t, params, "parameterized mode must drop bound values so PII never reaches logs")
+}
+
+func Test_GormLogger_ParamsFilterKeepsValuesWhenDisabled(t *testing.T) {
+	l := testGormLogger()
+	l.parameterizedQueries = false
+	sql, params := l.ParamsFilter(context.Background(), "SELECT 1", "v")
+	assert.Equal(t, "SELECT 1", sql)
+	assert.Equal(t, []any{"v"}, params)
+}
+
+func Test_GormMessage_WithAndWithoutData(t *testing.T) {
+	assert.Equal(t, "plain message", gormMessage("plain message"))
+	assert.Equal(t, "rows: 5", gormMessage("rows: %d", 5))
+}
+
+func Test_GormLogger_PassthroughLevels(t *testing.T) {
+	buf := captureLogs(t, slog.LevelInfo)
+	l := testGormLogger()
+
+	l.Error(context.Background(), "migrator failed: %s", "table x")
+
+	var line map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &line))
+	assert.Equal(t, "ERROR", line["level"])
+	assert.Equal(t, "migrator failed: table x", line["msg"])
+	assert.Equal(t, "postgres", line["db"])
+}


### PR DESCRIPTION
# feat: SJRA-1590 structured GORM logging

## 📌 Context

Follow-up to #1410 (slog + request-id correlation, already merged). GORM was still using its **default logger**, which writes plain-text lines straight to stdout — bypassing slog. That produced unstructured output like `2026/… SLOW SQL >= 200ms [473ms] [rows:30] SELECT …`, and the interpolated SQL leaked literal identifiers (`case_id = '1'`) into logs. This replaces it with an slog-backed `logger.Interface`.

## 📝 Changes

- **`internal/observability/gorm_logger.go`** — slog-backed `logger.Interface` (`NewGormLogger(dbName)`) wired into `NewPostgresDB` (`"postgres"`) and `NewStarrocksDB` (`"starrocks"`).
  - **Slow queries → WARN**, **query errors → DEBUG** (the request boundary `HandleError` owns the single authoritative ERROR log — avoids double-logging the same failure), normal queries → DEBUG (silent unless `LOG_LEVEL=debug`), `ErrRecordNotFound` suppressed.
  - **PII-safe**: implements `ParamsFilter` so logged SQL keeps placeholders instead of interpolated values — patient/clinical identifiers never reach the logs.
  - Level is resolved **before** `fc()` runs, so the SQL string isn't built (`Dialector.Explain`) for records that will be dropped — this is on the per-query hot path.
  - Slow-query threshold configurable via `DB_SLOW_QUERY_THRESHOLD_MS` (default 200ms).

## ☑️ TO-DOs

- [ ] Follow-up: Prometheus counters/histograms + public `/metrics` (the GORM `Trace` hook is the intended place for the repo query-latency histogram) — the deferred metrics half of SJRA-1590.

## 🧪 Tests

- `internal/observability/gorm_logger_test.go`: slow→WARN (fields + placeholder SQL), fast query silent at INFO / logged at DEBUG, query error → DEBUG (never ERROR/WARN), `ErrRecordNotFound` suppressed, `ParamsFilter` strips values when parameterized, passthrough levels.
- `go build ./...` clean, `golangci-lint run` → 0 issues, observability tests pass.
- Manual: rebuild compose, re-trigger the germline SNV `…/list` endpoint → the SLOW SQL line is now JSON `{"level":"WARN","msg":"gorm slow query","db":"starrocks","sql":"…WHERE g_snv_o.seq_id = ?…","rows":30,"elapsed_ms":473,"threshold_ms":200}` with placeholders, not literal values.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
SJRA-1590
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- Error-logging policy: lower layers wrap-and-return; the request boundary is the single log site. The GORM logger logs query errors at DEBUG only, so a failed query isn't logged twice.
- `parameterizedQueries` is on by default and treated as a hard requirement (no literal values in logs) for this medical/genomic platform; the trade-off is that bound values are hidden when debugging a specific slow query.
