### PR TITLE
feat: SJRA-1670 Adjust Cypress tests related to switch tenant

### DIFF
--- a/cypress/pom/shared/Selectors.ts
+++ b/cypress/pom/shared/Selectors.ts
@@ -86,6 +86,7 @@ export const CommonSelectors = {
   tag: (color: string) => `[class*="bg-${color}/20 text-${color}-foreground"]`,
   tagBlank: '[class*="text-foreground"]',
   tagLevel: (level: string) => `[class*="bg-${level} text-${level}-foreground"]`,
+  tenantSwitcherButton: '[data-cy="tenant-switcher"]:visible',
   title: 'h1, h2',
   tooltipPopper: '[class*="radix-tooltip-content"]',
   underlineHeader: '[class*="decoration-dotted"]',

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -146,6 +146,16 @@ Cypress.Commands.add('setLang', (lang: string) => {
 });
 
 /**
+ * Set the tenant of the application (from the env).
+ */
+Cypress.Commands.add('setTenant', () => {
+  const tenant = Cypress.expose('api_tenant');
+
+  cy.get(CommonSelectors.tenantSwitcherButton).click();
+  cy.get(CommonSelectors.menuPopper).contains(tenant).clickAndWait();
+});
+
+/**
  * Asserts that the given tab is active.
  * @param subject The tab element.
  */
@@ -390,6 +400,7 @@ Cypress.Commands.add('visitCasesPage', (searchCriteria?: string) => {
   }
 
   cy.setLang('EN');
+  cy.setTenant();
   cy.resetColumns();
 });
 
@@ -412,6 +423,7 @@ Cypress.Commands.add('visitFilesPage', (searchCriteria?: string) => {
   }
 
   cy.setLang('EN');
+  cy.setTenant();
   cy.resetColumns();
 });
 
@@ -422,6 +434,7 @@ Cypress.Commands.add('visitFilesPage', (searchCriteria?: string) => {
 Cypress.Commands.add('visitCaseDetailsPage', (caseId: string) => {
   cy.visitAndIntercept(`/case/entity/${caseId}?tab=details`, 'GET', `**/cases/${caseId}`, 1);
   cy.setLang('EN');
+  cy.setTenant();
 });
 
 /**
@@ -444,6 +457,7 @@ Cypress.Commands.add('visitCaseFilesPage', (caseId: string, searchCriteria?: str
   }
 
   cy.setLang('EN');
+  cy.setTenant();
   cy.resetColumns();
 });
 
@@ -488,6 +502,7 @@ Cypress.Commands.add('visitCaseVariantsPage', (caseId: string, seqId: string, ty
   }
 
   cy.setLang('EN');
+  cy.setTenant();
   cy.resetColumns();
 });
 
@@ -498,6 +513,7 @@ Cypress.Commands.add('visitCaseVariantsPage', (caseId: string, seqId: string, ty
 Cypress.Commands.add('visitVariantEvidCondPage', (locusID: string) => {
   cy.visitAndIntercept(`/variants/entity/${locusID}?tab=evidenceAndConditions`, 'GET', `**/conditions/omim`, 1);
   cy.setLang('EN');
+  cy.setTenant();
 });
 
 /**
@@ -507,6 +523,7 @@ Cypress.Commands.add('visitVariantEvidCondPage', (locusID: string) => {
 Cypress.Commands.add('visitVariantFrequencyPage', (locusID: string) => {
   cy.visitAndIntercept(`/variants/entity/${locusID}?tab=frequency`, 'GET', `**/external_frequencies`, 1);
   cy.setLang('EN');
+  cy.setTenant();
 });
 
 /**
@@ -516,6 +533,7 @@ Cypress.Commands.add('visitVariantFrequencyPage', (locusID: string) => {
 Cypress.Commands.add('visitVariantOverviewPage', (locusID: string) => {
   cy.visitAndIntercept(`/variants/entity/${locusID}?tab=overview`, 'GET', `**/variants/germline/*/overview`, 1);
   cy.setLang('EN');
+  cy.setTenant();
 });
 
 /**
@@ -525,6 +543,7 @@ Cypress.Commands.add('visitVariantOverviewPage', (locusID: string) => {
 Cypress.Commands.add('visitVariantPatientsPage', (locusID: string) => {
   cy.visitAndIntercept(`/variants/entity/${locusID}?tab=patients`, 'POST', `**/cases/interpreted`, 1);
   cy.setLang('EN');
+  cy.setTenant();
 });
 
 /**

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -24,6 +24,7 @@ declare namespace Cypress {
     pinColumn(position: number, tableId: string = ''): cy & CyEventEmitter;
     resetColumns(): cy & CyEventEmitter;
     setLang(lang: string): cy & CyEventEmitter;
+    setTenant(): cy & CyEventEmitter;
     shouldBeActiveTab(): cy & CyEventEmitter;
     shouldBeDataState(state: string): Chainable<JQuery<HTMLElement>>;
     shouldBePinnable(isPinnable: boolean): Chainable<Element>;


### PR DESCRIPTION
# feat: SJRA-1670 Adjust Cypress tests related to switch tenant

## 📌 Context

Les tests Cypress doivent maintenant tenir compte du sélecteur de tenant (« switch tenant ») introduit dans l'application. Sans sélection explicite du tenant, les pages visitées par les tests ne se chargeaient pas dans le bon contexte. Ce PR ajoute la sélection automatique du tenant lors de la navigation vers les pages testées.

## 📝 Changes

- Ajout d'une nouvelle commande Cypress `setTenant()` ([cypress/support/commands.ts](cypress/support/commands.ts)) qui récupère le tenant depuis l'environnement (`Cypress.expose('api_tenant')`), ouvre le sélecteur de tenant et clique sur l'option correspondante.
- Ajout du sélecteur `tenantSwitcherButton` (`[data-cy="tenant-switcher"]:visible`) dans [cypress/pom/shared/Selectors.ts](cypress/pom/shared/Selectors.ts).
- Déclaration du type de la commande `setTenant()` dans [cypress/support/index.d.ts](cypress/support/index.d.ts).
- Appel de `cy.setTenant()` après `cy.setLang('EN')` dans toutes les commandes de navigation : `visitCasesPage`, `visitFilesPage`, `visitCaseDetailsPage`, `visitCaseFilesPage`, `visitCaseVariantsPage`, `visitVariantEvidCondPage`, `visitVariantFrequencyPage`, `visitVariantOverviewPage`, `visitVariantPatientsPage`.

## 🧪 Tests

Tests d'intégration Cypress. Le tenant sélectionné provient de la variable d'environnement `api_tenant`. Les tests impactés ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1670](https://d3b.atlassian.net/browse/SJRA-1670)<!-- End JIRA Issues -->

[SJRA-1670]: https://d3b.atlassian.net/browse/SJRA-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ