### PR TITLE
feat: SJRA-1654 Adjust Cypress tests related to Qlin env

### DIFF
--- a/cypress/pom/shared/Data.ts
+++ b/cypress/pom/shared/Data.ts
@@ -76,7 +76,7 @@ export const data = {
     patients: '2 (1.43e-1)',
     transcript_id: 'ENST00000370552',
     exon: null,
-    dna_change: null,
+    dna_change: 'c.290+7C>T',
     omim: {
       condition: 'Urofacial syndrome 1',
       inheritance: 'AR',

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -19,12 +19,12 @@ Cypress.Commands.add('isValidToken', token => {
   return cy
     .request({
       method: 'GET',
-      url: `${apiUrl}${tenant}/batches/mustReturn500ifTokenValid`,
+      url: `${apiUrl}${tenant}/batches/${globalData.BatchesId.patientNotFound}`,
       headers: { Authorization: `Bearer ${token}` },
       failOnStatusCode: false,
     })
     .then(res => {
-      return cy.wrap(res.status === 500);
+      return cy.wrap(res.status !== 401 && res.status !== 403);
     });
 });
 


### PR DESCRIPTION
# feat: SJRA-1654 Adjust Cypress tests related to Qlin env

## 📌 Context

Les tests Cypress devaient être ajustés pour fonctionner correctement avec l'environnement Qlin. Deux problèmes étaient en cause : une donnée attendue désormais désuète et une vérification de validité de token reposant sur un endpoint factice.

## 📝 Changes

- **`cypress/pom/shared/Data.ts`** : mise à jour de la donnée attendue `dna_change` (`null` → `c.290+7C>T`) pour refléter les valeurs réelles retournées par l'environnement Qlin.
- **`cypress/support/e2e.js`** : refonte de la commande `isValidToken`.
  - L'appel pointe maintenant vers un batch réel (`globalData.BatchesId.patientNotFound`) plutôt qu'un ID de batche invalide `mustReturn500ifTokenValid`.
  - La validité du token est déterminée par l'absence d'erreur d'authentification (`status !== 401 && status !== 403`) au lieu d'un code `500` codé en dur, rendant la vérification fiable peu importe l'environnement.

## 🧪 Tests

Les tests Cypress impactés ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1654](https://d3b.atlassian.net/browse/SJRA-1654)<!-- End JIRA Issues -->

[SJRA-1654]: https://d3b.atlassian.net/browse/SJRA-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ