### PR TITLE
feat: CLIN-6059 - tenant 403 not found instead of 500

### DIFF
--- a/backend/internal/repository/auth.go
+++ b/backend/internal/repository/auth.go
@@ -39,6 +39,21 @@ func (r *AuthRepository) HasAction(userID, tenantCode, orgCode, actionCode strin
 	return allowed, nil
 }
 
+// TenantExists reports whether a tenant with the given code exists. It backs the
+// tenant-routing middleware: an unknown tenant in the URL path becomes a 404 instead of
+// reaching a write and surfacing as a foreign-key violation (a 500) downstream.
+func (r *AuthRepository) TenantExists(tenantCode string) (bool, error) {
+	var exists bool
+	err := r.db.Raw(`
+		SELECT EXISTS (
+			SELECT 1 FROM tenant WHERE code = ?
+		)`, tenantCode).Scan(&exists).Error
+	if err != nil {
+		return false, fmt.Errorf("error checking tenant existence for %q: %w", tenantCode, err)
+	}
+	return exists, nil
+}
+
 // HasTenantAccess reports whether the user holds at least one role in the given tenant.
 // It backs the tenant-routing middleware: any grant (org-scoped or tenant-wide) makes the
 // caller a member of the tenant.

--- a/backend/internal/server/handlers_auth_test.go
+++ b/backend/internal/server/handlers_auth_test.go
@@ -26,7 +26,7 @@ type mockAuthRepository struct {
 }
 
 // TenantExists defaults to reporting the tenant as present (zero-value tenantNotFound=false)
-// so existing tests need no change; set tenantNotFound to exercise the 404 path.
+// so existing tests need no change; set tenantNotFound to exercise the unknown-tenant 403 path.
 func (m *mockAuthRepository) TenantExists(tenantCode string) (bool, error) {
 	return !m.tenantNotFound, m.tenantExistsErr
 }

--- a/backend/internal/server/handlers_auth_test.go
+++ b/backend/internal/server/handlers_auth_test.go
@@ -15,12 +15,20 @@ import (
 type mockAuthRepository struct {
 	memberships     []types.TenantMembership
 	err             error
+	tenantNotFound  bool
+	tenantExistsErr error
 	hasTenantAccess bool
 	tenantErr       error
 	hasAction       bool
 	actionErr       error
 	gotOrgCode      string
 	gotAction       string
+}
+
+// TenantExists defaults to reporting the tenant as present (zero-value tenantNotFound=false)
+// so existing tests need no change; set tenantNotFound to exercise the 404 path.
+func (m *mockAuthRepository) TenantExists(tenantCode string) (bool, error) {
+	return !m.tenantNotFound, m.tenantExistsErr
 }
 
 func (m *mockAuthRepository) HasTenantAccess(email, tenantCode string) (bool, error) {

--- a/backend/internal/server/middlewares.go
+++ b/backend/internal/server/middlewares.go
@@ -99,13 +99,15 @@ type tenantAccessChecker interface {
 }
 
 // RequireTenantAccess gates tenant-scoped routes (`/:tenant/...`). It always reads the
-// `tenant` path param, rejects an unknown tenant with 404, and stores the resolved tenant
+// `tenant` path param, rejects an unknown tenant with 403, and stores the resolved tenant
 // code in the request context. When enforce is true it additionally verifies the caller
 // holds at least one role in that tenant, rejecting cross-tenant access with 403.
 //
 // The existence check runs regardless of enforce: the tenant comes from the URL path and is
-// foreign-key enforced on every write, so an unknown tenant is a client error (404) that must
-// not be allowed to reach a write and surface as an opaque 500 from an FK violation.
+// foreign-key enforced on every write, so an unknown tenant must not be allowed to reach a
+// write and surface as an opaque 500 from an FK violation. It is rejected with the same
+// generic 403 as a cross-tenant denial so the response never discloses whether a tenant
+// exists (an authenticated caller cannot distinguish "unknown tenant" from "not a member").
 //
 // enforce is wired from TENANT_ENFORCEMENT_ENABLED so the path-prefix routing can be
 // deployed before users are backfilled into user_role: with enforcement off, routing and
@@ -121,7 +123,7 @@ func RequireTenantAccess(auth utils.Auth, repo tenantAccessChecker, enforce bool
 			return
 		}
 		if !exists {
-			HandleNotFoundError(c, "tenant")
+			HandleForbiddenError(c)
 			c.Abort()
 			return
 		}

--- a/backend/internal/server/middlewares.go
+++ b/backend/internal/server/middlewares.go
@@ -91,16 +91,21 @@ func RequestLogger() gin.HandlerFunc {
 // resolved tenant code for downstream handlers.
 const TenantContextKey = "tenant"
 
-// tenantAccessChecker reports whether a caller may access a tenant. RequireTenantAccess
-// needs only this slice of the auth repository.
+// tenantAccessChecker is the slice of the auth repository RequireTenantAccess needs: it
+// resolves whether a tenant exists and whether a caller may access it.
 type tenantAccessChecker interface {
+	TenantExists(tenantCode string) (bool, error)
 	HasTenantAccess(userID, tenantCode string) (bool, error)
 }
 
 // RequireTenantAccess gates tenant-scoped routes (`/:tenant/...`). It always reads the
-// `tenant` path param and stores the resolved tenant code in the request context. When
-// enforce is true it additionally verifies the caller holds at least one role in that
-// tenant, rejecting cross-tenant access with 403.
+// `tenant` path param, rejects an unknown tenant with 404, and stores the resolved tenant
+// code in the request context. When enforce is true it additionally verifies the caller
+// holds at least one role in that tenant, rejecting cross-tenant access with 403.
+//
+// The existence check runs regardless of enforce: the tenant comes from the URL path and is
+// foreign-key enforced on every write, so an unknown tenant is a client error (404) that must
+// not be allowed to reach a write and surface as an opaque 500 from an FK violation.
 //
 // enforce is wired from TENANT_ENFORCEMENT_ENABLED so the path-prefix routing can be
 // deployed before users are backfilled into user_role: with enforcement off, routing and
@@ -108,6 +113,18 @@ type tenantAccessChecker interface {
 func RequireTenantAccess(auth utils.Auth, repo tenantAccessChecker, enforce bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tenant := c.Param("tenant")
+
+		exists, err := repo.TenantExists(tenant)
+		if err != nil {
+			HandleError(c, err)
+			c.Abort()
+			return
+		}
+		if !exists {
+			HandleNotFoundError(c, "tenant")
+			c.Abort()
+			return
+		}
 
 		if enforce {
 			userID, err := auth.RetrieveUserIdFromToken(c)

--- a/backend/internal/server/middlewares_test.go
+++ b/backend/internal/server/middlewares_test.go
@@ -82,6 +82,34 @@ func Test_RequireTenantAccess_RepoError_Returns500(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+// An unknown tenant in the URL path is a client error: 404, regardless of enforcement. This
+// guards against the bad tenant_code reaching a write and surfacing as an opaque 500 from a
+// foreign-key violation. Enforcement is off here to prove the check is independent of it.
+func Test_RequireTenantAccess_UnknownTenant_Returns404(t *testing.T) {
+	repo := &mockAuthRepository{tenantNotFound: true}
+	auth := &testutils.MockAuth{Id: mockUserID}
+	router := tenantTestRouter(repo, auth, false)
+
+	req, _ := http.NewRequest("GET", "/nope/cases/filters", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.JSONEq(t, `{"status":404,"message":"tenant not found"}`, w.Body.String())
+}
+
+func Test_RequireTenantAccess_TenantLookupError_Returns500(t *testing.T) {
+	repo := &mockAuthRepository{tenantExistsErr: fmt.Errorf("db down")}
+	auth := &testutils.MockAuth{Id: mockUserID}
+	router := tenantTestRouter(repo, auth, true)
+
+	req, _ := http.NewRequest("GET", "/radiant/cases/filters", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
 // With enforcement off, a non-member still passes and the tenant is stored in context. The
 // repo is rigged to error to prove the membership check is skipped entirely (no lockout
 // before users are backfilled).

--- a/backend/internal/server/middlewares_test.go
+++ b/backend/internal/server/middlewares_test.go
@@ -82,10 +82,11 @@ func Test_RequireTenantAccess_RepoError_Returns500(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-// An unknown tenant in the URL path is a client error: 404, regardless of enforcement. This
-// guards against the bad tenant_code reaching a write and surfacing as an opaque 500 from a
-// foreign-key violation. Enforcement is off here to prove the check is independent of it.
-func Test_RequireTenantAccess_UnknownTenant_Returns404(t *testing.T) {
+// An unknown tenant in the URL path is rejected with the same generic 403 as a cross-tenant
+// denial, regardless of enforcement, so the response never discloses whether a tenant exists.
+// This also guards against the bad tenant_code reaching a write and surfacing as an opaque 500
+// from a foreign-key violation. Enforcement is off here to prove the check is independent of it.
+func Test_RequireTenantAccess_UnknownTenant_Returns403(t *testing.T) {
 	repo := &mockAuthRepository{tenantNotFound: true}
 	auth := &testutils.MockAuth{Id: mockUserID}
 	router := tenantTestRouter(repo, auth, false)
@@ -94,8 +95,7 @@ func Test_RequireTenantAccess_UnknownTenant_Returns404(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	assert.JSONEq(t, `{"status":404,"message":"tenant not found"}`, w.Body.String())
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 func Test_RequireTenantAccess_TenantLookupError_Returns500(t *testing.T) {

--- a/backend/scripts/init-sql/insert_clinical_data.sql
+++ b/backend/scripts/init-sql/insert_clinical_data.sql
@@ -561,7 +561,8 @@ VALUES (1, 'FI0037662.S13230.cram', 'genomic', 'alignment', 'cram', 110187385978
 ON CONFLICT(id) DO NOTHING;
 
 INSERT INTO tenant (code, name)
-VALUES ('radiant', 'Radiant')
+VALUES ('radiant', 'Radiant'),
+       ('QLIN', 'QLIN')
 ON CONFLICT (code) DO NOTHING;
 
 INSERT INTO organization (code, name, category_code, tenant_code)


### PR DESCRIPTION
- [x] `404` if tenant doesn't exist
- [x] add `QLIN` in init database SQL script
- [x] Unit Tests
- [x] Local Tests