### PR TITLE
feat(notes): SJRA-1660 add header in popover

### DIFF
--- a/frontend/components/base/notes/notes-container.tsx
+++ b/frontend/components/base/notes/notes-container.tsx
@@ -108,7 +108,8 @@ function NotesContainer({ enableEmptyIcon = false, enableSkeletonLoading = true,
 
   return (
     <>
-      <div className="px-4 py-3 shrink-0">
+      <div className="px-4 pt-4 text-foreground text-sm font-semibold">{t('notes.variant.title')}</div>
+      <div className="p-4 shrink-0">
         <RichTextEditor
           onChange={setContent}
           clearContent={clearContent}

--- a/frontend/components/base/notes/notes-container.tsx
+++ b/frontend/components/base/notes/notes-container.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/base/shadcn/button';
 import { TooltipProvider } from '@/components/base/shadcn/tooltip';
 import { useI18n } from '@/components/hooks/i18n';
 import { useLoginContext } from '@/components/hooks/use-login';
+import { cn } from '@/lib/utils';
 import { DEFAULT_TENANT, occurencesNotesApi } from '@/utils/api';
 
 import { useNotesContext } from './hooks/use-notes';
@@ -31,6 +32,7 @@ type NoteContainerBaseProps = {
 export type NotesContainerProps = NoteContainerBaseProps & {
   enableEmptyIcon?: boolean;
   enableSkeletonLoading?: boolean;
+  withHeader?: boolean;
 };
 
 export type GetOccurrenceNoteInput = Omit<NotesContainerProps, 'enableEmptyIcon'>;
@@ -56,7 +58,12 @@ async function saveNote(_url: string, { arg }: { arg: CreateOccurrenceNoteInput 
  *
  * - ListFetcher refresh the table list when a note is saved or deleted to update the note's icon state
  */
-function NotesContainer({ enableEmptyIcon = false, enableSkeletonLoading = true, ...props }: NotesContainerProps) {
+function NotesContainer({
+  enableEmptyIcon = false,
+  enableSkeletonLoading = true,
+  withHeader = false,
+  ...props
+}: NotesContainerProps) {
   const { t } = useI18n();
   const { sub } = useLoginContext();
   const { onChangeCallback } = useNotesContext();
@@ -108,8 +115,8 @@ function NotesContainer({ enableEmptyIcon = false, enableSkeletonLoading = true,
 
   return (
     <>
-      <div className="px-4 pt-4 text-foreground text-sm font-semibold">{t('notes.variant.title')}</div>
-      <div className="p-4 shrink-0">
+      {withHeader && <div className="px-4 pt-4 text-foreground text-sm font-semibold">{t('notes.variant.title')}</div>}
+      <div className={cn('shrink-0', withHeader ? 'p-4' : 'px-4 py-3')}>
         <RichTextEditor
           onChange={setContent}
           clearContent={clearContent}

--- a/frontend/components/base/notes/notes-popover.tsx
+++ b/frontend/components/base/notes/notes-popover.tsx
@@ -52,7 +52,7 @@ function NotesPopover({ hasNotes, loading = false, ...props }: NotesPopoverProps
         onFocusOutside={handlePreventClosing}
         onInteractOutside={handlePreventClosing}
       >
-        <NotesContainer {...props} enableSkeletonLoading={false} />
+        <NotesContainer {...props} enableSkeletonLoading={false} withHeader />
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
# Feat (notes): Add header in popover

## 📌 Context

Add title to the variant notes popover

## 📝 Changes

- Add header in notes popover content
- No impact on notes slider

## 🧪 Tests

<img width="625" height="601" alt="Capture d’écran, le 2026-06-22 à 14 12 11" src="https://github.com/user-attachments/assets/028896fe-564b-4433-a6c6-a540bbd1489c" />

<img width="625" height="601" alt="Capture d’écran, le 2026-06-22 à 14 12 17" src="https://github.com/user-attachments/assets/8ea0ffa3-2807-429d-95f4-6db564dda097" />

<img width="672" height="605" alt="Capture d’écran, le 2026-06-22 à 14 25 32" src="https://github.com/user-attachments/assets/68cb8086-260d-4f71-94f3-cc6e29327c48" />

### Storybook

<img width="839" height="561" alt="Capture d’écran, le 2026-06-22 à 14 29 48" src="https://github.com/user-attachments/assets/35e5be22-254c-465d-b0e0-73cae4d7dd78" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1660](https://d3b.atlassian.net/browse/SJRA-1660)<!-- End JIRA Issues -->

[SJRA-1660]: https://d3b.atlassian.net/browse/SJRA-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ