### PR TITLE
fix: SJRA-1657 retrieve user on email instead of username

### DIFF
--- a/backend/cmd/createuser/main.go
+++ b/backend/cmd/createuser/main.go
@@ -4,8 +4,10 @@
 //	go run ./cmd/createuser -email carol@demo.org -first Carol -last Demo \
 //	    -grant tenant_a:ORG_A1:geneticist -grant tenant_b:*:geneticist
 //
-// The realm is configured with email-as-username, so the email is sent as the
-// Keycloak username verbatim — the CLI never derives a separate username.
+// On create, the email is sent as the Keycloak username verbatim — the CLI never
+// derives a separate username. Identity is keyed on email, not username, so this
+// works whether or not the realm enforces email-as-username: an existing user is
+// matched by email even if its stored username differs.
 package main
 
 import (
@@ -68,7 +70,8 @@ func main() {
 		log.Fatalf("createuser: %v", err)
 	}
 
-	// The realm uses email-as-username, so the email is the Keycloak username.
+	// New users are created with the email as their Keycloak username; existing
+	// users are matched by email regardless of their stored username.
 	in := types.UserInput{
 		Username: *email, Email: *email, FirstName: *first, LastName: *last,
 		Password: password, Grants: grants,

--- a/backend/internal/client/admin_keycloak.go
+++ b/backend/internal/client/admin_keycloak.go
@@ -87,7 +87,10 @@ func (c *KeycloakAdminClient) UpsertUser(ctx context.Context, username, email, f
 		RequiredActions: []string{},
 	}
 
-	id, err := c.findUserID(ctx, token, username)
+	// Match on email, not username: a pre-existing user may have been provisioned
+	// with a username that differs from its email (the realm need not enforce
+	// email-as-username), so email is the reliable identity key.
+	id, err := c.findUserIDByEmail(ctx, token, email)
 	if err != nil {
 		return "", err
 	}
@@ -95,11 +98,11 @@ func (c *KeycloakAdminClient) UpsertUser(ctx context.Context, username, email, f
 		if err := c.createUser(ctx, token, user); err != nil {
 			return "", err
 		}
-		if id, err = c.findUserID(ctx, token, username); err != nil {
+		if id, err = c.findUserIDByEmail(ctx, token, email); err != nil {
 			return "", err
 		}
 		if id == "" {
-			return "", fmt.Errorf("user %q not found after create", username)
+			return "", fmt.Errorf("user %q not found after create", email)
 		}
 	} else {
 		if err := c.updateUser(ctx, token, id, user); err != nil {
@@ -154,26 +157,26 @@ func (c *KeycloakAdminClient) adminToken(ctx context.Context) (string, error) {
 	return parsed.AccessToken, nil
 }
 
-// findUserID returns the id of the user with an exact username match, or "" if none.
-func (c *KeycloakAdminClient) findUserID(ctx context.Context, token, username string) (string, error) {
-	endpoint := fmt.Sprintf("%s/admin/realms/%s/users?username=%s&exact=true",
-		c.cfg.BaseURL, c.cfg.Realm, url.QueryEscape(username))
+// findUserIDByEmail returns the id of the user with an exact email match, or "" if none.
+func (c *KeycloakAdminClient) findUserIDByEmail(ctx context.Context, token, email string) (string, error) {
+	endpoint := fmt.Sprintf("%s/admin/realms/%s/users?email=%s&exact=true",
+		c.cfg.BaseURL, c.cfg.Realm, url.QueryEscape(email))
 	status, body, err := c.adminRequest(ctx, http.MethodGet, endpoint, token, nil)
 	if err != nil {
 		return "", err
 	}
 	if status != http.StatusOK {
-		return "", fmt.Errorf("find user %q failed: HTTP %d: %s", username, status, string(body))
+		return "", fmt.Errorf("find user %q failed: HTTP %d: %s", email, status, string(body))
 	}
 	var users []keycloakUser
 	if err := json.Unmarshal(body, &users); err != nil {
-		return "", fmt.Errorf("parse user search for %q: %w", username, err)
+		return "", fmt.Errorf("parse user search for %q: %w", email, err)
 	}
 	if len(users) == 0 {
 		return "", nil
 	}
 	if len(users) > 1 {
-		return "", fmt.Errorf("find user %q: expected at most 1 exact match, got %d", username, len(users))
+		return "", fmt.Errorf("find user %q: expected at most 1 exact match, got %d", email, len(users))
 	}
 	return users[0].ID, nil
 }

--- a/backend/internal/client/admin_keycloak_test.go
+++ b/backend/internal/client/admin_keycloak_test.go
@@ -15,11 +15,11 @@ import (
 // fakeKeycloak is a minimal stateful stand-in for the Keycloak admin REST API.
 type fakeKeycloak struct {
 	realm           string
-	usersByName     map[string]string // username -> id (the sub)
+	usersByEmail    map[string]string // email -> id (the sub)
 	nextID          string
 	tokenStatus     int  // override token endpoint status (0 => 200)
 	createStatus    int  // override create status (0 => 201)
-	duplicateSearch bool // return two rows for the searched username
+	duplicateSearch bool // return two rows for the searched email
 	created         int
 	updated         int
 	passwordSets    int
@@ -29,9 +29,9 @@ type fakeKeycloak struct {
 
 func newFakeKeycloak(realm string) *fakeKeycloak {
 	return &fakeKeycloak{
-		realm:       realm,
-		usersByName: map[string]string{},
-		nextID:      "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		realm:        realm,
+		usersByEmail: map[string]string{},
+		nextID:       "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 	}
 }
 
@@ -50,13 +50,13 @@ func (f *fakeKeycloak) server() *httptest.Server {
 	mux.HandleFunc(usersPath, func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			username := r.URL.Query().Get("username")
-			id, ok := f.usersByName[username]
+			email := r.URL.Query().Get("email")
+			id, ok := f.usersByEmail[email]
 			out := []map[string]string{}
 			if ok {
-				out = append(out, map[string]string{"id": id, "username": username})
+				out = append(out, map[string]string{"id": id, "email": email})
 				if f.duplicateSearch {
-					out = append(out, map[string]string{"id": id + "-dup", "username": username})
+					out = append(out, map[string]string{"id": id + "-dup", "email": email})
 				}
 			}
 			_ = json.NewEncoder(w).Encode(out)
@@ -67,7 +67,7 @@ func (f *fakeKeycloak) server() *httptest.Server {
 			}
 			var u map[string]any
 			_ = json.NewDecoder(r.Body).Decode(&u)
-			f.usersByName[u["username"].(string)] = f.nextID
+			f.usersByEmail[u["email"].(string)] = f.nextID
 			f.created++
 			w.WriteHeader(http.StatusCreated)
 		}
@@ -137,7 +137,7 @@ func Test_KeycloakAdminClient_UpsertUser_SkipsPasswordWhenEmpty(t *testing.T) {
 
 func Test_KeycloakAdminClient_UpsertUser_UpdatesExistingUser(t *testing.T) {
 	fake := newFakeKeycloak("CQDG")
-	fake.usersByName["alice"] = "existing-1111-2222-3333-444444444444"
+	fake.usersByEmail["alice@demo.org"] = "existing-1111-2222-3333-444444444444"
 	srv := fake.server()
 	defer srv.Close()
 
@@ -180,7 +180,7 @@ func Test_KeycloakAdminClient_UpsertUser_TokenFailureIsReported(t *testing.T) {
 
 func Test_KeycloakAdminClient_UpsertUser_AmbiguousSearchIsReported(t *testing.T) {
 	fake := newFakeKeycloak("CQDG")
-	fake.usersByName["alice"] = "existing-id"
+	fake.usersByEmail["alice@demo.org"] = "existing-id"
 	fake.duplicateSearch = true
 	srv := fake.server()
 	defer srv.Close()


### PR DESCRIPTION
## 📌 Context

`cmd/createuser` failed when re-run for a user that already exists in Keycloak with a username that differs from their email (e.g. `cypress@email.me` stored with username `cypress`):

```
createuser: provision "[cypress@email.me](mailto:cypress@email.me)": keycloak: upsert user "[cypress@email.me](mailto:cypress@email.me)": user "[cypress@email.me](mailto:cypress@email.me)" not found after create
```

`UpsertUser` looked the user up by **username** (`?username=…&exact=true`), assuming the realm enforces email-as-username. When that assumption doesn't hold, the lookup misses, the create POST conflicts on the unique email (silently accepted as a 409), and the follow-up lookup misses again → `not found after create`. The result: an existing user could never be matched, so granting an existing user access to a new tenant was impossible.

## 📝 Changes

- **Look up users by email instead of username** in `KeycloakAdminClient.UpsertUser` (`findUserID` → `findUserIDByEmail`, querying `?email=…&exact=true`). 
- New users are still **created** with `username = email` via the admin API, which is unaffected by the realm's `registrationEmailAsUsername` setting.

## ☑️ TO-DOs

- [ ] None

## 🧪 Tests

- Updated the test fake to key users by email (`usersByEmail`) and match the `email` query param.
- The existing-user test now uses a deliberate `username != email` case (`username "alice"` / `email "alice@demo.org"`), which reproduces the original failure scenario and verifies the user is matched and updated rather than re-created.
- Run: `cd backend && go test ./internal/client/...`
- Test locally with success to add existing user to a new tenant

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1657](https://d3b.atlassian.net/browse/SJRA-1657)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- The fix is config-agnostic: it works whether the realm is email-as-username or not, because the username search assumption was the bug.
- The one remaining assumption is that **emails are unique** (`duplicateEmailsAllowed: false`, the Keycloak default). If emails are not unique, `findUserIDByEmail` fails loudly with `expected at most 1 exact match` rather than silently picking the wrong user — intended behavior.

[SJRA-1657]: https://d3b.atlassian.net/browse/SJRA-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ