### PR TITLE
feat: SJRA-1651 change unique constraint for project

### DIFF
--- a/backend/scripts/init-sql/migrations/000014_project_tenant_unique_constraint.up.sql
+++ b/backend/scripts/init-sql/migrations/000014_project_tenant_unique_constraint.up.sql
@@ -1,0 +1,10 @@
+-- Widen project's UNIQUE(code) to UNIQUE(code, tenant_code).
+--
+-- Migration 000013 tenant-scoped public.project (added tenant_code + FK + index) but
+-- forgot to widen its unique constraint, leaving UNIQUE(code) global. project keeps its
+-- integer PK, so tenant_code is a plain column and inbound FKs (cases.project_id → id)
+-- are untouched; widening the unique key lets two tenants reuse the same project code —
+-- the same treatment analysis_catalog & panel already got in 000013.
+
+ALTER TABLE public.project DROP CONSTRAINT project_code_key;                  -- was UNIQUE (code)
+ALTER TABLE public.project ADD CONSTRAINT project_code_key UNIQUE (code, tenant_code);


### PR DESCRIPTION
# fix: SJRA-1651 widen project unique constraint to include tenant_code

## 📌 Context

Migration `000013_tenant_scope_clinical_tables` tenant-scoped `public.project` (added
`tenant_code` + FK + index) but forgot to widen its unique constraint, leaving
`UNIQUE(code)` global. This prevents two tenants from reusing the same project `code` —
inconsistent with `analysis_catalog` and `panel`, which already had their `UNIQUE(code)`
widened to `UNIQUE(code, tenant_code)` in 000013.

## 📝 Changes

- Add migration `000014_project_tenant_unique_constraint.up.sql` that drops the global
  `project_code_key UNIQUE (code)` and re-adds it as `UNIQUE (code, tenant_code)`.

## ☑️ TO-DOs

- [ ] None

## 🧪 Tests

- No new automated tests; this is a constraint change applied via migration (runs
  automatically on API startup). Verified the migration applies cleanly against a
  PostgreSQL instance with existing `project` rows.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1651](https://d3b.atlassian.net/browse/SJRA-1651)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- Follow-up to 000013 — `project` keeps its integer PK, so `tenant_code` stays a plain
  column and the inbound `cases.project_id → id` FK is unaffected.
- Migrations in this repo are sequential and up-only (no `.down.sql` files), matching the
  existing convention.

[SJRA-1651]: https://d3b.atlassian.net/browse/SJRA-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ