### PR TITLE
feat(tenant): SJRA-1451 add tenant switcher and storybook

### DIFF
--- a/frontend/apps/case/src/entity/case-entity.tsx
+++ b/frontend/apps/case/src/entity/case-entity.tsx
@@ -11,7 +11,8 @@ import { Button } from '@/components/base/shadcn/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/shadcn/tooltip';
 import { CaseEntityTabs } from '@/components/cores/types/case-tabs';
 import { useI18n } from '@/components/hooks/i18n';
-import { caseApi, DEFAULT_TENANT } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { caseApi } from '@/utils/api';
 import { useCaseIdFromParam } from '@/utils/helper';
 
 import DetailsTab from './details/details-tab';
@@ -27,13 +28,14 @@ type CaseEntityInput = {
   caseId: number;
 };
 
-async function fetchCaseEntity(input: CaseEntityInput) {
-  const response = await caseApi.caseEntity(DEFAULT_TENANT, input.caseId);
+async function fetchCaseEntity(input: CaseEntityInput, tenant: string) {
+  const response = await caseApi.caseEntity(tenant, input.caseId);
   return response.data;
 }
 
 export default function App() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const caseId = useCaseIdFromParam();
   const mainRef = useRef<HTMLDivElement>(null);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -46,7 +48,7 @@ export default function App() {
       key: 'case-entity',
       caseId,
     },
-    fetchCaseEntity,
+    input => fetchCaseEntity(input, tenant),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,

--- a/frontend/apps/case/src/entity/files/files-tab.tsx
+++ b/frontend/apps/case/src/entity/files/files-tab.tsx
@@ -6,7 +6,8 @@ import { ApiError, DocumentsSearchResponse, ListBodyWithCriteria, SearchCriterio
 import DataTable from '@/components/base/data-table/data-table';
 import { Card, CardContent } from '@/components/base/shadcn/card';
 import { useI18n } from '@/components/hooks/i18n';
-import { caseApi, DEFAULT_TENANT } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { caseApi } from '@/utils/api';
 import { useCaseIdFromParam } from '@/utils/helper';
 
 import { defaultSettings, getCaseEntityDocumentsColumns } from './files-table/files-tab-table-settings';
@@ -17,13 +18,14 @@ type DocumentInput = {
   body: ListBodyWithCriteria;
 };
 
-async function fetchDocuments(input: DocumentInput) {
-  const response = await caseApi.caseEntityDocumentsSearch(DEFAULT_TENANT, input.caseId, input.body);
+async function fetchDocuments(input: DocumentInput, tenant: string) {
+  const response = await caseApi.caseEntityDocumentsSearch(tenant, input.caseId, input.body);
   return response.data;
 }
 
 function FilesTab() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const caseId = useCaseIdFromParam();
   const [searchCriteria, setSearchCriteria] = useState<SearchCriterion[]>([]);
   const [sorting, setSorting] = useState<SortBody[]>([]);
@@ -46,7 +48,7 @@ function FilesTab() {
         search_criteria: searchCriteria,
       },
     },
-    fetchDocuments,
+    input => fetchDocuments(input, tenant),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,

--- a/frontend/apps/case/src/entity/files/files-table/files-table-filters.tsx
+++ b/frontend/apps/case/src/entity/files/files-table/files-table-filters.tsx
@@ -8,8 +8,9 @@ import getDataTypeOptions from '@/components/base/data-table/filters/options/opt
 import getFileFormatOptions from '@/components/base/data-table/filters/options/option-file-format';
 import getRelationshipOptions from '@/components/base/data-table/filters/options/option-relationship';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import usePersistedFilters, { StringArrayRecord } from '@/components/hooks/usePersistedFilters';
-import { caseApi, DEFAULT_TENANT } from '@/utils/api';
+import { caseApi } from '@/utils/api';
 
 const DEFAULT_VISIBLE_FILTERS = ['format_code', 'data_type_code', 'relationship_to_proband_code'];
 
@@ -30,24 +31,29 @@ const CRITERIAS = {
   relationship_to_proband_code: { key: 'relationship_to_proband_code', weight: 3, visible: true },
 };
 
-async function fetchFilters(caseId: number) {
-  const response = await caseApi.caseEntityDocumentsFilters(DEFAULT_TENANT, caseId);
+async function fetchFilters(caseId: number, tenant: string) {
+  const response = await caseApi.caseEntityDocumentsFilters(tenant, caseId);
   return response.data;
 }
 
 function FilesTableFilters({ caseId, setSearchCriteria }: FilesTableFilters) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [changedFilterButtons, setChangedFilterButtons] = useState<string[]>([]);
   const [openFilters, setOpenFilters] = useState<Record<string, boolean>>({});
   const [filters, setFilters] = usePersistedFilters<StringArrayRecord>('case-files-filters', {
     ...FILTER_DEFAULTS,
   });
-  const { data: apiFilters, isLoading } = useSWR<DocumentFilters>('document-filters', () => fetchFilters(caseId), {
-    revalidateOnFocus: false,
-    revalidateOnMount: true,
-    revalidateIfStale: false,
-    revalidateOnReconnect: false,
-  });
+  const { data: apiFilters, isLoading } = useSWR<DocumentFilters>(
+    'document-filters',
+    () => fetchFilters(caseId, tenant),
+    {
+      revalidateOnFocus: false,
+      revalidateOnMount: true,
+      revalidateIfStale: false,
+      revalidateOnReconnect: false,
+    },
+  );
 
   // Mesmoize filter buttons to prevent unnecessary re-renders
   const filterButtons = useMemo(() => {

--- a/frontend/apps/case/src/entity/variants/germline-occurrence/cnv-tab.tsx
+++ b/frontend/apps/case/src/entity/variants/germline-occurrence/cnv-tab.tsx
@@ -6,7 +6,8 @@ import QueryBuilder from '@/components/base/query-builder/query-builder';
 import QueryBuilderDataTable from '@/components/base/query-builder/query-builder-data-table';
 import { useConfig } from '@/components/cores/applications-config';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, occurrencesApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { occurrencesApi } from '@/utils/api';
 import { useCaseIdFromParam, useTaskIdFromSearchParam } from '@/utils/helper';
 
 import { isValidSeqId } from './libs/seq-id';
@@ -22,6 +23,7 @@ type CNVTabProps = {
 
 function CNVTab({ seqId, caseEntity }: CNVTabProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const config = useConfig();
   const caseId = useCaseIdFromParam();
   const appId = config.germline_cnv_occurrence.app_id;
@@ -40,13 +42,13 @@ function CNVTab({ seqId, caseEntity }: CNVTabProps) {
         list: async (params: IListInput) => {
           if (taskId === undefined) return [];
           return occurrencesApi
-            .listGermlineCNVOccurrences(DEFAULT_TENANT, caseId, seqId, taskId, params.listBody)
+            .listGermlineCNVOccurrences(tenant, caseId, seqId, taskId, params.listBody)
             .then(response => response.data);
         },
         count: async (params: ICountInput) => {
           if (taskId === undefined) return { count: 0 };
           return occurrencesApi
-            .countGermlineCNVOccurrences(DEFAULT_TENANT, caseId, seqId, taskId, params.countBody)
+            .countGermlineCNVOccurrences(tenant, caseId, seqId, taskId, params.countBody)
             .then(response => response.data);
         },
       }}

--- a/frontend/apps/case/src/entity/variants/germline-occurrence/interpretation/germline-interpretation-dialog.tsx
+++ b/frontend/apps/case/src/entity/variants/germline-occurrence/interpretation/germline-interpretation-dialog.tsx
@@ -22,7 +22,8 @@ import {
 } from '@/components/base/slider/slider-variant-details-card';
 import { Spinner } from '@/components/base/spinner';
 import { useI18n } from '@/components/hooks/i18n';
-import { caseApi, DEFAULT_TENANT, interpretationApi, occurrencesApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { caseApi, interpretationApi, occurrencesApi } from '@/utils/api';
 import { useCaseIdFromParam, useSeqIdFromSearchParam } from '@/utils/helper';
 
 import { SELECTED_VARIANT_PARAM } from '../../constants';
@@ -69,14 +70,18 @@ type GermlineInterpretationFormInput = {
   interpretationGermline: InterpretationGermline;
 };
 
-async function fetchCaseEntity(_url: string, { arg }: { arg: CaseEntityInput }) {
-  const response = await caseApi.caseEntity(DEFAULT_TENANT, arg.caseId);
+async function fetchCaseEntity(_url: string, { arg }: { arg: CaseEntityInput }, tenant: string) {
+  const response = await caseApi.caseEntity(tenant, arg.caseId);
   return response.data;
 }
 
-async function fetchInterpretationGermline(_url: string, { arg }: { arg: InterpretationGermlineInput }) {
+async function fetchInterpretationGermline(
+  _url: string,
+  { arg }: { arg: InterpretationGermlineInput },
+  tenant: string,
+) {
   const response = await interpretationApi.getInterpretationGermline(
-    DEFAULT_TENANT,
+    tenant,
     arg.caseId,
     arg.seqId,
     arg.locusId,
@@ -85,9 +90,9 @@ async function fetchInterpretationGermline(_url: string, { arg }: { arg: Interpr
   return response.data;
 }
 
-async function fetchExpandedGermlineSNVOccurrence(_url: string, { arg }: { arg: ExpandGermlineInput }) {
+async function fetchExpandedGermlineSNVOccurrence(_url: string, { arg }: { arg: ExpandGermlineInput }, tenant: string) {
   const response = await occurrencesApi.getExpandedGermlineSNVOccurrence(
-    DEFAULT_TENANT,
+    tenant,
     arg.caseId,
     arg.seqId,
     arg.taskId,
@@ -96,9 +101,13 @@ async function fetchExpandedGermlineSNVOccurrence(_url: string, { arg }: { arg: 
   return response.data;
 }
 
-async function saveGermlineInterpretation(_url: string, { arg }: { arg: GermlineInterpretationFormInput }) {
+async function saveGermlineInterpretation(
+  _url: string,
+  { arg }: { arg: GermlineInterpretationFormInput },
+  tenant: string,
+) {
   const response = await interpretationApi.postInterpretationGermline(
-    DEFAULT_TENANT,
+    tenant,
     arg.caseId,
     arg.seqId,
     arg.locusId,
@@ -118,6 +127,7 @@ function GermlineInterpretationDialog({
   isCreation = false,
 }: GermlineInterpretationDialogProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [searchParams, setSearchParams] = useSearchParams();
   const [open, setOpen] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
@@ -125,21 +135,23 @@ function GermlineInterpretationDialog({
   const caseId = useCaseIdFromParam();
   const seqId = useSeqIdFromSearchParam();
 
-  const caseEntity = useSWRMutation<CaseEntity, any, string, CaseEntityInput>('case-entity', fetchCaseEntity);
+  const caseEntity = useSWRMutation<CaseEntity, any, string, CaseEntityInput>('case-entity', (url, opts) =>
+    fetchCaseEntity(url, opts, tenant),
+  );
 
   const occurrenceExpand = useSWRMutation<ExpandedGermlineSNVOccurrence, any, string, ExpandGermlineInput>(
     `form-somatic-expand-${caseId}-${locusId}-${seqId}`,
-    fetchExpandedGermlineSNVOccurrence,
+    (url, opts) => fetchExpandedGermlineSNVOccurrence(url, opts, tenant),
   );
 
   const interpretation = useSWRMutation<Interpretation, any, string, InterpretationGermlineInput>(
     `form-somatic-interpretation-${seqId}-${locusId}-${transcriptId}`,
-    fetchInterpretationGermline,
+    (url, opts) => fetchInterpretationGermline(url, opts, tenant),
   );
 
   const saveInterpretation = useSWRMutation(
     `save-germline-interpretation-${seqId}-${locusId}-${transcriptId}`,
-    saveGermlineInterpretation,
+    (url, opts) => saveGermlineInterpretation(url, opts, tenant),
     {
       onSuccess: () => {
         setOpen(false);

--- a/frontend/apps/case/src/entity/variants/germline-occurrence/overlapping-gene-dialog.tsx
+++ b/frontend/apps/case/src/entity/variants/germline-occurrence/overlapping-gene-dialog.tsx
@@ -12,8 +12,9 @@ import {
   DialogTrigger,
 } from '@/components/base/shadcn/dialog';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { toKiloBases } from '@/components/lib/number-format';
-import { DEFAULT_TENANT, occurrencesApi } from '@/utils/api';
+import { occurrencesApi } from '@/utils/api';
 import { useCaseIdFromParam, useSeqIdFromSearchParam } from '@/utils/helper';
 
 import {
@@ -34,12 +35,13 @@ type OverlappingGeneDialogProps = {
 };
 
 export function useCNVOverlappingGenesListHelper(input: OverlappingGenesInput) {
+  const { tenant } = useTenant();
   const fetch = useCallback(
     async () =>
       occurrencesApi
-        .listGermlineCNVGenesOverlap(DEFAULT_TENANT, input.caseId, input.seqId, input.taskId, input.cnvId)
+        .listGermlineCNVGenesOverlap(tenant, input.caseId, input.seqId, input.taskId, input.cnvId)
         .then(response => response.data),
-    [input],
+    [input, tenant],
   );
 
   return {

--- a/frontend/apps/case/src/entity/variants/germline-occurrence/sliders/slider-germline-occurrence-sheet.tsx
+++ b/frontend/apps/case/src/entity/variants/germline-occurrence/sliders/slider-germline-occurrence-sheet.tsx
@@ -19,7 +19,8 @@ import SliderSheet from '@/components/base/slider/slider-sheet';
 import SliderSheetSkeleton from '@/components/base/slider/slider-sheet-skeleton';
 import SliderVariantDetailsCard from '@/components/base/slider/slider-variant-details-card';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, interpretationApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { interpretationApi } from '@/utils/api';
 import { useCaseIdFromParam } from '@/utils/helper';
 
 import { SELECTED_VARIANT_PARAM } from '../../constants';
@@ -33,9 +34,9 @@ type InterpretationInput = {
   transcriptId: string;
 };
 
-async function fetchInterpretation(input: InterpretationInput) {
+async function fetchInterpretation(input: InterpretationInput, tenant: string) {
   const response = await interpretationApi.getInterpretationGermline(
-    DEFAULT_TENANT,
+    tenant,
     input.caseId,
     input.seqId,
     input.locusId,
@@ -93,6 +94,7 @@ export function GermlineOccurrenceSheetContent({
   patientSelected,
 }: OccurrenceSheetContentProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const caseId = useCaseIdFromParam();
   const { list } = useDataTable();
 
@@ -111,7 +113,7 @@ export function GermlineOccurrenceSheetContent({
       locusId: occurrence.locus_id,
       transcriptId: expandResult.data?.transcript_id,
     },
-    fetchInterpretation,
+    (key: InterpretationInput) => fetchInterpretation(key, tenant),
     {
       revalidateOnFocus: false,
       revalidateOnMount: false,

--- a/frontend/apps/case/src/entity/variants/germline-occurrence/snv-tab.tsx
+++ b/frontend/apps/case/src/entity/variants/germline-occurrence/snv-tab.tsx
@@ -6,8 +6,9 @@ import QueryBuilder from '@/components/base/query-builder/query-builder';
 import QueryBuilderDataTable from '@/components/base/query-builder/query-builder-data-table';
 import { useConfig } from '@/components/cores/applications-config';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { getPatientClinicalInformation } from '@/components/lib/case-entity';
-import { DEFAULT_TENANT, occurrencesApi } from '@/utils/api';
+import { occurrencesApi } from '@/utils/api';
 import { useCaseIdFromParam, useTaskIdFromSearchParam } from '@/utils/helper';
 
 import VariantsOnboardingWizard from '../onboardings/variants-onboarding-wizard';
@@ -27,6 +28,7 @@ type SNVTabProps = {
 
 function SNVTab({ seqId, patientSelected, caseEntity }: SNVTabProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const config = useConfig();
   const caseId = useCaseIdFromParam();
   const appId = config.germline_snv_occurrence.app_id;
@@ -50,13 +52,13 @@ function SNVTab({ seqId, patientSelected, caseEntity }: SNVTabProps) {
           list: async (params: IListInput) => {
             if (taskId === undefined) return [];
             return occurrencesApi
-              .listGermlineSNVOccurrences(DEFAULT_TENANT, caseId, seqId, taskId, params.listBody)
+              .listGermlineSNVOccurrences(tenant, caseId, seqId, taskId, params.listBody)
               .then(response => response.data);
           },
           count: async (params: ICountInput) => {
             if (taskId === undefined) return { count: 0 };
             return occurrencesApi
-              .countGermlineSNVOccurrences(DEFAULT_TENANT, caseId, seqId, taskId, params.countBody)
+              .countGermlineSNVOccurrences(tenant, caseId, seqId, taskId, params.countBody)
               .then(response => response.data);
           },
         }}

--- a/frontend/apps/case/src/entity/variants/interpretation/mondo-auto-complete-form-field.tsx
+++ b/frontend/apps/case/src/entity/variants/interpretation/mondo-auto-complete-form-field.tsx
@@ -8,8 +8,9 @@ import { AutoComplete, Option } from '@/components/base/data-entry/auto-complete
 import AnchorLink from '@/components/base/navigation/anchor-link';
 import { FormControl, FormField, FormItem, FormLabel } from '@/components/base/shadcn/form';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { debounce } from '@/components/hooks/useDebounce';
-import { DEFAULT_TENANT, mondoApi } from '@/utils/api';
+import { mondoApi } from '@/utils/api';
 import MondoOptionItemLabel from 'components/base/variant/mondo-option-item-label';
 
 import { GermlineInterpretationSchemaType, SomaticInterpretationSchemaType } from './types';
@@ -23,6 +24,7 @@ type MondoAutoCompleteFormFieldProps = {
 
 function MondoAutoCompleteFormField({ name, label, placeholder, schema }: MondoAutoCompleteFormFieldProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const form = useFormContext();
   const [options, setOptions] = useState<Option[]>([]);
   const [searchValue, setSearchValue] = useState<string>('');
@@ -30,7 +32,7 @@ function MondoAutoCompleteFormField({ name, label, placeholder, schema }: MondoA
 
   const mondoSearch = useSWR(
     searchValue || form.getValues(name),
-    (value: string) => mondoApi.mondoTermAutoComplete(DEFAULT_TENANT, value),
+    (value: string) => mondoApi.mondoTermAutoComplete(tenant, value),
     {
       onSuccess: data => {
         setOptions(

--- a/frontend/apps/case/src/entity/variants/interpretation/pubmed-form-field.tsx
+++ b/frontend/apps/case/src/entity/variants/interpretation/pubmed-form-field.tsx
@@ -9,12 +9,14 @@ import { Button } from '@/components/base/shadcn/button';
 import { FormLabel, FormMessage } from '@/components/base/shadcn/form';
 import { Input } from '@/components/base/shadcn/input';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, interpretationApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { interpretationApi } from '@/utils/api';
 
 import { GenericInterpretationSchemaType } from './types';
 
 function PubmedFormField() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const { control, register, getValues, setError, clearErrors, setValue, getFieldState } =
     useFormContext<GenericInterpretationSchemaType>();
   const { fields, append, remove } = useFieldArray<GenericInterpretationSchemaType>({
@@ -26,7 +28,7 @@ function PubmedFormField() {
 
   const pubmedFetch = useSWR(
     pubmedFetchKey,
-    ({ value }) => interpretationApi.getPubmedCitation(DEFAULT_TENANT, value).then(res => res.data),
+    ({ value }) => interpretationApi.getPubmedCitation(tenant, value).then(res => res.data),
     {
       onSuccess: data => {
         if (pubmedFetchKey?.index !== undefined) {

--- a/frontend/apps/case/src/entity/variants/somatic-occurrence/interpretation/somatic-interpretation-dialog.tsx
+++ b/frontend/apps/case/src/entity/variants/somatic-occurrence/interpretation/somatic-interpretation-dialog.tsx
@@ -22,7 +22,8 @@ import {
 } from '@/components/base/slider/slider-variant-details-card';
 import { Spinner } from '@/components/base/spinner';
 import { useI18n } from '@/components/hooks/i18n';
-import { caseApi, DEFAULT_TENANT, interpretationApi, occurrencesApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { caseApi, interpretationApi, occurrencesApi } from '@/utils/api';
 import { useCaseIdFromParam, useSeqIdFromSearchParam } from '@/utils/helper';
 
 import { SELECTED_VARIANT_PARAM } from '../../constants';
@@ -69,14 +70,14 @@ type SomaticInterpretationFormInput = {
   interpretationSomatic: InterpretationSomatic;
 };
 
-async function fetchCaseEntity(_url: string, { arg }: { arg: CaseEntityInput }) {
-  const response = await caseApi.caseEntity(DEFAULT_TENANT, arg.caseId);
+async function fetchCaseEntity(_url: string, { arg }: { arg: CaseEntityInput }, tenant: string) {
+  const response = await caseApi.caseEntity(tenant, arg.caseId);
   return response.data;
 }
 
-async function fetchInterpretationSomatic(_url: string, { arg }: { arg: InterpretationSomaticInput }) {
+async function fetchInterpretationSomatic(_url: string, { arg }: { arg: InterpretationSomaticInput }, tenant: string) {
   const response = await interpretationApi.getInterpretationSomatic(
-    DEFAULT_TENANT,
+    tenant,
     arg.caseId,
     arg.seqId,
     arg.locusId,
@@ -85,9 +86,9 @@ async function fetchInterpretationSomatic(_url: string, { arg }: { arg: Interpre
   return response.data;
 }
 
-async function fetchExpandedSomaticSNVOccurrence(_url: string, { arg }: { arg: ExpandSomaticInput }) {
+async function fetchExpandedSomaticSNVOccurrence(_url: string, { arg }: { arg: ExpandSomaticInput }, tenant: string) {
   const response = await occurrencesApi.getExpandedSomaticSNVOccurrence(
-    DEFAULT_TENANT,
+    tenant,
     arg.caseId,
     arg.seqId,
     arg.taskId,
@@ -96,9 +97,13 @@ async function fetchExpandedSomaticSNVOccurrence(_url: string, { arg }: { arg: E
   return response.data;
 }
 
-async function saveSomaticInterpretation(_url: string, { arg }: { arg: SomaticInterpretationFormInput }) {
+async function saveSomaticInterpretation(
+  _url: string,
+  { arg }: { arg: SomaticInterpretationFormInput },
+  tenant: string,
+) {
   const response = await interpretationApi.postInterpretationSomatic(
-    DEFAULT_TENANT,
+    tenant,
     arg.caseId,
     arg.seqId,
     arg.locusId,
@@ -118,6 +123,7 @@ function SomaticInterpretationDialog({
   isCreation = false,
 }: SomaticInterpretationDialogProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [searchParams, setSearchParams] = useSearchParams();
   const [open, setOpen] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
@@ -125,21 +131,23 @@ function SomaticInterpretationDialog({
   const caseId = useCaseIdFromParam();
   const seqId = useSeqIdFromSearchParam();
 
-  const caseEntity = useSWRMutation<CaseEntity, any, string, CaseEntityInput>('case-entity', fetchCaseEntity);
+  const caseEntity = useSWRMutation<CaseEntity, any, string, CaseEntityInput>('case-entity', (url, opts) =>
+    fetchCaseEntity(url, opts, tenant),
+  );
 
   const occurrenceExpand = useSWRMutation<ExpandedSomaticSNVOccurrence, any, string, ExpandSomaticInput>(
     `form-somatic-expand-${caseId}-${locusId}-${seqId}`,
-    fetchExpandedSomaticSNVOccurrence,
+    (url, opts) => fetchExpandedSomaticSNVOccurrence(url, opts, tenant),
   );
 
   const interpretation = useSWRMutation<Interpretation, any, string, InterpretationSomaticInput>(
     `form-somatic-interpretation-${seqId}-${locusId}-${transcriptId}`,
-    fetchInterpretationSomatic,
+    (url, opts) => fetchInterpretationSomatic(url, opts, tenant),
   );
 
   const saveInterpretation = useSWRMutation(
     `save-somatic-interpretation-${seqId}-${locusId}-${transcriptId}`,
-    saveSomaticInterpretation,
+    (url, opts) => saveSomaticInterpretation(url, opts, tenant),
     {
       onSuccess: () => {
         setOpen(false);

--- a/frontend/apps/case/src/entity/variants/somatic-occurrence/sliders/slider-somatic-occurrence-sheet.tsx
+++ b/frontend/apps/case/src/entity/variants/somatic-occurrence/sliders/slider-somatic-occurrence-sheet.tsx
@@ -24,8 +24,9 @@ import SliderSheetSkeleton from '@/components/base/slider/slider-sheet-skeleton'
 import SliderVariantDetailsCard from '@/components/base/slider/slider-variant-details-card';
 import SomaticSliderInterpretationDetailsCard from '@/components/base/slider/somatic-slider-interpretation-details-card';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { getPatientClinicalInformation } from '@/components/lib/case-entity';
-import { caseApi, DEFAULT_TENANT, interpretationApi, occurrencesApi } from '@/utils/api';
+import { caseApi, interpretationApi, occurrencesApi } from '@/utils/api';
 import { useCaseIdFromParam } from '@/utils/helper';
 
 import { SELECTED_VARIANT_PARAM } from '../../constants';
@@ -56,9 +57,9 @@ type InterpretationInput = {
   transcriptId: string;
 };
 
-export async function fetchSomaticOccurrenceExpand(input: OccurrenceExpandInput) {
+export async function fetchSomaticOccurrenceExpand(input: OccurrenceExpandInput, tenant: string) {
   const response = await occurrencesApi.getExpandedSomaticSNVOccurrence(
-    DEFAULT_TENANT,
+    tenant,
     input.caseId,
     input.seqId,
     input.taskId,
@@ -67,14 +68,14 @@ export async function fetchSomaticOccurrenceExpand(input: OccurrenceExpandInput)
   return response.data;
 }
 
-export async function fetchCaseEntity(input: CaseInput) {
-  const response = await caseApi.caseEntity(DEFAULT_TENANT, input.caseId);
+export async function fetchCaseEntity(input: CaseInput, tenant: string) {
+  const response = await caseApi.caseEntity(tenant, input.caseId);
   return response.data;
 }
 
-export async function fetchInterpretation(input: InterpretationInput) {
+export async function fetchInterpretation(input: InterpretationInput, tenant: string) {
   const response = await interpretationApi.getInterpretationSomatic(
-    DEFAULT_TENANT,
+    tenant,
     input.caseId,
     input.seqId,
     input.locusId,
@@ -127,6 +128,7 @@ export function SomaticOccurrenceSheetContent({
   hasPrevious,
 }: SomaticOccurrenceSheetContentProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const caseId = useCaseIdFromParam();
 
   const { list } = useDataTable();
@@ -139,7 +141,7 @@ export function SomaticOccurrenceSheetContent({
       seqId: occurrence.seq_id,
       taskId: occurrence.task_id,
     },
-    fetchSomaticOccurrenceExpand,
+    key => fetchSomaticOccurrenceExpand(key, tenant),
     {
       shouldRetryOnError: false,
       revalidateOnFocus: false,
@@ -152,7 +154,7 @@ export function SomaticOccurrenceSheetContent({
       key: 'case-entity',
       caseId: caseId,
     },
-    fetchCaseEntity,
+    key => fetchCaseEntity(key as CaseInput, tenant),
     {
       shouldRetryOnError: false,
       revalidateOnFocus: false,
@@ -166,7 +168,7 @@ export function SomaticOccurrenceSheetContent({
       locusId: occurrence.locus_id,
       transcriptId: expandResult.data?.transcript_id,
     },
-    fetchInterpretation,
+    key => fetchInterpretation(key as InterpretationInput, tenant),
     {
       revalidateOnFocus: false,
       revalidateOnMount: false,

--- a/frontend/apps/case/src/entity/variants/somatic-occurrence/snv-tumor-normal-tab.tsx
+++ b/frontend/apps/case/src/entity/variants/somatic-occurrence/snv-tumor-normal-tab.tsx
@@ -6,8 +6,9 @@ import QueryBuilder from '@/components/base/query-builder/query-builder';
 import QueryBuilderDataTable from '@/components/base/query-builder/query-builder-data-table';
 import { useConfig } from '@/components/cores/applications-config';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { getPatientClinicalInformation } from '@/components/lib/case-entity';
-import { DEFAULT_TENANT, occurrencesApi } from '@/utils/api';
+import { occurrencesApi } from '@/utils/api';
 import { useCaseIdFromParam, useTaskIdFromSearchParam } from '@/utils/helper';
 
 import { isValidSeqId } from '../germline-occurrence/libs/seq-id';
@@ -27,6 +28,7 @@ type SomaticOccurrencesProps = {
 
 function SNVTumorNormalTab({ seqId, patientSelected, caseEntity }: SomaticOccurrencesProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const config = useConfig();
   const caseId = useCaseIdFromParam();
   const appId = config.somatic_snv_to_occurrence.app_id;
@@ -50,13 +52,13 @@ function SNVTumorNormalTab({ seqId, patientSelected, caseEntity }: SomaticOccurr
           list: async (params: IListInput) => {
             if (taskId === undefined) return [];
             return occurrencesApi
-              .listSomaticSNVOccurrences(DEFAULT_TENANT, caseId, seqId, taskId, params.listBody)
+              .listSomaticSNVOccurrences(tenant, caseId, seqId, taskId, params.listBody)
               .then(response => response.data);
           },
           count: async (params: ICountInput) => {
             if (taskId === undefined) return { count: 0 };
             return occurrencesApi
-              .countSomaticSNVOccurrences(DEFAULT_TENANT, caseId, seqId, taskId, params.countBody)
+              .countSomaticSNVOccurrences(tenant, caseId, seqId, taskId, params.countBody)
               .then(response => response.data);
           },
         }}

--- a/frontend/apps/case/src/entity/variants/table/cells/occurrence-note-cell.tsx
+++ b/frontend/apps/case/src/entity/variants/table/cells/occurrence-note-cell.tsx
@@ -6,7 +6,8 @@ import { useDataTable } from '@/components/base/data-table/hooks/use-data-table'
 import { NotesProvider } from '@/components/base/notes/hooks/use-notes';
 import { GetOccurrenceNoteInput } from '@/components/base/notes/notes-container';
 import NotesPopover from '@/components/base/notes/notes-popover';
-import { DEFAULT_TENANT, occurencesNotesApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { occurencesNotesApi } from '@/utils/api';
 import { useCaseIdFromParam } from '@/utils/helper';
 
 type VariantNoteCellProps = {
@@ -16,9 +17,9 @@ type VariantNoteCellProps = {
   hasNote: boolean;
 };
 
-async function fetchNotesCount(_url: string, { arg }: { arg: GetOccurrenceNoteInput }) {
+async function fetchNotesCount(_url: string, { arg }: { arg: GetOccurrenceNoteInput }, tenant: string) {
   const response = await occurencesNotesApi.countOccurrenceNotes(
-    DEFAULT_TENANT,
+    tenant,
     arg.caseId,
     arg.seqId,
     arg.taskId,
@@ -29,11 +30,12 @@ async function fetchNotesCount(_url: string, { arg }: { arg: GetOccurrenceNoteIn
 
 function OccurrenceNoteCell({ seqId, taskId, occurrenceId, hasNote }: VariantNoteCellProps) {
   const caseId = useCaseIdFromParam();
+  const { tenant } = useTenant();
   const { list } = useDataTable();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const { trigger } = useSWRMutation<Count, Error, string, GetOccurrenceNoteInput>(
     `list/notes/cout/${caseId}/${seqId}/${taskId}/${occurrenceId}`,
-    fetchNotesCount,
+    (key, opts) => fetchNotesCount(key, opts, tenant),
   );
 
   const onChangeCallback = useCallback(async () => {

--- a/frontend/apps/case/src/exploration/case-exploration.tsx
+++ b/frontend/apps/case/src/exploration/case-exploration.tsx
@@ -7,7 +7,8 @@ import DataTable from '@/components/base/data-table/data-table';
 import PageHeader from '@/components/base/page/page-header';
 import { Card, CardContent } from '@/components/base/shadcn/card';
 import { useI18n } from '@/components/hooks/i18n';
-import { caseApi, DEFAULT_TENANT } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { caseApi } from '@/utils/api';
 
 import TableFilters from './table/case-exploration-table-filters';
 import { defaultSettings, getCaseExplorationColumns } from './table/cases-exploration-table-settings';
@@ -16,13 +17,14 @@ type CaseListInput = {
   listBodyWithCriteria: ListBodyWithCriteria;
 };
 
-async function fetchCasesList(input: CaseListInput) {
-  const response = await caseApi.searchCases(DEFAULT_TENANT, input.listBodyWithCriteria);
+async function fetchCasesList(input: CaseListInput, tenant: string) {
+  const response = await caseApi.searchCases(tenant, input.listBodyWithCriteria);
   return response.data;
 }
 
 export default function App() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [sorting, setSorting] = useState<SortBody[]>([]);
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -44,7 +46,7 @@ export default function App() {
         sort: sorting,
       },
     },
-    fetchCasesList,
+    input => fetchCasesList(input, tenant),
     {
       revalidateOnFocus: false,
     },

--- a/frontend/apps/case/src/exploration/table/case-exploration-table-filters.tsx
+++ b/frontend/apps/case/src/exploration/table/case-exploration-table-filters.tsx
@@ -12,8 +12,9 @@ import DataTableFilters, {
 import getItemPriority from '@/components/base/data-table/filters/options/option-priority';
 import getItemStatus from '@/components/base/data-table/filters/options/option-status';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import usePersistedFilters, { StringArrayRecord } from '@/components/hooks/usePersistedFilters';
-import { caseApi, DEFAULT_TENANT } from '@/utils/api';
+import { caseApi } from '@/utils/api';
 
 type FiltersGroupFormProps = {
   loading?: boolean;
@@ -48,20 +49,21 @@ export const FILTER_DEFAULTS = {
   case_category_code: [],
 };
 
-async function fetchFilters() {
-  const response = await caseApi.casesFilters(DEFAULT_TENANT);
+async function fetchFilters(tenant: string) {
+  const response = await caseApi.casesFilters(tenant);
   return response.data;
 }
 
 function FiltersGroupForm({ loading = true, setSearchCriteria }: FiltersGroupFormProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [changedFilterButtons, setChangedFilterButtons] = useState<string[]>([]);
   const [openFilters, setOpenFilters] = useState<Record<string, boolean>>({});
   const [filters, setFilters] = usePersistedFilters<StringArrayRecord>('case-exploration-filters', {
     ...FILTER_DEFAULTS,
   });
 
-  const { data: apiFilters } = useSWR<CaseFilters>('case-filters', () => fetchFilters(), {
+  const { data: apiFilters } = useSWR<CaseFilters>('case-filters', () => fetchFilters(tenant), {
     revalidateOnFocus: false,
     revalidateOnMount: true,
     revalidateIfStale: false,
@@ -133,7 +135,7 @@ function FiltersGroupForm({ loading = true, setSearchCriteria }: FiltersGroupFor
       filterSearch={{
         placeholder: t('case_exploration.filters_group.search_placeholder'),
         minSearchLength: 1,
-        api: (prefix: string) => caseApi.autocompleteCases(DEFAULT_TENANT, prefix, '10'),
+        api: (prefix: string) => caseApi.autocompleteCases(tenant, prefix, '10'),
       }}
       filterButtons={filterButtons}
       changedFilterButtons={changedFilterButtons}

--- a/frontend/apps/file-archive/src/exploration/archive/files-archive-list-table-filters.tsx
+++ b/frontend/apps/file-archive/src/exploration/archive/files-archive-list-table-filters.tsx
@@ -11,8 +11,9 @@ import getDataTypeOptions from '@/components/base/data-table/filters/options/opt
 import getFileFormatOptions from '@/components/base/data-table/filters/options/option-file-format';
 import getRelationshipOptions from '@/components/base/data-table/filters/options/option-relationship';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import usePersistedFilters, { StringArrayRecord } from '@/components/hooks/usePersistedFilters';
-import { DEFAULT_TENANT, documentApi } from '@/utils/api';
+import { documentApi } from '@/utils/api';
 
 type FilesTableFilters = {
   setSearchCriteria: (searchCriteria: SearchCriterion[]) => void;
@@ -34,19 +35,20 @@ const CRITERIAS = {
   data_type_code: { key: 'data_type_code', weight: 5, visible: true },
 };
 
-async function fetchFilters() {
-  const response = await documentApi.documentsFilters(DEFAULT_TENANT);
+async function fetchFilters(tenant: string) {
+  const response = await documentApi.documentsFilters(tenant);
   return response.data;
 }
 
 function FilesTableFilters({ setSearchCriteria }: FilesTableFilters) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [changedFilterButtons, setChangedFilterButtons] = useState<string[]>([]);
   const [openFilters, setOpenFilters] = useState<Record<string, boolean>>({});
   const [filters, setFilters] = usePersistedFilters<StringArrayRecord>('files-filters', {
     ...FILTER_DEFAULTS,
   });
-  const { data: apiFilters, isLoading } = useSWR<DocumentFilters>('document-filters', () => fetchFilters(), {
+  const { data: apiFilters, isLoading } = useSWR<DocumentFilters>('document-filters', () => fetchFilters(tenant), {
     revalidateOnFocus: false,
     revalidateOnMount: true,
     revalidateIfStale: false,
@@ -107,7 +109,7 @@ function FilesTableFilters({ setSearchCriteria }: FilesTableFilters) {
       filterSearch={{
         minSearchLength: 1,
         placeholder: t('file_entity.search_by_id_placeholder'),
-        api: (prefix: string) => documentApi.autocompleteDocuments(DEFAULT_TENANT, prefix, '10'),
+        api: (prefix: string) => documentApi.autocompleteDocuments(tenant, prefix, '10'),
       }}
       filterButtons={filterButtons}
       changedFilterButtons={changedFilterButtons}

--- a/frontend/apps/file-archive/src/exploration/archive/files-archive-list.tsx
+++ b/frontend/apps/file-archive/src/exploration/archive/files-archive-list.tsx
@@ -5,7 +5,8 @@ import useSWR from 'swr';
 import { ApiError, DocumentsSearchResponse, ListBodyWithCriteria, SearchCriterion, SortBody } from '@/api/api';
 import DataTable from '@/components/base/data-table/data-table';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, documentApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { documentApi } from '@/utils/api';
 
 import FilesTableFilters from './files-archive-list-table-filters';
 import { defaultSettings, getFilesArchiveColumns } from './files-archive-table-settings';
@@ -14,13 +15,14 @@ type DocumentInput = {
   body: ListBodyWithCriteria;
 };
 
-async function fetchDocuments(input: DocumentInput) {
-  const response = await documentApi.searchDocuments(DEFAULT_TENANT, input.body);
+async function fetchDocuments(input: DocumentInput, tenant: string) {
+  const response = await documentApi.searchDocuments(tenant, input.body);
   return response.data;
 }
 
 function FilesArchiveList() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [searchCriteria, setSearchCriteria] = useState<SearchCriterion[]>([]);
   const [sorting, setSorting] = useState<SortBody[]>([]);
   const [pagination, setPagination] = useState<PaginationState>({
@@ -41,7 +43,7 @@ function FilesArchiveList() {
         search_criteria: searchCriteria,
       },
     },
-    fetchDocuments,
+    input => fetchDocuments(input, tenant),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,

--- a/frontend/apps/variant/src/entity/cases/cases-tab.tsx
+++ b/frontend/apps/variant/src/entity/cases/cases-tab.tsx
@@ -8,8 +8,9 @@ import TabsNav, { TabsContent, TabsList, TabsListItem } from '@/components/base/
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/base/shadcn/card';
 import { CaseEntityCasesTabs } from '@/components/cores/types/case-tabs';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { tabContentClassName } from '@/style';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { variantsApi } from '@/utils/api';
 
 import { CasesFiltersProvider } from './table/filters/cases-filters-context';
 import InterpretedCasesTable from './interpreted-cases-table';
@@ -22,18 +23,19 @@ type CasesCountInput = {
   locusId: string;
 };
 
-async function fetchCasesCount(input: CasesCountInput) {
-  const response = await variantsApi.getGermlineVariantCasesCount(DEFAULT_TENANT, input.locusId);
+async function fetchCasesCount(input: CasesCountInput, tenant: string) {
+  const response = await variantsApi.getGermlineVariantCasesCount(tenant, input.locusId);
   return response.data;
 }
 
-async function fetchCasesFilters() {
-  const response = await variantsApi.getGermlineVariantCasesFilters(DEFAULT_TENANT);
+async function fetchCasesFilters(tenant: string) {
+  const response = await variantsApi.getGermlineVariantCasesFilters(tenant);
   return response.data;
 }
 
 function CasesTab() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const params = useParams<{ locusId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState<CaseEntityCasesTabs>(
@@ -45,14 +47,14 @@ function CasesTab() {
       key: 'cases-count',
       locusId: params.locusId!,
     },
-    fetchCasesCount,
+    input => fetchCasesCount(input, tenant),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,
     },
   );
 
-  const filtersQuery = useSWR<VariantCasesFilters, ApiError, string>('cases-filters', fetchCasesFilters);
+  const filtersQuery = useSWR<VariantCasesFilters, ApiError, string>('cases-filters', () => fetchCasesFilters(tenant));
 
   const handleOnTabChange = useCallback(
     (value: CaseEntityCasesTabs) => {

--- a/frontend/apps/variant/src/entity/cases/interpreted-cases-table.tsx
+++ b/frontend/apps/variant/src/entity/cases/interpreted-cases-table.tsx
@@ -12,7 +12,8 @@ import {
 } from '@/api/api';
 import DataTable from '@/components/base/data-table/data-table';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { variantsApi } from '@/utils/api';
 
 import SliderInterpretedCaseSheet from './slider/slider-interpreted-case-sheet';
 import { useSliderCasePatientIdNavigation } from './slider/use-slider-case-navigation';
@@ -26,13 +27,14 @@ type InterpretedCasesSearchInput = {
   criteria: ListBodyWithCriteria;
 };
 
-async function fetchInterpretedCases(input: InterpretedCasesSearchInput) {
-  const response = await variantsApi.getGermlineVariantInterpretedCases(DEFAULT_TENANT, input.locusId, input.criteria);
+async function fetchInterpretedCases(input: InterpretedCasesSearchInput, tenant: string) {
+  const response = await variantsApi.getGermlineVariantInterpretedCases(tenant, input.locusId, input.criteria);
   return response.data;
 }
 
 function InterpretedCasesTable() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const params = useParams<{ locusId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const [rowSelection, setRowSelection] = useState({});
@@ -96,7 +98,7 @@ function InterpretedCasesTable() {
         page_index: pagination.pageIndex,
       },
     },
-    fetchInterpretedCases,
+    input => fetchInterpretedCases(input, tenant),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,

--- a/frontend/apps/variant/src/entity/cases/slider/slider-interpreted-case-sheet.tsx
+++ b/frontend/apps/variant/src/entity/cases/slider/slider-interpreted-case-sheet.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router';
 import { ArrowUpRight } from 'lucide-react';
 
 import { CaseTasksWithOccurrencesDataTypeEnum, VariantInterpretedCase } from '@/api/api';
-import Empty from '@/components/base/empty';
+import Empty from '@/components/base/empties/empty';
 import { Button } from '@/components/base/shadcn/button';
 import { Separator } from '@/components/base/shadcn/separator';
 import GermlineSliderInterpretationDetailsCard from '@/components/base/slider/germline-slider-interpretation-details-card';
@@ -122,6 +122,7 @@ function CaseSheetContent({ caseData, onPrevious, onNext, hasPrevious, hasNext }
         isManePlus={expandResult.data.is_mane_plus}
         isCanonical={expandResult.data.is_canonical}
         transcriptId={expandResult.data.transcript_id}
+        actions={undefined}
       />
 
       <OccurrenceSheetDetailsCard

--- a/frontend/apps/variant/src/entity/cases/slider/slider-uninterpreted-case-sheet.tsx
+++ b/frontend/apps/variant/src/entity/cases/slider/slider-uninterpreted-case-sheet.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router';
 import { ArrowUpRight } from 'lucide-react';
 
 import { CaseTasksWithOccurrencesDataTypeEnum, VariantUninterpretedCase } from '@/api/api';
-import Empty from '@/components/base/empty';
+import Empty from '@/components/base/empties/empty';
 import { Button } from '@/components/base/shadcn/button';
 import { Separator } from '@/components/base/shadcn/separator';
 import { useCase } from '@/components/base/slider/hooks/use-slider-occurrence-and-case';

--- a/frontend/apps/variant/src/entity/cases/table/uninterpreted-cases-table-filters.tsx
+++ b/frontend/apps/variant/src/entity/cases/table/uninterpreted-cases-table-filters.tsx
@@ -11,8 +11,9 @@ import DataTableFilters, {
 import getItemTransmissionMode from '@/components/base/data-table/filters/options/option-transmission-mode';
 import getItemZygosity from '@/components/base/data-table/filters/options/option-zygosity';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import usePersistedFilters, { StringArrayRecord } from '@/components/hooks/usePersistedFilters';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { variantsApi } from '@/utils/api';
 
 import PhenotypeCasesFilter from './filters/phenotype-cases-filter';
 
@@ -40,8 +41,8 @@ const CRITERIAS = {
   sex_code: { key: 'sex_code', weight: 6, visible: false },
 };
 
-async function fetchFilters() {
-  const response = await variantsApi.getGermlineVariantCasesFilters(DEFAULT_TENANT);
+async function fetchFilters(tenant: string) {
+  const response = await variantsApi.getGermlineVariantCasesFilters(tenant);
   return response.data;
 }
 
@@ -51,13 +52,14 @@ function UninterpretedCasesTableFilters({
   loading,
 }: UninterpretedCasesTableFiltersProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [changedFilterButtons, setChangedFilterButtons] = useState<string[]>([]);
   const [openFilters, setOpenFilters] = useState<Record<string, boolean>>({});
   const [filters, setFilters] = usePersistedFilters<StringArrayRecord>('uninterpreted-cases-filters', {
     ...FILTER_DEFAULTS,
   });
 
-  const { data: apiFilters } = useSWR<VariantCasesFilters>('uninterpreted-cases-filters', fetchFilters, {
+  const { data: apiFilters } = useSWR<VariantCasesFilters>('uninterpreted-cases-filters', () => fetchFilters(tenant), {
     revalidateOnFocus: false,
     revalidateOnMount: true,
     revalidateIfStale: false,

--- a/frontend/apps/variant/src/entity/cases/uninterpreted-cases-table.tsx
+++ b/frontend/apps/variant/src/entity/cases/uninterpreted-cases-table.tsx
@@ -12,9 +12,10 @@ import {
 } from '@/api/api';
 import DataTable from '@/components/base/data-table/data-table';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import SliderUninterpretedCaseSheet from '@/entity/cases/slider/slider-uninterpreted-case-sheet';
 import { useSliderCasePatientIdNavigation } from '@/entity/cases/slider/use-slider-case-navigation';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { variantsApi } from '@/utils/api';
 
 import UninterpretedCasesTableFilters from './table/uninterpreted-cases-table-filters';
 import {
@@ -29,9 +30,9 @@ type UninterpretedCasesSearchInput = {
   listBodyWithCriteria: ListBodyWithCriteria;
 };
 
-async function fetchUninterpretedCases(input: UninterpretedCasesSearchInput) {
+async function fetchUninterpretedCases(input: UninterpretedCasesSearchInput, tenant: string) {
   const response = await variantsApi.getGermlineVariantUninterpretedCases(
-    DEFAULT_TENANT,
+    tenant,
     input.locusId,
     input.listBodyWithCriteria,
   );
@@ -40,6 +41,7 @@ async function fetchUninterpretedCases(input: UninterpretedCasesSearchInput) {
 
 function UninterpretedCasesTable() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const params = useParams<{ locusId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const [rowSelection, setRowSelection] = useState({});
@@ -68,7 +70,7 @@ function UninterpretedCasesTable() {
         sort: sorting,
       },
     },
-    fetchUninterpretedCases,
+    input => fetchUninterpretedCases(input, tenant),
     {
       revalidateOnFocus: false,
     },

--- a/frontend/apps/variant/src/entity/evidence/clinVar-card.tsx
+++ b/frontend/apps/variant/src/entity/evidence/clinVar-card.tsx
@@ -9,7 +9,8 @@ import { Button } from '@/components/base/shadcn/button';
 import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/base/shadcn/card';
 import { Input } from '@/components/base/shadcn/input';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { variantsApi } from '@/utils/api';
 
 import { getPathogenicEvidenceColumns, pathogenicEvidenceDefaultSettings } from './table-settings';
 
@@ -18,13 +19,14 @@ type ClinVarConditionsSearchInput = {
   locusId: string;
 };
 
-async function fetchClinVarConditions(input: ClinVarConditionsSearchInput) {
-  const response = await variantsApi.getGermlineVariantConditionsClinvar(DEFAULT_TENANT, input.locusId);
+async function fetchClinVarConditions(input: ClinVarConditionsSearchInput, tenant: string) {
+  const response = await variantsApi.getGermlineVariantConditionsClinvar(tenant, input.locusId);
   return response.data;
 }
 
 function ClinVarCard() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const params = useParams<{ locusId: string }>();
   const [search, setSearch] = useState('');
   const columns = useMemo(() => getPathogenicEvidenceColumns(t), [t]);
@@ -34,7 +36,7 @@ function ClinVarCard() {
       key: 'interpreted-cases',
       locusId: params.locusId!,
     },
-    fetchClinVarConditions,
+    input => fetchClinVarConditions(input, tenant),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,

--- a/frontend/apps/variant/src/entity/evidence/condition-phenotype-card.tsx
+++ b/frontend/apps/variant/src/entity/evidence/condition-phenotype-card.tsx
@@ -16,8 +16,9 @@ import { Input } from '@/components/base/shadcn/input';
 import { Skeleton } from '@/components/base/shadcn/skeleton';
 import { Tabs, TabsList, TabsTrigger } from '@/components/base/shadcn/tabs';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { thousandNumberFormat } from '@/components/lib/number-format';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { variantsApi } from '@/utils/api';
 
 import GeneAccordionItem from './gene-accordion-item';
 
@@ -27,13 +28,14 @@ type ConditionByPanelTypeInput = {
   panel_type: GetGermlineVariantConditionsPanelTypeEnum;
 };
 
-async function fetchConditionByPanelType(input: ConditionByPanelTypeInput) {
-  const response = await variantsApi.getGermlineVariantConditions(DEFAULT_TENANT, input.locus_id, input.panel_type);
+async function fetchConditionByPanelType(input: ConditionByPanelTypeInput, tenant: string) {
+  const response = await variantsApi.getGermlineVariantConditions(tenant, input.locus_id, input.panel_type);
   return response.data;
 }
 
 function ConditionPhenotypeCard() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const params = useParams<{ locusId: string }>();
   const [panelType, setPanelType] = useState<GetGermlineVariantConditionsPanelTypeEnum>(
     GetGermlineVariantConditionsPanelTypeEnum.Omim,
@@ -46,7 +48,7 @@ function ConditionPhenotypeCard() {
       locus_id: params.locusId!,
       panel_type: panelType,
     },
-    fetchConditionByPanelType,
+    input => fetchConditionByPanelType(input, tenant),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,

--- a/frontend/apps/variant/src/entity/evidence/condition-phenotype-card.tsx
+++ b/frontend/apps/variant/src/entity/evidence/condition-phenotype-card.tsx
@@ -9,7 +9,7 @@ import {
   GenePanelConditions,
   GetGermlineVariantConditionsPanelTypeEnum,
 } from '@/api/api';
-import Empty from '@/components/base/empty';
+import Empty from '@/components/base/empties/empty';
 import { Accordion } from '@/components/base/shadcn/accordion';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/base/shadcn/card';
 import { Input } from '@/components/base/shadcn/input';

--- a/frontend/apps/variant/src/entity/evidence/gene-accordion-item.tsx
+++ b/frontend/apps/variant/src/entity/evidence/gene-accordion-item.tsx
@@ -4,7 +4,7 @@ import { ArrowUpRight } from 'lucide-react';
 
 import { GenePanelCondition, GetGermlineVariantConditionsPanelTypeEnum } from '@/api/api';
 import DataTable from '@/components/base/data-table/data-table';
-import Empty from '@/components/base/empty';
+import Empty from '@/components/base/empties/empty';
 import { AccordionContent, AccordionItem, AccordionTrigger } from '@/components/base/shadcn/accordion';
 import { Button } from '@/components/base/shadcn/button';
 import { getOmimOrgUrl } from '@/components/base/variant/utils';

--- a/frontend/apps/variant/src/entity/frequency/my-network-card.tsx
+++ b/frontend/apps/variant/src/entity/frequency/my-network-card.tsx
@@ -14,8 +14,9 @@ import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle }
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/base/shadcn/tabs';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/shadcn/tooltip';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { toPercentage } from '@/components/lib/number-format';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { variantsApi } from '@/utils/api';
 
 import { getMyNetworkColumns, myNetworkDefaultSettings } from './table-settings';
 
@@ -24,13 +25,13 @@ type MyNetworkInput = {
   split: GetGermlineVariantInternalFrequenciesSplitEnum;
 };
 
-async function fetchFrequenciesBySplit(input: MyNetworkInput): Promise<VariantInternalFrequencies> {
-  const response = await variantsApi.getGermlineVariantInternalFrequencies(DEFAULT_TENANT, input.locusId, input.split);
+async function fetchFrequenciesBySplit(input: MyNetworkInput, tenant: string): Promise<VariantInternalFrequencies> {
+  const response = await variantsApi.getGermlineVariantInternalFrequencies(tenant, input.locusId, input.split);
   return response.data;
 }
 
-async function fetchGlobalFrequencies(locusId: string): Promise<InternalFrequencies> {
-  const response = await variantsApi.getGermlineVariantGlobalInternalFrequencies(DEFAULT_TENANT, locusId);
+async function fetchGlobalFrequencies(locusId: string, tenant: string): Promise<InternalFrequencies> {
+  const response = await variantsApi.getGermlineVariantGlobalInternalFrequencies(tenant, locusId);
   return response.data;
 }
 
@@ -54,6 +55,7 @@ const TABS_CONFIG = [
 
 function MyNetworkCard() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const params = useParams<{ locusId: string }>();
   const [activeTab, setActiveTab] = useState<string>(GetGermlineVariantInternalFrequenciesSplitEnum.PrimaryCondition);
   const columns = useMemo(() => getMyNetworkColumns(t, activeTab), [t, activeTab]);
@@ -62,14 +64,14 @@ function MyNetworkCard() {
     InternalFrequencies,
     ApiError,
     string
-  >(`global-frequencies-${params.locusId}`, () => fetchGlobalFrequencies(params.locusId!), {
+  >(`global-frequencies-${params.locusId}`, () => fetchGlobalFrequencies(params.locusId!, tenant), {
     revalidateOnFocus: false,
     shouldRetryOnError: false,
   });
 
   const { data } = useSWR<VariantInternalFrequencies, ApiError, MyNetworkInput>(
     { locusId: params.locusId!, split: activeTab as GetGermlineVariantInternalFrequenciesSplitEnum },
-    fetchFrequenciesBySplit,
+    input => fetchFrequenciesBySplit(input, tenant),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,

--- a/frontend/apps/variant/src/entity/frequency/public-cohorts-card.tsx
+++ b/frontend/apps/variant/src/entity/frequency/public-cohorts-card.tsx
@@ -6,22 +6,24 @@ import { ApiError, VariantExternalFrequencies } from '@/api/index';
 import DisplayTable from '@/components/base/data-table/display-table';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/base/shadcn/card';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { variantsApi } from '@/utils/api';
 
 import { getPublicCohortsColumns } from './table-settings';
 
-async function fetchPublicCohorts(locusId: string): Promise<VariantExternalFrequencies> {
-  const response = await variantsApi.getGermlineVariantExternalFrequencies(DEFAULT_TENANT, locusId);
+async function fetchPublicCohorts(locusId: string, tenant: string): Promise<VariantExternalFrequencies> {
+  const response = await variantsApi.getGermlineVariantExternalFrequencies(tenant, locusId);
   return response.data;
 }
 
 function PublicCohortsCard() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const params = useParams<{ locusId: string }>();
 
   const { data } = useSWR<VariantExternalFrequencies, ApiError, string>(
     `public-cohorts-${params.locusId}`,
-    () => fetchPublicCohorts(params.locusId!),
+    () => fetchPublicCohorts(params.locusId!, tenant),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,

--- a/frontend/apps/variant/src/entity/overview/associated-conditions-card.tsx
+++ b/frontend/apps/variant/src/entity/overview/associated-conditions-card.tsx
@@ -1,5 +1,5 @@
 import { VariantOverview } from '@/api/api';
-import Empty from '@/components/base/empty';
+import Empty from '@/components/base/empties/empty';
 import { Badge } from '@/components/base/shadcn/badge';
 import { Card, CardContent, CardHeader, CardProps } from '@/components/base/shadcn/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/shadcn/tooltip';

--- a/frontend/apps/variant/src/entity/overview/external-references-card.tsx
+++ b/frontend/apps/variant/src/entity/overview/external-references-card.tsx
@@ -1,5 +1,5 @@
 import { VariantOverview } from '@/api/api';
-import Empty from '@/components/base/empty';
+import Empty from '@/components/base/empties/empty';
 import AnchorLink from '@/components/base/navigation/anchor-link';
 import { Card, CardContent, CardHeader, CardProps } from '@/components/base/shadcn/card';
 import { getDbSnpUrl } from '@/components/base/variant/utils';

--- a/frontend/apps/variant/src/entity/overview/overview-tab.tsx
+++ b/frontend/apps/variant/src/entity/overview/overview-tab.tsx
@@ -5,8 +5,9 @@ import { VariantOverview } from '@/api/api';
 import { Card, CardContent, CardFooter } from '@/components/base/shadcn/card';
 import { Separator } from '@/components/base/shadcn/separator';
 import { Skeleton } from '@/components/base/shadcn/skeleton';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { tabContentClassName } from '@/style';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { variantsApi } from '@/utils/api';
 
 import AssociatedConditionsCard from './associated-conditions-card';
 import ClassificationCard from './classification-card';
@@ -20,12 +21,13 @@ type VariantOverviewInput = {
   locusId: string;
 };
 
-async function fetchVariantOverview(input: VariantOverviewInput) {
-  const response = await variantsApi.getGermlineVariantOverview(DEFAULT_TENANT, input.locusId);
+async function fetchVariantOverview(input: VariantOverviewInput, tenant: string) {
+  const response = await variantsApi.getGermlineVariantOverview(tenant, input.locusId);
   return response.data;
 }
 
 function OverviewTab() {
+  const { tenant } = useTenant();
   const params = useParams<{ locusId: string }>();
 
   const { data, isLoading } = useSWR<VariantOverview, any, VariantOverviewInput>(
@@ -33,7 +35,7 @@ function OverviewTab() {
       key: 'variant-overview',
       locusId: params.locusId!,
     },
-    fetchVariantOverview,
+    input => fetchVariantOverview(input, tenant),
     {
       revalidateOnFocus: false,
     },

--- a/frontend/apps/variant/src/entity/overview/prediction-scores-card.tsx
+++ b/frontend/apps/variant/src/entity/overview/prediction-scores-card.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { TFunction } from 'i18next';
 
 import { VariantOverview } from '@/api/api';
-import Empty from '@/components/base/empty';
+import Empty from '@/components/base/empties/empty';
 import { Badge } from '@/components/base/shadcn/badge';
 import { Button } from '@/components/base/shadcn/button';
 import { Card, CardContent, CardHeader, CardProps } from '@/components/base/shadcn/card';

--- a/frontend/apps/variant/src/entity/transcripts/transcripts-tab.tsx
+++ b/frontend/apps/variant/src/entity/transcripts/transcripts-tab.tsx
@@ -5,7 +5,8 @@ import { VariantConsequence } from '@/api/api';
 import { Accordion } from '@/components/base/shadcn/accordion';
 import { Card, CardContent, CardHeader } from '@/components/base/shadcn/card';
 import { Skeleton } from '@/components/base/shadcn/skeleton';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { variantsApi } from '@/utils/api';
 
 import ConsequenceAccordionItem from './consequence-accordion-item';
 
@@ -14,12 +15,13 @@ type VariantTranscriptsInput = {
   locusId: string;
 };
 
-async function fetchVariantConsequences(input: VariantTranscriptsInput) {
-  const response = await variantsApi.getGermlineVariantConsequences(DEFAULT_TENANT, input.locusId);
+async function fetchVariantConsequences(input: VariantTranscriptsInput, tenant: string) {
+  const response = await variantsApi.getGermlineVariantConsequences(tenant, input.locusId);
   return response.data;
 }
 
 function TranscriptsTab() {
+  const { tenant } = useTenant();
   const params = useParams<{ locusId: string }>();
 
   const { data, isLoading } = useSWR<VariantConsequence[], any, VariantTranscriptsInput>(
@@ -27,7 +29,7 @@ function TranscriptsTab() {
       key: 'variant-transcripts',
       locusId: params.locusId!,
     },
-    fetchVariantConsequences,
+    input => fetchVariantConsequences(input, tenant),
     {
       revalidateOnFocus: false,
     },

--- a/frontend/apps/variant/src/entity/variant-entity.tsx
+++ b/frontend/apps/variant/src/entity/variant-entity.tsx
@@ -11,7 +11,8 @@ import { BadgeProps } from '@/components/base/shadcn/badge';
 import { Button } from '@/components/base/shadcn/button';
 import { VariantEntityTabs } from '@/components/cores/types/variant-tabs';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, variantsApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { variantsApi } from '@/utils/api';
 
 import CasesTab from './cases/cases-tab';
 import EvidenceTab from './evidence/evidence-tab';
@@ -26,13 +27,14 @@ type VariantHeaderInput = {
   locusId: string;
 };
 
-async function fetchVariantHeader(input: VariantHeaderInput) {
-  const response = await variantsApi.getGermlineVariantHeader(DEFAULT_TENANT, input.locusId);
+async function fetchVariantHeader(input: VariantHeaderInput, tenant: string) {
+  const response = await variantsApi.getGermlineVariantHeader(tenant, input.locusId);
   return response.data;
 }
 
 export default function App() {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const params = useParams<{ locusId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState<VariantEntityTabs>(
@@ -44,7 +46,7 @@ export default function App() {
       key: 'variant-header',
       locusId: params.locusId!,
     },
-    fetchVariantHeader,
+    input => fetchVariantHeader(input, tenant),
     {
       revalidateOnFocus: false,
       shouldRetryOnError: false,

--- a/frontend/components/base/data-table/cells/download-file-cell.tsx
+++ b/frontend/components/base/data-table/cells/download-file-cell.tsx
@@ -13,8 +13,9 @@ import {
 } from '@/components/base/shadcn/alert-dialog';
 import { Button } from '@/components/base/shadcn/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/shadcn/tooltip';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { useI18n } from '@/hooks/i18n';
-import { DEFAULT_TENANT, documentApi } from '@/utils/api';
+import { documentApi } from '@/utils/api';
 
 interface DownloadFileCellProps {
   documentId: number;
@@ -22,13 +23,14 @@ interface DownloadFileCellProps {
 
 function DownloadFileCell({ documentId }: DownloadFileCellProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [isDownloading, setIsDownloading] = useState(false);
   const [showError, setShowError] = useState(false);
 
   const handleDownload = async () => {
     setIsDownloading(true);
     try {
-      const response = await documentApi.getDocumentDownloadUrl(DEFAULT_TENANT, documentId.toString());
+      const response = await documentApi.getDocumentDownloadUrl(tenant, documentId.toString());
       const { url } = response.data;
 
       if (url) {

--- a/frontend/components/base/data-table/data-table.tsx
+++ b/frontend/components/base/data-table/data-table.tsx
@@ -55,7 +55,7 @@ import {
 import { useI18n } from '@/components/hooks/i18n';
 import { cn } from '@/lib/utils';
 
-import Empty from '../empty';
+import Empty from '../empties/empty';
 
 import { useDataTable } from './hooks/use-data-table';
 import {

--- a/frontend/components/base/data-table/display-table.tsx
+++ b/frontend/components/base/data-table/display-table.tsx
@@ -5,7 +5,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useI18n } from '@/components/hooks/i18n';
 import { cn } from '@/components/lib/utils';
 
-import Empty from '../empty';
+import Empty from '../empties/empty';
 
 import { HEADER_HEIGHT, ROW_HEIGHT, TableColumnDef } from './data-table';
 

--- a/frontend/components/base/dropdowns/occurrence-flag-dropdown.tsx
+++ b/frontend/components/base/dropdowns/occurrence-flag-dropdown.tsx
@@ -12,8 +12,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/base/shadcn/dropdown-menu';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { cn } from '@/components/lib/utils';
-import { DEFAULT_TENANT, occurrenceFlagApi } from '@/utils/api';
+import { occurrenceFlagApi } from '@/utils/api';
 
 import { useDataTable } from '../data-table/hooks/use-data-table';
 
@@ -63,9 +64,9 @@ export const FLAGS = {
   },
 } as OccurrenceFlagConfig;
 
-async function saveOccurrenceFlag(_url: string, { arg }: { arg: UpsertOccurrenceFlagInput }) {
+async function saveOccurrenceFlag(_url: string, { arg }: { arg: UpsertOccurrenceFlagInput }, tenant: string) {
   const response = await occurrenceFlagApi.upsertOccurrenceFlag(
-    DEFAULT_TENANT,
+    tenant,
     arg.caseId,
     arg.seqId,
     arg.taskId,
@@ -75,9 +76,9 @@ async function saveOccurrenceFlag(_url: string, { arg }: { arg: UpsertOccurrence
   return response.data;
 }
 
-async function deleteOccurrenceFlag(_url: string, { arg }: { arg: DeleteOccurrenceFlagInput }) {
+async function deleteOccurrenceFlag(_url: string, { arg }: { arg: DeleteOccurrenceFlagInput }, tenant: string) {
   const response = await occurrenceFlagApi.deleteOccurrenceFlag(
-    DEFAULT_TENANT,
+    tenant,
     arg.caseId,
     arg.seqId,
     arg.taskId,
@@ -96,14 +97,15 @@ function OccurrenceFlagDropdown({
   ...props
 }: OccurrenceFlagDropdownProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const { list } = useDataTable();
   const saveFlag = useSWRMutation(
     `upsert-occurrence-flag-${caseId}-${taskId}-${seqId}-${occurrenceId}`,
-    saveOccurrenceFlag,
+    (key, opts: { arg: UpsertOccurrenceFlagInput }) => saveOccurrenceFlag(key, opts, tenant),
   );
   const deleteFlag = useSWRMutation(
     `delete-occurrence-flag-${caseId}-${taskId}-${seqId}-${occurrenceId}`,
-    deleteOccurrenceFlag,
+    (key, opts: { arg: DeleteOccurrenceFlagInput }) => deleteOccurrenceFlag(key, opts, tenant),
   );
   const [selectedFlag, setSelectedFlag] = useState<OccurrenceFlagType | null>(flag ?? null);
   const selectedFlagConfig = selectedFlag ? FLAGS[selectedFlag] : null;

--- a/frontend/components/base/empties/empty.tsx
+++ b/frontend/components/base/empties/empty.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ChartColumn, ChartLine, ChartPie, ChartScatter, LucideIcon } from 'lucide-react';
 import { tv, VariantProps } from 'tailwind-variants';
 
-import { cn } from '../lib/utils';
+import { cn } from '@/components/lib/utils';
 
 const emptyVariants = tv({
   slots: {
@@ -79,17 +79,15 @@ function Empty({
 
   return (
     <div className={styles.base({ className })} {...props}>
-      {showIcon ? (
-        iconType === 'chartRow' ? (
-          <EmptyIconsRow className={styles.iconsContainer()} />
-        ) : iconType === 'chartGrid' ? (
-          <EmptyIconsGrid className={styles.iconsContainer()} />
-        ) : iconType === 'custom' ? (
-          <div className="flex justify-center">
-            <div className={styles.customIcon()}>{<Icon />}</div>
+      {showIcon && iconType === 'chartRow' && <EmptyIconsRow className={styles.iconsContainer()} />}
+      {showIcon && iconType === 'chartGrid' && <EmptyIconsGrid className={styles.iconsContainer()} />}
+      {showIcon && iconType === 'custom' && Icon && (
+        <div className="flex justify-center">
+          <div className={styles.customIcon()}>
+            <Icon />
           </div>
-        ) : null
-      ) : null}
+        </div>
+      )}
       <div className={styles.textContainer()}>
         {title && <h1 className={styles.title()}>{title}</h1>}
         {description && <div className={styles.description()}>{description}</div>}

--- a/frontend/components/base/empties/empty_tenant.tsx
+++ b/frontend/components/base/empties/empty_tenant.tsx
@@ -1,0 +1,20 @@
+import { useI18n } from '@/components/hooks/i18n';
+
+/** Full-screen message shown by TenantProvider when the user belongs to no tenant. */
+function EmptyTenant() {
+  const { t } = useI18n();
+  return (
+    <div className="flex h-screen w-screen flex-col items-center justify-center gap-2 px-6 text-center">
+      <h1 className="text-lg font-semibold">
+        {t('main_navbar.tenant_switcher.empty_title', { defaultValue: 'No tenant available' })}
+      </h1>
+      <p className="text-muted-foreground">
+        {t('main_navbar.tenant_switcher.empty_description', {
+          defaultValue: 'You do not have access to any tenant. Please contact your administrator.',
+        })}
+      </p>
+    </div>
+  );
+}
+
+export default EmptyTenant;

--- a/frontend/components/base/igv/igv-dialog.tsx
+++ b/frontend/components/base/igv/igv-dialog.tsx
@@ -5,7 +5,8 @@ import { IGVTracks } from '@/api/api';
 import { Dialog, DialogBody, DialogContent, DialogHeader, DialogTitle } from '@/components/base/shadcn/dialog';
 import { Spinner } from '@/components/base/spinner';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, igvApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { igvApi } from '@/utils/api';
 
 import IgvContainer from './igv-container';
 
@@ -20,17 +21,18 @@ type IGVDialogProps = {
   renderTrigger?: (handleOpen: () => void) => ReactNode;
 };
 
-const fetchIGVForCaseId = async ({ caseId }: { caseId: number }) =>
-  igvApi.getIGV(DEFAULT_TENANT, caseId.toString()).then(response => response.data);
+const fetchIGVForCaseId = async ({ caseId }: { caseId: number }, tenant: string) =>
+  igvApi.getIGV(tenant, caseId.toString()).then(response => response.data);
 
 const IGVDialog = ({ caseId, seqId, locus, start, chromosome, open, setOpen, renderTrigger }: IGVDialogProps) => {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const fetchIGV = useSWR<IGVTracks>(
     {
       key: `igv-${caseId}-${seqId}-${locus}`,
       caseId: caseId,
     },
-    fetchIGVForCaseId,
+    ({ caseId }: { caseId: number }) => fetchIGVForCaseId({ caseId }, tenant),
     {
       revalidateOnFocus: false,
       revalidateOnMount: false,

--- a/frontend/components/base/navbar/main-navbar-tenant-switcher.tsx
+++ b/frontend/components/base/navbar/main-navbar-tenant-switcher.tsx
@@ -1,0 +1,70 @@
+import { Check, ChevronsUpDown } from 'lucide-react';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/base/shadcn/dropdown-menu';
+import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { cn } from '@/components/lib/utils';
+
+interface MainNavbarTenantSwitcherProps {
+  /** When true, render nothing for single-tenant users (mobile omits the label). */
+  hideSingleTenantLabel?: boolean;
+}
+
+function MainNavbarTenantSwitcher({ hideSingleTenantLabel = false }: MainNavbarTenantSwitcherProps) {
+  const { t } = useI18n();
+  const { tenant, tenants, setTenant } = useTenant();
+
+  // Single-tenant user: non-interactive label (no dropdown) — omitted entirely on mobile.
+  if (tenants.length <= 1) {
+    if (hideSingleTenantLabel) {
+      return null;
+    }
+    return (
+      <span data-cy="tenant-label" className="text-sm font-semibold text-primary">
+        {tenant}
+      </span>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        data-cy="tenant-switcher"
+        className="flex items-center gap-1 text-sm font-semibold text-primary outline-none"
+      >
+        {tenant}
+        <ChevronsUpDown className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuLabel>
+          {t('main_navbar.tenant_switcher.title', { defaultValue: 'Switch Tenant' })}
+        </DropdownMenuLabel>
+        {tenants.map(membership => (
+          <DropdownMenuItem
+            key={membership.code}
+            className="flex items-center justify-between gap-3"
+            onClick={() => {
+              if (membership.code && membership.code !== tenant) {
+                setTenant(membership.code);
+              }
+            }}
+          >
+            <div className="flex flex-col">
+              <span className="text-sm font-normal text-foreground">{membership.code}</span>
+              <span className="text-xs font-normal text-muted-foreground">{membership.name}</span>
+            </div>
+            <Check className={cn('size-4', membership.code === tenant ? 'opacity-100' : 'opacity-0')} />
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default MainNavbarTenantSwitcher;

--- a/frontend/components/base/navbar/main-navbar.tsx
+++ b/frontend/components/base/navbar/main-navbar.tsx
@@ -11,6 +11,7 @@ import { ThemeToggle } from '../theme-toggle/theme-toggle';
 
 import MainNavbarItem from './main-navbar-item';
 import MainNavbarLangSwitcher from './main-navbar-lang-switcher';
+import MainNavbarTenantSwitcher from './main-navbar-tenant-switcher';
 import { BaseMainNavbarProps } from './main-navbar-types';
 import MainNavbarUserAvatar from './main-navbar-user-avatar';
 import MainSidebar from './main-sidebar';
@@ -92,7 +93,7 @@ function MainNavbar({ placement, logo, links, actions, userDetails, onLogoutClic
           <div className={navbarStyles.base()}>
             <div
               data-cy="logo-desktop"
-              className="flex mr-6 h-7 text-primary [&_svg]:h-full [&_img]:h-full"
+              className="flex mr-2 h-7 text-primary [&_svg]:h-full [&_img]:h-full"
               onClick={e => {
                 if (e.metaKey && e.altKey) {
                   setBetaSuperMode(!betaSuperMode);
@@ -101,7 +102,8 @@ function MainNavbar({ placement, logo, links, actions, userDetails, onLogoutClic
             >
               {logo}
             </div>
-            <div className="flex flex-1 gap-1 items-center">
+            <MainNavbarTenantSwitcher />
+            <div className="flex flex-1 gap-1 items-center ml-2">
               {links.map(link => (
                 <MainNavbarItem key={link.title} {...link} />
               ))}
@@ -144,8 +146,11 @@ function MobileNavbar({
         as="button"
         responsive={false}
       />
-      <div data-cy="logo-mobile" className="flex flex-1 h-8 justify-center text-primary">
-        {logo}
+      <div className="flex flex-1 items-center justify-center gap-1.5">
+        <div data-cy="logo-mobile" className="flex h-8 text-primary">
+          {logo}
+        </div>
+        <MainNavbarTenantSwitcher hideSingleTenantLabel />
       </div>
       <MainNavbarLangSwitcher />
     </div>

--- a/frontend/components/base/notes/note.tsx
+++ b/frontend/components/base/notes/note.tsx
@@ -18,8 +18,9 @@ import {
 } from '@/components/base/shadcn/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/shadcn/tooltip';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { formatRelativeByCurrentTime } from '@/components/lib/date';
-import { DEFAULT_TENANT, occurencesNotesApi } from '@/utils/api';
+import { occurencesNotesApi } from '@/utils/api';
 
 import { useNotesContext } from './hooks/use-notes';
 import NoteSkeleton from './note-skeleton';
@@ -33,24 +34,29 @@ type PutOccurrenceNoteInput = UpdateOccurrenceNoteInput & {
   id: string;
 };
 
-async function updateNote(_url: string, { arg }: { arg: PutOccurrenceNoteInput }) {
-  const response = await occurencesNotesApi.putOccurrenceNote(DEFAULT_TENANT, arg.id, { content: arg.content });
+async function updateNote(_url: string, { arg }: { arg: PutOccurrenceNoteInput }, tenant: string) {
+  const response = await occurencesNotesApi.putOccurrenceNote(tenant, arg.id, { content: arg.content });
   return response.data;
 }
 
-async function deleteNote(_url: string, { arg }: { arg: string }) {
-  const response = await occurencesNotesApi.deleteOccurrenceNote(DEFAULT_TENANT, arg);
+async function deleteNote(_url: string, { arg }: { arg: string }, tenant: string) {
+  const response = await occurencesNotesApi.deleteOccurrenceNote(tenant, arg);
   return response.data;
 }
 
 function Note({ id, user_id, user_name, created_at, updated_at, content, isOwner, onChanged }: NoteProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const { onChangeCallback } = useNotesContext();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [editedContent, setEditedContent] = useState<string>(content);
   const [isEditing, setIsEditing] = useState<boolean>(false);
-  const { trigger: triggerDelete } = useSWRMutation(`note/delete/${id}`, deleteNote);
-  const { trigger: triggerUpdate } = useSWRMutation(`note/update/${id}`, updateNote);
+  const { trigger: triggerDelete } = useSWRMutation(`note/delete/${id}`, (key, opts: { arg: string }) =>
+    deleteNote(key, opts, tenant),
+  );
+  const { trigger: triggerUpdate } = useSWRMutation(`note/update/${id}`, (key, opts: { arg: PutOccurrenceNoteInput }) =>
+    updateNote(key, opts, tenant),
+  );
 
   const changedCallback = useCallback(async () => {
     onChanged().then(() => {

--- a/frontend/components/base/notes/notes-container.tsx
+++ b/frontend/components/base/notes/notes-container.tsx
@@ -11,8 +11,9 @@ import { Button } from '@/components/base/shadcn/button';
 import { TooltipProvider } from '@/components/base/shadcn/tooltip';
 import { useI18n } from '@/components/hooks/i18n';
 import { useLoginContext } from '@/components/hooks/use-login';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { cn } from '@/lib/utils';
-import { DEFAULT_TENANT, occurencesNotesApi } from '@/utils/api';
+import { occurencesNotesApi } from '@/utils/api';
 
 import { useNotesContext } from './hooks/use-notes';
 import Note from './note';
@@ -37,9 +38,9 @@ export type NotesContainerProps = NoteContainerBaseProps & {
 
 export type GetOccurrenceNoteInput = Omit<NotesContainerProps, 'enableEmptyIcon'>;
 
-async function fetchNotes(input: GetOccurrenceNoteInput) {
+async function fetchNotes(input: GetOccurrenceNoteInput, tenant: string) {
   const response = await occurencesNotesApi.getOccurrenceNotes(
-    DEFAULT_TENANT,
+    tenant,
     input.caseId,
     input.seqId,
     input.taskId,
@@ -48,8 +49,8 @@ async function fetchNotes(input: GetOccurrenceNoteInput) {
   return response.data;
 }
 
-async function saveNote(_url: string, { arg }: { arg: CreateOccurrenceNoteInput }) {
-  const response = await occurencesNotesApi.postOccurrenceNote(DEFAULT_TENANT, arg);
+async function saveNote(_url: string, { arg }: { arg: CreateOccurrenceNoteInput }, tenant: string) {
+  const response = await occurencesNotesApi.postOccurrenceNote(tenant, arg);
   return response.data;
 }
 
@@ -65,11 +66,14 @@ function NotesContainer({
   ...props
 }: NotesContainerProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const { sub } = useLoginContext();
   const { onChangeCallback } = useNotesContext();
   const [content, setContent] = useState<string>('');
   const [clearContent, setClearContent] = useState<boolean>(false);
-  const save = useSWRMutation('notes/save', saveNote);
+  const save = useSWRMutation('notes/save', (key, opts: { arg: CreateOccurrenceNoteInput }) =>
+    saveNote(key, opts, tenant),
+  );
   const fetcher = useSWR<OccurrenceNote[], ApiError, GetOccurrenceNoteInput>(
     {
       caseId: props.caseId,
@@ -77,7 +81,7 @@ function NotesContainer({
       taskId: props.taskId,
       occurrenceId: props.occurrenceId,
     },
-    fetchNotes,
+    input => fetchNotes(input, tenant),
     {
       revalidateOnMount: true,
       revalidateOnFocus: true,

--- a/frontend/components/base/notes/notes-slider-sheet.tsx
+++ b/frontend/components/base/notes/notes-slider-sheet.tsx
@@ -4,7 +4,8 @@ import useSWR from 'swr';
 
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/base/shadcn/sheet';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, occurencesNotesApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { occurencesNotesApi } from '@/utils/api';
 
 import { Button } from '../shadcn/button';
 import { Spinner } from '../shadcn/spinner';
@@ -13,9 +14,9 @@ import NotesContainer, { NotesContainerProps } from './notes-container';
 
 type NotesSliderProps = NotesContainerProps;
 
-async function fetchNotesCount(input: NotesContainerProps) {
+async function fetchNotesCount(input: NotesContainerProps, tenant: string) {
   const response = await occurencesNotesApi.countOccurrenceNotes(
-    DEFAULT_TENANT,
+    tenant,
     input.caseId,
     input.seqId,
     input.taskId,
@@ -26,17 +27,21 @@ async function fetchNotesCount(input: NotesContainerProps) {
 
 function NotesSliderSheet({ ...props }: NotesSliderProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const { data, mutate, isLoading } = useSWR(
     `fetch-note-count-${props.caseId}-${props.seqId}-${props.taskId}-${props.occurrenceId}`,
     () =>
-      fetchNotesCount({
-        seqId: props.seqId,
-        caseId: props.caseId,
-        taskId: props.taskId,
-        occurrenceId: props.occurrenceId,
-      }),
+      fetchNotesCount(
+        {
+          seqId: props.seqId,
+          caseId: props.caseId,
+          taskId: props.taskId,
+          occurrenceId: props.occurrenceId,
+        },
+        tenant,
+      ),
     {
       revalidateOnFocus: true,
     },

--- a/frontend/components/base/pubmed/pubmed-list-dialog.tsx
+++ b/frontend/components/base/pubmed/pubmed-list-dialog.tsx
@@ -12,17 +12,18 @@ import {
   DialogTitle,
 } from '@/components/base/shadcn/dialog';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, sequencingApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { sequencingApi } from '@/utils/api';
 
 type SequencingInput = {
   seqId: string;
 };
 
 export function useSequencingHelper(input: SequencingInput) {
+  const { tenant } = useTenant();
   const fetchSequencingHelper = useCallback(
-    async () =>
-      sequencingApi.getSequencingExperimentDetailById(DEFAULT_TENANT, input.seqId).then(response => response.data),
-    [input],
+    async () => sequencingApi.getSequencingExperimentDetailById(tenant, input.seqId).then(response => response.data),
+    [input, tenant],
   );
 
   return fetchSequencingHelper;

--- a/frontend/components/base/query-builder/facets/search-facet.tsx
+++ b/frontend/components/base/query-builder/facets/search-facet.tsx
@@ -9,7 +9,8 @@ import { Label } from '@/components/base/shadcn/label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/base/shadcn/tooltip';
 import { type Aggregation as AggregationConfig } from '@/components/cores/applications-config';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, genesApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { genesApi } from '@/utils/api';
 
 import {
   QBActionType,
@@ -27,6 +28,7 @@ const MAX_API_CALLS = 2;
 
 export function SearchFacet({ search }: SearchFilterProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const dispatch = useQBDispatch();
   const activeQuery = useQBActiveQuery();
   const history = useQBHistory();
@@ -82,7 +84,7 @@ export function SearchFacet({ search }: SearchFilterProps) {
         // Fetch details for each selected gene
         const optionsPromises = selectedValues.map(async value => {
           try {
-            const response = await genesApi.geneAutoComplete(DEFAULT_TENANT, value);
+            const response = await genesApi.geneAutoComplete(tenant, value);
             const geneData = response.data.find(item => item.source?.name === value);
 
             if (geneData) {
@@ -130,7 +132,7 @@ export function SearchFacet({ search }: SearchFilterProps) {
     if (!searchTerm) return [];
 
     try {
-      const response = await genesApi.geneAutoComplete(DEFAULT_TENANT, searchTerm);
+      const response = await genesApi.geneAutoComplete(tenant, searchTerm);
       return response.data.map(item => ({
         value: item.source?.name || '',
         label: (

--- a/frontend/components/base/query-builder/facets/upload-id-facet.tsx
+++ b/frontend/components/base/query-builder/facets/upload-id-facet.tsx
@@ -19,9 +19,10 @@ import { Label } from '@/components/base/shadcn/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/base/shadcn/tabs';
 import { Textarea } from '@/components/base/shadcn/textarea';
 import { useI18n } from '@/components/hooks/i18n';
+import { useTenant } from '@/components/hooks/use-tenant';
 import { useDebounce } from '@/components/hooks/useDebounce';
 import { thousandNumberFormat } from '@/components/lib/number-format';
-import { DEFAULT_TENANT, genesApi } from '@/utils/api';
+import { genesApi } from '@/utils/api';
 
 import CollapsibleCard from '../../cards/collapsible-card';
 import { TableColumnDef } from '../../data-table/data-table';
@@ -96,6 +97,7 @@ async function readFile(file: File): Promise<string> {
 
 function UploadIdModal({ variant }: UploadIdModalProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const dispatch = useQBDispatch();
   const [value, setValue] = useState('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -161,7 +163,7 @@ function UploadIdModal({ variant }: UploadIdModalProps) {
     if (debouncedValue) {
       (async () => {
         setIsLoading(true);
-        const results = await genesApi.geneSearch(DEFAULT_TENANT, {
+        const results = await genesApi.geneSearch(tenant, {
           inputs: debouncedValue.split(/[\n,\r ]/).filter(val => !!val),
         });
         setMatched(getMatchList(results.data));

--- a/frontend/components/base/query-builder/hooks/use-aggregation-builder.tsx
+++ b/frontend/components/base/query-builder/hooks/use-aggregation-builder.tsx
@@ -3,7 +3,8 @@ import useSWR from 'swr';
 import { type Aggregation, AggregationBodyWithSqon, Statistics, StatisticsBodyWithSqon } from '@/api/api';
 import { useQBActiveSqon } from '@/components/base/query-builder/hooks/use-query-builder';
 import { ApplicationId } from '@/components/cores/applications-config';
-import { DEFAULT_TENANT, occurrencesApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { occurrencesApi } from '@/utils/api';
 import { useCaseIdFromParam, useSeqIdFromSearchParam, useTaskIdFromSearchParam } from '@/utils/helper';
 
 export interface IAggregationBuilder {
@@ -72,6 +73,7 @@ export function useGermlineSNVAggregationBuilder({
   size = 30,
   withDictionary = false,
 }: SNVAggregationBuilderProps) {
+  const { tenant } = useTenant();
   const activeSqon = useQBActiveSqon();
   const caseId = useCaseIdFromParam();
   const seqId = useSeqIdFromSearchParam();
@@ -96,14 +98,7 @@ export function useGermlineSNVAggregationBuilder({
     data,
     async () =>
       occurrencesApi
-        .aggregateGermlineSNVOccurrences(
-          DEFAULT_TENANT,
-          caseId,
-          seqId,
-          taskId!,
-          data!.aggregationBody,
-          data!.withDictionary,
-        )
+        .aggregateGermlineSNVOccurrences(tenant, caseId, seqId, taskId!, data!.aggregationBody, data!.withDictionary)
         .then(response => response.data),
     {
       revalidateOnFocus: false,
@@ -112,6 +107,7 @@ export function useGermlineSNVAggregationBuilder({
 }
 
 export function useGermlineSNVAggregationStatistics({ field }: CNVAggregationBuilderProps) {
+  const { tenant } = useTenant();
   const activeSqon = useQBActiveSqon();
   const caseId = useCaseIdFromParam();
   const seqId = useSeqIdFromSearchParam();
@@ -134,7 +130,7 @@ export function useGermlineSNVAggregationStatistics({ field }: CNVAggregationBui
     data,
     async () =>
       occurrencesApi
-        .statisticsGermlineSNVOccurrences(DEFAULT_TENANT, caseId, seqId, taskId!, data!.statisticsBody)
+        .statisticsGermlineSNVOccurrences(tenant, caseId, seqId, taskId!, data!.statisticsBody)
         .then(response => response.data),
     {
       revalidateOnFocus: false,
@@ -147,6 +143,7 @@ export function useGermlineSNVAggregationStatistics({ field }: CNVAggregationBui
  */
 type CNVAggregationBuilderProps = IAggregationBuilder;
 export function useGermlineCNVAggregationBuilder({ field, size = 30 }: CNVAggregationBuilderProps) {
+  const { tenant } = useTenant();
   const activeSqon = useQBActiveSqon();
   const caseId = useCaseIdFromParam();
   const seqId = useSeqIdFromSearchParam();
@@ -170,7 +167,7 @@ export function useGermlineCNVAggregationBuilder({ field, size = 30 }: CNVAggreg
     data,
     async () =>
       occurrencesApi
-        .aggregateGermlineCNVOccurrences(DEFAULT_TENANT, caseId, seqId, taskId!, data!.aggregationBody)
+        .aggregateGermlineCNVOccurrences(tenant, caseId, seqId, taskId!, data!.aggregationBody)
         .then(response => response.data),
     {
       revalidateOnFocus: false,
@@ -179,6 +176,7 @@ export function useGermlineCNVAggregationBuilder({ field, size = 30 }: CNVAggreg
 }
 
 export function useGermlineCNVAggregationStatistics({ field }: CNVAggregationBuilderProps) {
+  const { tenant } = useTenant();
   const activeSqon = useQBActiveSqon();
   const caseId = useCaseIdFromParam();
   const seqId = useSeqIdFromSearchParam();
@@ -201,7 +199,7 @@ export function useGermlineCNVAggregationStatistics({ field }: CNVAggregationBui
     data,
     async () =>
       occurrencesApi
-        .statisticsGermlineCNVOccurrences(DEFAULT_TENANT, caseId, seqId, taskId!, data!.statisticsBody)
+        .statisticsGermlineCNVOccurrences(tenant, caseId, seqId, taskId!, data!.statisticsBody)
         .then(response => response.data),
     {
       revalidateOnFocus: false,
@@ -217,6 +215,7 @@ export function useSomaticSNVAggregationBuilder({
   size = 30,
   withDictionary = false,
 }: SNVAggregationBuilderProps) {
+  const { tenant } = useTenant();
   const activeSqon = useQBActiveSqon();
   const caseId = useCaseIdFromParam();
   const seqId = useSeqIdFromSearchParam();
@@ -241,14 +240,7 @@ export function useSomaticSNVAggregationBuilder({
     data,
     async () =>
       occurrencesApi
-        .aggregateSomaticSNVOccurrences(
-          DEFAULT_TENANT,
-          caseId,
-          seqId,
-          taskId!,
-          data!.aggregationBody,
-          data!.withDictionary,
-        )
+        .aggregateSomaticSNVOccurrences(tenant, caseId, seqId, taskId!, data!.aggregationBody, data!.withDictionary)
         .then(response => response.data),
     {
       revalidateOnFocus: false,
@@ -257,6 +249,7 @@ export function useSomaticSNVAggregationBuilder({
 }
 
 export function useSomaticSNVAggregationStatistics({ field }: CNVAggregationBuilderProps) {
+  const { tenant } = useTenant();
   const activeSqon = useQBActiveSqon();
   const caseId = useCaseIdFromParam();
   const seqId = useSeqIdFromSearchParam();
@@ -279,7 +272,7 @@ export function useSomaticSNVAggregationStatistics({ field }: CNVAggregationBuil
     data,
     async () =>
       occurrencesApi
-        .statisticsSomaticSNVOccurrences(DEFAULT_TENANT, caseId, seqId, taskId!, data!.statisticsBody)
+        .statisticsSomaticSNVOccurrences(tenant, caseId, seqId, taskId!, data!.statisticsBody)
         .then(response => response.data),
     {
       revalidateOnFocus: false,

--- a/frontend/components/base/sequencing/sequencing-information-dialog.tsx
+++ b/frontend/components/base/sequencing/sequencing-information-dialog.tsx
@@ -18,7 +18,8 @@ import {
 } from '@/components/base/shadcn/dialog';
 import { Separator } from '@/components/base/shadcn/separator';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, sequencingApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { sequencingApi } from '@/utils/api';
 
 import EmptyField from '../information/empty-field';
 
@@ -27,10 +28,10 @@ type SequencingInput = {
 };
 
 export function useSequencingHelper(input: SequencingInput) {
+  const { tenant } = useTenant();
   const fetchSequencingHelper = useCallback(
-    async () =>
-      sequencingApi.getSequencingExperimentDetailById(DEFAULT_TENANT, input.seqId).then(response => response.data),
-    [input],
+    async () => sequencingApi.getSequencingExperimentDetailById(tenant, input.seqId).then(response => response.data),
+    [input, tenant],
   );
 
   return fetchSequencingHelper;

--- a/frontend/components/base/slider/germline-slider-interpretation-details-card.tsx
+++ b/frontend/components/base/slider/germline-slider-interpretation-details-card.tsx
@@ -22,7 +22,8 @@ import SliderCard from '@/components/base/slider/slider-card';
 import TranscriptIdLink from '@/components/base/variant/transcript-id-link';
 import { getOmimOrgUrl } from '@/components/base/variant/utils';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, interpretationApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { interpretationApi } from '@/utils/api';
 
 type GermlineSliderInterpretationDetailsCardProps = {
   seqId: number;
@@ -43,9 +44,9 @@ type InterpretationInput = {
   transcriptId: string;
 };
 
-export async function fetchInterpretation(input: InterpretationInput) {
+export async function fetchInterpretation(input: InterpretationInput, tenant: string) {
   const response = await interpretationApi.getInterpretationGermline(
-    DEFAULT_TENANT,
+    tenant,
     input.caseId,
     input.seqId,
     input.locusId,
@@ -66,6 +67,7 @@ function GermlineSliderInterpretationDetailsCard({
   transcriptId,
 }: GermlineSliderInterpretationDetailsCardProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [isPubmedOpen, setIsPubmedOpen] = useState<boolean>(false);
 
   const interpretation = useSWR<InterpretationGermline>(
@@ -75,7 +77,7 @@ function GermlineSliderInterpretationDetailsCard({
       locusId: locusId,
       transcriptId: transcriptId,
     },
-    fetchInterpretation,
+    input => fetchInterpretation(input, tenant),
     {
       revalidateOnFocus: false,
       revalidateOnMount: false,

--- a/frontend/components/base/slider/hooks/use-slider-occurrence-and-case.ts
+++ b/frontend/components/base/slider/hooks/use-slider-occurrence-and-case.ts
@@ -8,7 +8,8 @@ import {
   ExpandedSomaticSNVOccurrence,
 } from '@/api/api';
 import { PROBAND } from '@/components/base/constants';
-import { caseApi, DEFAULT_TENANT, occurrencesApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { caseApi, occurrencesApi } from '@/utils/api';
 
 export type OccurrenceExpandInput = {
   caseId: number;
@@ -22,9 +23,9 @@ export type CaseInput = {
   caseId: number;
 };
 
-export async function fetchGermlineOccurrenceExpand(input: OccurrenceExpandInput) {
+export async function fetchGermlineOccurrenceExpand(input: OccurrenceExpandInput, tenant: string) {
   const response = await occurrencesApi.getExpandedGermlineSNVOccurrence(
-    DEFAULT_TENANT,
+    tenant,
     input.caseId,
     input.seqId,
     input.taskId,
@@ -33,9 +34,9 @@ export async function fetchGermlineOccurrenceExpand(input: OccurrenceExpandInput
   return response.data;
 }
 
-export async function fetchSomaticOccurrenceExpand(input: OccurrenceExpandInput) {
+export async function fetchSomaticOccurrenceExpand(input: OccurrenceExpandInput, tenant: string) {
   const response = await occurrencesApi.getExpandedSomaticSNVOccurrence(
-    DEFAULT_TENANT,
+    tenant,
     input.caseId,
     input.seqId,
     input.taskId,
@@ -44,12 +45,12 @@ export async function fetchSomaticOccurrenceExpand(input: OccurrenceExpandInput)
   return response.data;
 }
 
-export async function fetchCase(input: CaseInput) {
+export async function fetchCase(input: CaseInput, tenant: string) {
   if (!input.caseId) {
     return null;
   }
 
-  const response = await caseApi.caseEntity(DEFAULT_TENANT, input.caseId);
+  const response = await caseApi.caseEntity(tenant, input.caseId);
   return response.data;
 }
 
@@ -63,6 +64,7 @@ export function useGermlineOccurrenceAndCase(
   locusId: string,
   patientSelected?: CaseSequencingExperiment,
 ) {
+  const { tenant } = useTenant();
   const expandResult = useSWR<ExpandedGermlineSNVOccurrence, any, OccurrenceExpandInput>(
     {
       caseId: caseId,
@@ -70,7 +72,7 @@ export function useGermlineOccurrenceAndCase(
       seqId: seqId,
       taskId: taskId,
     },
-    fetchGermlineOccurrenceExpand,
+    input => fetchGermlineOccurrenceExpand(input, tenant),
     {
       shouldRetryOnError: false,
       revalidateOnFocus: false,
@@ -82,7 +84,7 @@ export function useGermlineOccurrenceAndCase(
       key: 'case-entity',
       caseId: caseId,
     },
-    fetchCase,
+    input => fetchCase(input, tenant),
     {
       shouldRetryOnError: false,
       revalidateOnFocus: false,
@@ -120,6 +122,7 @@ export function useSomaticOccurrenceAndCase(
   locusId: string,
   patientSelected?: CaseSequencingExperiment,
 ) {
+  const { tenant } = useTenant();
   const expandResult = useSWR<ExpandedSomaticSNVOccurrence, any, OccurrenceExpandInput>(
     {
       caseId: caseId,
@@ -127,7 +130,7 @@ export function useSomaticOccurrenceAndCase(
       seqId: seqId,
       taskId: taskId,
     },
-    fetchSomaticOccurrenceExpand,
+    input => fetchSomaticOccurrenceExpand(input, tenant),
     {
       shouldRetryOnError: false,
       revalidateOnFocus: false,
@@ -139,7 +142,7 @@ export function useSomaticOccurrenceAndCase(
       key: 'case-entity',
       caseId: caseId,
     },
-    fetchCase,
+    input => fetchCase(input, tenant),
     {
       shouldRetryOnError: false,
       revalidateOnFocus: false,
@@ -171,6 +174,7 @@ export function useSomaticOccurrenceAndCase(
  * Hook to fetch case data for preview sheets
  */
 export function useCase(caseId: number, seqId: number, taskId: number, locusId: string) {
+  const { tenant } = useTenant();
   const expandResult = useSWR<ExpandedGermlineSNVOccurrence, any, OccurrenceExpandInput>(
     {
       caseId: caseId,
@@ -178,7 +182,7 @@ export function useCase(caseId: number, seqId: number, taskId: number, locusId: 
       seqId: seqId,
       taskId: taskId,
     },
-    fetchGermlineOccurrenceExpand,
+    input => fetchGermlineOccurrenceExpand(input, tenant),
     {
       shouldRetryOnError: false,
       revalidateOnFocus: false,
@@ -190,7 +194,7 @@ export function useCase(caseId: number, seqId: number, taskId: number, locusId: 
       key: 'case-entity',
       caseId: caseId,
     },
-    fetchCase,
+    input => fetchCase(input, tenant),
     {
       shouldRetryOnError: false,
       revalidateOnFocus: false,

--- a/frontend/components/base/slider/somatic-slider-interpretation-details-card.tsx
+++ b/frontend/components/base/slider/somatic-slider-interpretation-details-card.tsx
@@ -17,7 +17,8 @@ import SliderCard from '@/components/base/slider/slider-card';
 import TranscriptIdLink from '@/components/base/variant/transcript-id-link';
 import { getOmimOrgUrl } from '@/components/base/variant/utils';
 import { useI18n } from '@/components/hooks/i18n';
-import { DEFAULT_TENANT, interpretationApi } from '@/utils/api';
+import { useTenant } from '@/components/hooks/use-tenant';
+import { interpretationApi } from '@/utils/api';
 
 import ClassificationBadge from '../badges/classification-badge';
 import { getOncogenicityClassificationCriteriaColor } from '../classifications/oncogenicity';
@@ -42,9 +43,9 @@ type InterpretationInput = {
   transcriptId: string;
 };
 
-export async function fetchInterpretation(input: InterpretationInput) {
+export async function fetchInterpretation(input: InterpretationInput, tenant: string) {
   const response = await interpretationApi.getInterpretationSomatic(
-    DEFAULT_TENANT,
+    tenant,
     input.caseId,
     input.seqId,
     input.locusId,
@@ -65,6 +66,7 @@ function SomaticSliderInterpretationDetailsCard({
   transcriptId,
 }: SliderInterpretationDetailsCardProps) {
   const { t } = useI18n();
+  const { tenant } = useTenant();
   const [isPubmedOpen, setIsPubmedOpen] = useState<boolean>(false);
 
   const interpretation = useSWR<InterpretationSomatic>(
@@ -74,7 +76,7 @@ function SomaticSliderInterpretationDetailsCard({
       locusId: locusId,
       transcriptId: transcriptId,
     },
-    fetchInterpretation,
+    input => fetchInterpretation(input, tenant),
     {
       revalidateOnFocus: false,
       revalidateOnMount: false,

--- a/frontend/components/hooks/use-occurrence-tasks.ts
+++ b/frontend/components/hooks/use-occurrence-tasks.ts
@@ -1,17 +1,20 @@
 import useSWR from 'swr';
 
-import { CaseTasksWithOccurrencesDataTypeEnum, TaskOccurrenceType } from '../../api/api';
-import { caseApi, DEFAULT_TENANT } from '../../utils/api';
+import { type CaseTasksWithOccurrencesDataTypeEnum, type TaskOccurrenceType } from '../../api/api';
+import { caseApi } from '../../utils/api';
+
+import { useTenant } from './use-tenant';
 
 /**
  * Fetch every task attached to the given (case, sequencing) pair that produces
  * occurrences of the requested data type. Powers the Variants tab task dropdown.
  */
 export function useOccurrenceTasks(caseId: number, seqId: number, dataType: CaseTasksWithOccurrencesDataTypeEnum) {
+  const { tenant } = useTenant();
   const { data, isLoading, error } = useSWR<TaskOccurrenceType[]>(
     ['occurrence-tasks', caseId, seqId, dataType],
     async () => {
-      const response = await caseApi.caseTasksWithOccurrences(DEFAULT_TENANT, caseId, seqId, dataType);
+      const response = await caseApi.caseTasksWithOccurrences(tenant, caseId, seqId, dataType);
       return response.data;
     },
     { revalidateOnFocus: false },

--- a/frontend/components/hooks/use-tenant.tsx
+++ b/frontend/components/hooks/use-tenant.tsx
@@ -1,0 +1,106 @@
+import { createContext, type ReactNode, useContext, useMemo } from 'react';
+import useSWR from 'swr';
+
+import type { TenantMembership, UserPreference } from '../../api/api';
+import { authApi, userPreferenceApi } from '../../utils/api';
+import { Spinner } from '../base/spinner';
+
+import { useI18n } from './i18n';
+
+export const TENANT_PREFERENCE_KEY = 'selected-tenant';
+
+export type TenantContextValue = {
+  /** Active tenant code (always defined once children render). */
+  tenant: string;
+  /** All tenants the user belongs to (from /auth/me). */
+  tenants: TenantMembership[];
+  /** Persist the chosen tenant then hard-reload so every request uses it. */
+  setTenant: (code: string) => Promise<void>;
+};
+
+export const TenantContext = createContext<TenantContextValue>({
+  tenant: '',
+  tenants: [],
+  setTenant: async () => {},
+});
+
+export function useTenant() {
+  return useContext(TenantContext);
+}
+
+async function fetchTenants(): Promise<TenantMembership[]> {
+  const response = await authApi.getMe();
+  return response.data ?? [];
+}
+
+async function fetchTenantPreference(): Promise<UserPreference> {
+  const response = await userPreferenceApi.getUserPreferences(TENANT_PREFERENCE_KEY);
+  return response.data;
+}
+
+export function TenantProvider({ children }: { children: ReactNode }) {
+  const { data: tenants, isLoading: tenantsLoading } = useSWR('auth-me-tenants', fetchTenants, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+  });
+
+  // Returns 404 when the user never picked a tenant before -> treated as "no preference".
+  const { data: preference, isLoading: preferenceLoading } = useSWR(
+    `user-preference-${TENANT_PREFERENCE_KEY}`,
+    fetchTenantPreference,
+    { revalidateOnFocus: false, shouldRetryOnError: false },
+  );
+
+  const tenant = useMemo(() => {
+    if (!tenants?.length) return undefined;
+    const preferredCode = (preference?.content as { tenant?: string } | undefined)?.tenant;
+    if (preferredCode && tenants.some(m => m.code === preferredCode)) {
+      return preferredCode;
+    }
+    return tenants[0].code;
+  }, [tenants, preference]);
+
+  const setTenant = async (code: string) => {
+    await userPreferenceApi.postUserPreferences(TENANT_PREFERENCE_KEY, {
+      key: TENANT_PREFERENCE_KEY,
+      content: { tenant: code },
+    });
+    // Hard reload: the provider re-reads the preference and every request picks
+    // up the new tenant. Keeps us clear of a global SWR cache mutate.
+    window.location.reload();
+  };
+
+  if (tenantsLoading || preferenceLoading) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center">
+        <Spinner size={32} className="text-primary" />
+      </div>
+    );
+  }
+
+  // Empty state: the user belongs to no tenant.
+  if (!tenant) {
+    return <TenantEmptyState />;
+  }
+
+  return (
+    <TenantContext.Provider value={{ tenant, tenants: tenants ?? [], setTenant }}>{children}</TenantContext.Provider>
+  );
+}
+
+/** Full-screen message shown by TenantProvider when the user belongs to no tenant. */
+export function TenantEmptyState() {
+  const { t } = useI18n();
+  return (
+    <div className="flex h-screen w-screen flex-col items-center justify-center gap-2 px-6 text-center">
+      <h1 className="text-lg font-semibold">
+        {t('main_navbar.tenant_switcher.empty_title', { defaultValue: 'No tenant available' })}
+      </h1>
+      <p className="text-muted-foreground">
+        {t('main_navbar.tenant_switcher.empty_description', {
+          defaultValue: 'You do not have access to any tenant. Please contact your administrator.',
+        })}
+      </p>
+    </div>
+  );
+}

--- a/frontend/components/hooks/use-tenant.tsx
+++ b/frontend/components/hooks/use-tenant.tsx
@@ -3,9 +3,8 @@ import useSWR from 'swr';
 
 import type { TenantMembership, UserPreference } from '../../api/api';
 import { authApi, userPreferenceApi } from '../../utils/api';
+import EmptyTenant from '../base/empties/empty_tenant';
 import { Spinner } from '../base/spinner';
-
-import { useI18n } from './i18n';
 
 export const TENANT_PREFERENCE_KEY = 'selected-tenant';
 
@@ -80,27 +79,10 @@ export function TenantProvider({ children }: { children: ReactNode }) {
 
   // Empty state: the user belongs to no tenant.
   if (!tenant) {
-    return <TenantEmptyState />;
+    return <EmptyTenant />;
   }
 
   return (
     <TenantContext.Provider value={{ tenant, tenants: tenants ?? [], setTenant }}>{children}</TenantContext.Provider>
-  );
-}
-
-/** Full-screen message shown by TenantProvider when the user belongs to no tenant. */
-export function TenantEmptyState() {
-  const { t } = useI18n();
-  return (
-    <div className="flex h-screen w-screen flex-col items-center justify-center gap-2 px-6 text-center">
-      <h1 className="text-lg font-semibold">
-        {t('main_navbar.tenant_switcher.empty_title', { defaultValue: 'No tenant available' })}
-      </h1>
-      <p className="text-muted-foreground">
-        {t('main_navbar.tenant_switcher.empty_description', {
-          defaultValue: 'You do not have access to any tenant. Please contact your administrator.',
-        })}
-      </p>
-    </div>
   );
 }

--- a/frontend/components/stories/empty/empty.stories.tsx
+++ b/frontend/components/stories/empty/empty.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Dna } from 'lucide-react';
 
-import Empty from '@/components/base/empty';
+import Empty from '@/components/base/empties/empty';
 
 import { StorySection } from '../story-section';
 

--- a/frontend/components/stories/navbar/navbar.stories.tsx
+++ b/frontend/components/stories/navbar/navbar.stories.tsx
@@ -15,9 +15,10 @@ import {
 import { fn } from 'storybook/test';
 
 import type { TenantMembership } from '@/api/api';
+import EmptyTenant from '@/components/base/empties/empty_tenant';
 import MainNavbar from '@/components/base/navbar/main-navbar';
 import { SidebarProvider } from '@/components/base/shadcn/sidebar';
-import { TenantContext, TenantEmptyState } from '@/components/hooks/use-tenant';
+import { TenantContext } from '@/components/hooks/use-tenant';
 
 import { StorySection } from '../story-section';
 
@@ -161,5 +162,5 @@ export const SingleTenant: Story = {
 export const WithoutTenant: Story = {
   args: MultiTenant.args,
   parameters: { layout: 'fullscreen' },
-  render: () => <TenantEmptyState />,
+  render: () => <EmptyTenant />,
 };

--- a/frontend/components/stories/navbar/navbar.stories.tsx
+++ b/frontend/components/stories/navbar/navbar.stories.tsx
@@ -1,4 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import {
   AudioWaveformIcon,
   BlendIcon,
@@ -13,10 +14,29 @@ import {
 } from 'lucide-react';
 import { fn } from 'storybook/test';
 
+import type { TenantMembership } from '@/api/api';
 import MainNavbar from '@/components/base/navbar/main-navbar';
 import { SidebarProvider } from '@/components/base/shadcn/sidebar';
+import { TenantContext, TenantEmptyState } from '@/components/hooks/use-tenant';
 
 import { StorySection } from '../story-section';
+
+const MOCK_TENANTS: TenantMembership[] = [
+  { code: 'CBTN', name: "Children's Brain Tumor Network" },
+  { code: 'UDN', name: 'Undiagnosed Diseases Network' },
+];
+
+/** Provides a mocked tenant context so the navbar's tenant switcher renders without network calls. */
+const withTenants =
+  (tenants: TenantMembership[], initialTenant: string): Decorator =>
+  Story => {
+    const [tenant, setTenant] = useState(initialTenant);
+    return (
+      <TenantContext.Provider value={{ tenant, tenants, setTenant: async code => setTenant(code) }}>
+        <Story />
+      </TenantContext.Provider>
+    );
+  };
 
 const meta = {
   title: 'Layout/Main Navbar',
@@ -37,7 +57,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const MultiTenant: Story = {
   args: {
     placement: 'top',
     onLogoutClick: fn(),
@@ -109,13 +129,37 @@ export const Default: Story = {
       },
     ],
     userDetails: {
+      id: 'olivier-cp',
       name: 'Olivier CP',
       email: 'olivier.castro-perrier@ssss.gouv.qc.ca',
     },
   },
+  decorators: [withTenants(MOCK_TENANTS, 'CBTN')],
   render: args => (
-    <StorySection title="Main navbar">
+    <StorySection
+      title="Main navbar (multi-tenant)"
+      description="Resize the window below 768px (or use the Viewport toolbar) to see the mobile navbar."
+    >
       <MainNavbar {...args} />
     </StorySection>
   ),
+};
+
+export const SingleTenant: Story = {
+  args: MultiTenant.args,
+  decorators: [withTenants([MOCK_TENANTS[0]], 'CBTN')],
+  render: args => (
+    <StorySection
+      title="Main navbar (single tenant)"
+      description="Resize the window below 768px (or use the Viewport toolbar) to see the mobile navbar."
+    >
+      <MainNavbar {...args} />
+    </StorySection>
+  ),
+};
+
+export const WithoutTenant: Story = {
+  args: MultiTenant.args,
+  parameters: { layout: 'fullscreen' },
+  render: () => <TenantEmptyState />,
 };

--- a/frontend/components/tsconfig.json
+++ b/frontend/components/tsconfig.json
@@ -37,6 +37,6 @@
       "@/apps/*": ["../apps/*"]
     }
   },
-  "include": ["base/**/*", "utils/**/*", "lib/**/*", "types/**/*", "stories/**/*"],
+  "include": ["base/**/*", "hooks/**/*", "utils/**/*", "lib/**/*", "types/**/*", "stories/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/frontend/portals/radiant/app/layout/protected-layout.tsx
+++ b/frontend/portals/radiant/app/layout/protected-layout.tsx
@@ -9,6 +9,7 @@ import { SidebarProvider } from '@/components/base/shadcn/sidebar';
 import { useBetaFeatures } from '@/components/hooks/beta-feature-provider';
 import { useI18n } from '@/components/hooks/i18n';
 import { LoginContext } from '@/components/hooks/use-login';
+import { TenantProvider } from '@/components/hooks/use-tenant';
 
 import type { Route } from '../+types/root';
 
@@ -47,75 +48,77 @@ const _ProtectedLayout = () => {
 
   return (
     <LoginContext value={{ ...data }}>
-      <SidebarProvider>
-        <div className={layoutVariants({ orientation })}>
-          <MainNavbar
-            placement={orientation}
-            logo={<img src={logo} alt="Logo" />}
-            links={[
-              // SJRA-389
-              // {
-              //   title: t('main_navbar.links.dashboard'),
-              //   icon: <LayoutDashboardIcon />,
-              //   as: 'button',
-              // },
-              {
-                title: t('main_navbar.links.cases'),
-                icon: <FolderIcon />,
-                to: '/case',
-                as: Link,
-                active: pathname === '/case',
-              },
-              {
-                title: t('main_navbar.links.files'),
-                icon: <ArchiveIcon />,
-                to: '/file',
-                as: Link,
-                active: pathname === '/file',
-              },
-            ]}
-            actions={
-              [
+      <TenantProvider>
+        <SidebarProvider>
+          <div className={layoutVariants({ orientation })}>
+            <MainNavbar
+              placement={orientation}
+              logo={<img src={logo} alt="Logo" />}
+              links={[
                 // SJRA-389
                 // {
-                //   title: t('main_navbar.actions.community'),
-                //   icon: <UsersIcon />,
+                //   title: t('main_navbar.links.dashboard'),
+                //   icon: <LayoutDashboardIcon />,
                 //   as: 'button',
                 // },
-                // {
-                //   title: t('main_navbar.actions.resources'),
-                //   icon: <LightbulbIcon />,
-                //   as: 'button',
-                //   subItems: [
-                //     {
-                //       title: t('main_navbar.actions.website'),
-                //       icon: <ExternalLink />,
-                //       as: 'a',
-                //       href: 'https://www.radiant-genomics.com',
-                //     },
-                //     {
-                //       title: t('main_navbar.actions.documentation'),
-                //       icon: <ExternalLink />,
-                //       as: 'button',
-                //     },
-                //     {
-                //       separator: true,
-                //     },
-                //     {
-                //       title: t('main_navbar.actions.contact'),
-                //       icon: <MailIcon />,
-                //       as: 'button',
-                //     },
-                //   ],
-                // },
-              ]
-            }
-            userDetails={{ id: data.sub, name: data.name, email: data.email }}
-            onLogoutClick={() => navigate('/auth/logout')}
-          />
-          <Outlet />
-        </div>
-      </SidebarProvider>
+                {
+                  title: t('main_navbar.links.cases'),
+                  icon: <FolderIcon />,
+                  to: '/case',
+                  as: Link,
+                  active: pathname === '/case',
+                },
+                {
+                  title: t('main_navbar.links.files'),
+                  icon: <ArchiveIcon />,
+                  to: '/file',
+                  as: Link,
+                  active: pathname === '/file',
+                },
+              ]}
+              actions={
+                [
+                  // SJRA-389
+                  // {
+                  //   title: t('main_navbar.actions.community'),
+                  //   icon: <UsersIcon />,
+                  //   as: 'button',
+                  // },
+                  // {
+                  //   title: t('main_navbar.actions.resources'),
+                  //   icon: <LightbulbIcon />,
+                  //   as: 'button',
+                  //   subItems: [
+                  //     {
+                  //       title: t('main_navbar.actions.website'),
+                  //       icon: <ExternalLink />,
+                  //       as: 'a',
+                  //       href: 'https://www.radiant-genomics.com',
+                  //     },
+                  //     {
+                  //       title: t('main_navbar.actions.documentation'),
+                  //       icon: <ExternalLink />,
+                  //       as: 'button',
+                  //     },
+                  //     {
+                  //       separator: true,
+                  //     },
+                  //     {
+                  //       title: t('main_navbar.actions.contact'),
+                  //       icon: <MailIcon />,
+                  //       as: 'button',
+                  //     },
+                  //   ],
+                  // },
+                ]
+              }
+              userDetails={{ id: data.sub, name: data.name, email: data.email }}
+              onLogoutClick={() => navigate('/auth/logout')}
+            />
+            <Outlet />
+          </div>
+        </SidebarProvider>
+      </TenantProvider>
     </LoginContext>
   );
 };

--- a/frontend/translations/common/en.json
+++ b/frontend/translations/common/en.json
@@ -1883,6 +1883,11 @@
       "website": "Website",
       "documentation": "Documentation",
       "contact": "Contact"
+    },
+    "tenant_switcher": {
+      "title": "Switch Tenant",
+      "empty_title": "No tenant available",
+      "empty_description": "You do not have access to any tenant. Please contact your administrator."
     }
   },
   "occurrence": {

--- a/frontend/translations/common/fr.json
+++ b/frontend/translations/common/fr.json
@@ -1880,6 +1880,11 @@
       "website": "Site web",
       "documentation": "Documentation",
       "contact": "Contact"
+    },
+    "tenant_switcher": {
+      "title": "Changer de tenant",
+      "empty_title": "Aucun tenant disponible",
+      "empty_description": "Vous n'avez accès à aucun tenant. Veuillez contacter votre administrateur."
     }
   },
   "occurrence": {

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -1,4 +1,5 @@
 import {
+  AuthApi,
   CasesApi,
   Configuration,
   DocumentsApi,
@@ -22,11 +23,7 @@ const config = new Configuration({
   basePath: '/api',
 });
 
-// Tenant-scoped endpoints now live under /{tenant}/. Until the tenant switcher ships
-// (SJRA follow-up), every tenant-scoped client call passes this default tenant.
-// TODO(multi-tenant): replace with the active tenant from the tenant switcher.
-export const DEFAULT_TENANT = 'radiant';
-
+export const authApi = new AuthApi(config, BASE_PATH, axiosClient);
 export const variantsApi = new VariantApi(config, BASE_PATH, axiosClient);
 export const occurrenceFlagApi = new OccurrenceFlagsApi(config, BASE_PATH, axiosClient);
 export const occurrencesApi = new OccurrencesApi(config, BASE_PATH, axiosClient);


### PR DESCRIPTION
# Feat (tenant): Add tenant switcher and storybook

## 📌 Context

Add a tenant switcher to the navbar. The active tenant is resolved via /auth/me + user preferences and replaces the former DEFAULT_TENANT constant in every tenant-scoped API call.

## 📝 Changes

- Add tenant context and save chosen tenant in user pref
- Handle loading state => empty tenants and tenant switching
- Use tenant switcher component in desktop and mobile navbar
- Remove all `DEFAULT_TENANT` usages
- Add switcher in navbar stories

## ☑️ TO-DOs

- Mobile single-tenant: the single-tenant label is hidden on mobile — interpretation to confirm with Lucas.

## 🧪 Tests

https://github.com/user-attachments/assets/cb2980f7-de5e-41d6-a7cd-b86df69e3570

<img width="1722" height="878" alt="Capture d’écran, le 2026-06-23 à 09 36 00" src="https://github.com/user-attachments/assets/3e774290-eda4-4af9-ae35-37d78154e6e7" />
<img width="1722" height="878" alt="Capture d’écran, le 2026-06-23 à 09 35 06" src="https://github.com/user-attachments/assets/909058c3-43e4-4a4d-bd55-5a9b371781e6" />

### Storybook

<img width="1722" height="737" alt="Capture d’écran, le 2026-06-23 à 09 32 44" src="https://github.com/user-attachments/assets/b876cd45-c7f8-4df9-8d3e-d5c4324a00f1" />
<img width="1051" height="725" alt="Capture d’écran, le 2026-06-23 à 09 32 33" src="https://github.com/user-attachments/assets/d1de4a7a-4ec2-4f99-8ebf-9eed50309242" />
<img width="1051" height="725" alt="Capture d’écran, le 2026-06-23 à 09 32 28" src="https://github.com/user-attachments/assets/b69b8221-963e-44e8-9a60-bc344e3d6681" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1451](https://d3b.atlassian.net/browse/SJRA-1451)
- [SJRA-1452](https://d3b.atlassian.net/browse/SJRA-1452)<!-- End JIRA Issues -->

[SJRA-1451]: https://d3b.atlassian.net/browse/SJRA-1451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ