### PR TITLE
fix(api): SJRA-1655 route glog to stderr to stop auth-path crash

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -28,6 +29,15 @@ import (
 	"github.com/radiant-network/radiant-api/internal/types"
 	"github.com/tbaehler/gin-keycloak/pkg/ginkeycloak"
 )
+
+// glog (pulled in transitively by gin-keycloak) defaults to writing log files under
+// /tmp. Our container has no writable /tmp, so when gin-keycloak logs an auth error
+// (e.g. an expired token, gin_keycloak.go:217) glog fails to create its file sink and
+// escalates to its own Fatal handler, aborting the whole process (SIGABRT, exit 2).
+// Forcing logtostderr keeps glog off the filesystem and routes those lines to stderr.
+func init() {
+	_ = flag.Set("logtostderr", "true")
+}
 
 func setupRouter(dbStarrocks *gorm.DB, dbPostgres *gorm.DB) *gin.Engine {
 	// Auth service


### PR DESCRIPTION
# fix(api): SJRA-1655 route glog to stderr to stop expired-token process crash

## 📌 Context

On QA, `radiant-api` pods were restarting repeatedly (10+ container restarts over a
few hours, exit code 2). The crash is triggered by any request carrying an
expired/invalid JWT:

1. The gin-keycloak auth middleware logs the auth failure via `glog.Errorf`
   (`gin_keycloak.go:217`, `[Gin-OAuth] Keycloak Token has expired`).
2. glog defaults to writing log **files** under `/tmp`. The container has no
   writable `/tmp`, so glog fails to create its file sink
   (`cannot create log: open /tmp/...: no such file or directory`).
3. glog escalates that sink error to its own **Fatal** handler → `SIGABRT` →
   the whole process exits (code 2) and the container restarts.

Because the app otherwise logs through `slog`, glog is only reached on auth
errors — which is why valid traffic was unaffected and the crashes looked
intermittent.

## 📝 Changes

- `backend/cmd/api/main.go`: force glog to log to stderr via
  `flag.Set("logtostderr", "true")` in an `init()`. This keeps glog off the
  filesystem entirely, so the failed-file-write → Fatal path can no longer fire.
  Auth-error lines now go to stderr (captured by the log pipeline) and the
  request gets a normal 401 instead of killing the process.

## ☑️ TO-DOs

- [ ] None — change is self-contained.

## 🧪 Tests

- `go build ./...` — clean
- `gofmt -l cmd/api/main.go` — clean
- `go vet ./cmd/api/` — clean
- No unit test added: the change is process-global logging configuration with no
  branching logic to assert. Behaviour is validated by deploying and confirming an
  expired-token request returns 401 (and is logged on stderr) without a pod restart.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1655](https://d3b.atlassian.net/browse/SJRA-1655)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- Root cause is a combination of (a) gin-keycloak hardcoding `glog` with no logger
  seam, and (b) glog defaulting to file logging with no writable `/tmp` in the
  container. `flag.Set` works without `flag.Parse()` because glog registers the
  `logtostderr` flag in its own package `init()`, which runs before ours.
- The **worker** is intentionally not changed: it has no REST interface, so the
  gin-keycloak auth chain (and thus glog) is never invoked there — glog is linked
  but never called.
- Considered but rejected for this PR: replacing gin-keycloak's middleware with an
  in-house slog-based one (would remove glog from the runtime entirely). That's a
  larger, security-sensitive change (JWKS fetch/cache + signature verification) and
  out of scope for this hotfix.

[SJRA-1655]: https://d3b.atlassian.net/browse/SJRA-1655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ