### PR TITLE
feat(tenant): SJRA-1666 on switch redirect to cases

### DIFF
--- a/frontend/components/hooks/use-tenant.tsx
+++ b/frontend/components/hooks/use-tenant.tsx
@@ -13,7 +13,7 @@ export type TenantContextValue = {
   tenant: string;
   /** All tenants the user belongs to (from /auth/me). */
   tenants: TenantMembership[];
-  /** Persist the chosen tenant then hard-reload so every request uses it. */
+  /** Persist the chosen tenant then hard-reload onto /case so every request uses it. */
   setTenant: (code: string) => Promise<void>;
 };
 
@@ -64,9 +64,9 @@ export function TenantProvider({ children }: { children: ReactNode }) {
       key: TENANT_PREFERENCE_KEY,
       content: { tenant: code },
     });
-    // Hard reload: the provider re-reads the preference and every request picks
-    // up the new tenant. Keeps us clear of a global SWR cache mutate.
-    window.location.reload();
+    // Hard navigation to /case: the provider re-reads the preference and every
+    // request picks up the new tenant. Keeps us clear of a global SWR cache mutate.
+    window.location.assign('/case');
   };
 
   if (tenantsLoading || preferenceLoading) {


### PR DESCRIPTION
# Feat (tenant): On switch redirect to cases

## 📌 Context

With the tenant switcher (SJRA-1451) now live, a user can change the active tenant from any page. Data is split by tenant, so an entity that belongs to tenant A cannot be retrieved under tenant B. When a user is on a tenant-scoped entity page (e.g. a Case entity) and switches tenant, the API returns no result for that resource and the front-end crashes instead of handling the missing entity.

## 📝 Changes

- Redirect to cases on tenant switch except if it's the same selected

## 🧪 Tests

https://github.com/user-attachments/assets/0d357f88-f1d4-4805-8053-a3940b725983

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1666](https://d3b.atlassian.net/browse/SJRA-1666)<!-- End JIRA Issues -->

[SJRA-1666]: https://d3b.atlassian.net/browse/SJRA-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ