### PR TITLE
feat: SJRA-1461 — tenant-scope PostgreSQL-direct reads/writes

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -117,7 +117,12 @@ Two `internal/server` middlewares enforce this model on `/:tenant/*` routes:
 
 Org resolution for org-scoped actions is deferred behind `resolveOrgCode(c)` (a seam in `middlewares.go`): step 1 returns `WildcardOnlyOrg` (`""`, matches only `'*'` grants — correct while all grants are `'*'`); a follow-up will resolve the real org per resource. Every privileged `/:tenant` route is covered by `Test_TenantRoutesAreMappedToActions`, which fails if a new route ships unmapped.
 
-Until per-tenant API routing lands, batch-ingested records are attached to the default tenant via `DefaultTenantCode = "radiant"` in `cmd/worker/case_validation.go` (see its `TODO(multi-tenant)`).
+#### Read-path tenant isolation
+
+Reads are scoped to the active tenant in two places, both activated by `TENANT_VIEWS_READ_ENABLED` (`RequireTenantAccess` binds the tenant to the request context only when on; off → no tenant bound → reads are unscoped / single-tenant behavior):
+
+- **StarRocks (federated clinical reads):** repositories address the tenant's view database `<code>_tenant.*` via `types.TenantSchema(ctx)` / `types.Table.In(schema)` instead of `radiant_jdbc.public.*`. Off → `radiant_jdbc.public` (unchanged).
+- **PostgreSQL-direct reads:** repositories that read/update/delete a tenant-scoped table apply the `repository.WithTenant(ctx)` GORM scope, which adds `WHERE tenant_code = ?` from the bound tenant. It is a **no-op when no tenant is bound**, so the worker (processes all tenants) and the unscoped default path are unaffected. A cross-tenant row is then invisible → repos return nil → handlers return 404 (no existence leak). **Any new read/update/delete against a tenant-scoped PG table (`interpretation_germline`/`interpretation_somatic`, `occurrence_note`, `occurrence_flag`, `batch`, `task`) must add `.Scopes(repository.WithTenant(ctx))`.** The federated tables (cases, patient, documents, …) are isolated by the StarRocks views above, not here.
 
 ## Worker
 

--- a/backend/internal/repository/batch.go
+++ b/backend/internal/repository/batch.go
@@ -57,6 +57,7 @@ func (r *BatchRepository) GetBatchByID(ctx context.Context, batchId string) (*Ba
 
 	tx := r.db.WithContext(ctx).
 		Table(types.BatchTable.Name).
+		Scopes(WithTenant(ctx)).
 		Omit("payload").
 		Where("id = ?", batchId)
 	if err := tx.First(&batch).Error; err != nil {

--- a/backend/internal/repository/batch_test.go
+++ b/backend/internal/repository/batch_test.go
@@ -39,6 +39,32 @@ func Test_CreateBatch_Valid(t *testing.T) {
 	})
 }
 
+// A batch created under the radiant tenant must be invisible to a caller acting in another
+// tenant (the handler surfaces nil as 404), and visible to the radiant tenant itself. The
+// worker path (ClaimNextBatch, no tenant in context) is unaffected — WithTenant is a no-op there.
+func Test_GetBatchByID_CrossTenantIsInvisible(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.ExclusivePostgres}, func(t *testing.T, env *testutils.Env) {
+		repo := NewBatchRepository(env.Postgres)
+		batchId := uuid.NewString()
+		if err := env.Postgres.Exec(`
+            INSERT INTO batch (id, payload, status, batch_type, dry_run, username, created_on, tenant_code) VALUES
+            (?, '{}', ?, 'patient', true, 'user1', now(), 'radiant')
+        `, batchId, types.BatchStatusSuccess).Error; err != nil {
+			t.Fatal("failed to insert data:", err)
+		}
+
+		other := types.ContextWithTenant(t.Context(), "tenant_b")
+		got, err := repo.GetBatchByID(other, batchId)
+		assert.NoError(t, err)
+		assert.Nil(t, got, "radiant batch must be invisible to another tenant")
+
+		radiant := types.ContextWithTenant(t.Context(), types.DefaultTenantCode)
+		got, err = repo.GetBatchByID(radiant, batchId)
+		assert.NoError(t, err)
+		assert.NotNil(t, got, "radiant batch must be visible to the radiant tenant")
+	})
+}
+
 func Test_GetBatchByID_Success(t *testing.T) {
 	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewBatchRepository(db)

--- a/backend/internal/repository/interpretations.go
+++ b/backend/internal/repository/interpretations.go
@@ -164,7 +164,8 @@ func (r *InterpretationsRepository) mapToInterpretationSomaticDAO(ctx context.Co
 func (r *InterpretationsRepository) FirstGermline(ctx context.Context, caseId string, sequencingId string, locus string, transcriptId string) (*types.InterpretationGermline, error) {
 	var dao types.InterpretationGermlineDAO
 	tx := r.db.WithContext(ctx).
-		Table(types.InterpretationGermlineTable.Name)
+		Table(types.InterpretationGermlineTable.Name).
+		Scopes(WithTenant(ctx))
 	addWhere(tx, caseId, sequencingId, locus, transcriptId)
 	if result := tx.
 		First(&dao); result.Error != nil {
@@ -192,7 +193,8 @@ func (r *InterpretationsRepository) CreateOrUpdateGermline(ctx context.Context, 
 		return err
 	}
 	query := r.db.WithContext(ctx).
-		Table(types.InterpretationGermlineTable.Name)
+		Table(types.InterpretationGermlineTable.Name).
+		Scopes(WithTenant(ctx))
 	addWhere(query, interpretation.CaseId, interpretation.SequencingId, interpretation.LocusId, interpretation.TranscriptId)
 	if existing != nil {
 		dao.CreatedBy = existing.CreatedBy
@@ -219,7 +221,7 @@ func (r *InterpretationsRepository) CreateOrUpdateGermline(ctx context.Context, 
 func (r *InterpretationsRepository) FirstSomatic(ctx context.Context, caseId string, sequencingId string, locus string, transcriptId string) (*types.InterpretationSomatic, error) {
 	var dao types.InterpretationSomaticDAO
 
-	tx := r.db.WithContext(ctx).Table(types.InterpretationSomaticTable.Name)
+	tx := r.db.WithContext(ctx).Table(types.InterpretationSomaticTable.Name).Scopes(WithTenant(ctx))
 	addWhere(tx, caseId, sequencingId, locus, transcriptId)
 	if result := tx.
 		First(&dao); result.Error != nil {
@@ -246,7 +248,7 @@ func (r *InterpretationsRepository) CreateOrUpdateSomatic(ctx context.Context, i
 	if err != nil {
 		return err
 	}
-	query := r.db.WithContext(ctx).Table(types.InterpretationSomaticTable.Name)
+	query := r.db.WithContext(ctx).Table(types.InterpretationSomaticTable.Name).Scopes(WithTenant(ctx))
 	addWhere(query, interpretation.CaseId, interpretation.SequencingId, interpretation.LocusId, interpretation.TranscriptId)
 	if existing != nil {
 		dao.CreatedBy = existing.CreatedBy
@@ -273,6 +275,7 @@ func (r *InterpretationsRepository) SearchGermline(ctx context.Context, analysis
 	var dao []types.InterpretationGermlineDAO
 	r.db.WithContext(ctx).
 		Table(types.InterpretationGermlineTable.Name).
+		Scopes(WithTenant(ctx)).
 		Where("metadata->>'analysis_id' IN ? OR metadata->>'patient_id' IN ? OR metadata->>'variant_hash' IN ?", analysisId, patientId, variantHash).
 		Find(&dao)
 
@@ -292,6 +295,7 @@ func (r *InterpretationsRepository) SearchSomatic(ctx context.Context, analysisI
 	var dao []types.InterpretationSomaticDAO
 	r.db.WithContext(ctx).
 		Table(types.InterpretationSomaticTable.Name).
+		Scopes(WithTenant(ctx)).
 		Where("metadata->>'analysis_id' IN ? OR metadata->>'patient_id' IN ? OR metadata->>'variant_hash' IN ?", analysisId, patientId, variantHash).
 		Find(&dao)
 
@@ -309,7 +313,7 @@ func (r *InterpretationsRepository) SearchSomatic(ctx context.Context, analysisI
 
 func (r *InterpretationsRepository) RetrieveGermlineInterpretationClassificationCounts(ctx context.Context, locusId int) (types.JsonMap[string, int], error) {
 	var classificationCounts []types.ClassificationCounts
-	tx := r.db.WithContext(ctx).Table("interpretation_germline")
+	tx := r.db.WithContext(ctx).Table("interpretation_germline").Scopes(WithTenant(ctx))
 	tx = tx.Select("classification, COUNT(1) as classification_count")
 	tx = tx.Where("locus_id = ?", fmt.Sprintf("%d", locusId))
 	tx = tx.Group("classification")
@@ -339,7 +343,7 @@ func (r *InterpretationsRepository) RetrieveGermlineInterpretationClassification
 
 func (r *InterpretationsRepository) RetrieveSomaticInterpretationClassificationCounts(ctx context.Context, locusId int) (types.JsonMap[string, int], error) {
 	var classificationCounts []types.ClassificationCounts
-	tx := r.db.WithContext(ctx).Table("interpretation_somatic")
+	tx := r.db.WithContext(ctx).Table("interpretation_somatic").Scopes(WithTenant(ctx))
 	tx = tx.Select("oncogenicity as classification, COUNT(1) as classification_count")
 	tx = tx.Where("locus_id = ?", fmt.Sprintf("%d", locusId))
 	tx = tx.Group("oncogenicity")

--- a/backend/internal/repository/interpretations_test.go
+++ b/backend/internal/repository/interpretations_test.go
@@ -43,6 +43,25 @@ func Test_Interpretations_FirstGermline(t *testing.T) {
 	})
 }
 
+// A row belonging to the radiant tenant must be invisible to a caller acting in another
+// tenant — the WithTenant scope filters it out, and the handler surfaces nil as 404 (no
+// existence leak). It is visible to the radiant tenant itself.
+func Test_Interpretations_FirstGermline_CrossTenantIsInvisible(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
+		repo := newTestInterpretationsRepo(env.Postgres)
+
+		other := types.ContextWithTenant(t.Context(), "tenant_b")
+		got, err := repo.FirstGermline(other, "1", "1", "1000", "T001")
+		assert.NoError(t, err)
+		assert.Nil(t, got, "radiant interpretation must be invisible to another tenant")
+
+		radiant := types.ContextWithTenant(t.Context(), types.DefaultTenantCode)
+		got, err = repo.FirstGermline(radiant, "1", "1", "1000", "T001")
+		assert.NoError(t, err)
+		assert.NotNil(t, got, "radiant interpretation must be visible to the radiant tenant")
+	})
+}
+
 func Test_Interpretations_FirstGermline_NotFound(t *testing.T) {
 	testutils.ParallelTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := newTestInterpretationsRepo(db)

--- a/backend/internal/repository/occurrence_flags.go
+++ b/backend/internal/repository/occurrence_flags.go
@@ -34,6 +34,7 @@ func (r *OccurrenceFlagsRepository) Upsert(ctx context.Context, flag types.Occur
 
 func (r *OccurrenceFlagsRepository) Delete(ctx context.Context, caseID, seqID, taskID int, occurrenceID string) (int64, error) {
 	result := r.db.WithContext(ctx).
+		Scopes(WithTenant(ctx)).
 		Where("case_id = ? AND seq_id = ? AND task_id = ? AND occurrence_id = ?", caseID, seqID, taskID, occurrenceID).
 		Delete(&types.OccurrenceFlag{})
 	if result.Error != nil {

--- a/backend/internal/repository/occurrence_notes.go
+++ b/backend/internal/repository/occurrence_notes.go
@@ -28,7 +28,7 @@ func (r *OccurrenceNotesRepository) Create(ctx context.Context, note types.Occur
 // GetByID returns the non-deleted note with the given ID, or nil if not found.
 func (r *OccurrenceNotesRepository) GetByID(ctx context.Context, id string) (*types.OccurrenceNote, error) {
 	var note types.OccurrenceNote
-	if err := r.db.WithContext(ctx).Where("id = ? AND deleted = false", id).First(&note).Error; err != nil {
+	if err := r.db.WithContext(ctx).Scopes(WithTenant(ctx)).Where("id = ? AND deleted = false", id).First(&note).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("error retrieving occurrence note: %w", err)
 		}
@@ -42,6 +42,7 @@ func (r *OccurrenceNotesRepository) Update(ctx context.Context, id string, conte
 	var note types.OccurrenceNote
 	if err := r.db.WithContext(ctx).Model(&note).
 		Clauses(clause.Returning{}).
+		Scopes(WithTenant(ctx)).
 		Where("id = ?", id).
 		Update("content", content).Error; err != nil {
 		return nil, fmt.Errorf("error updating occurrence note: %w", err)
@@ -52,6 +53,7 @@ func (r *OccurrenceNotesRepository) Update(ctx context.Context, id string, conte
 // Delete soft-deletes the note with the given ID by setting deleted = true.
 func (r *OccurrenceNotesRepository) Delete(ctx context.Context, id string) error {
 	if err := r.db.WithContext(ctx).Model(&types.OccurrenceNote{}).
+		Scopes(WithTenant(ctx)).
 		Where("id = ?", id).
 		Update("deleted", true).Error; err != nil {
 		return fmt.Errorf("error deleting occurrence note: %w", err)
@@ -63,6 +65,7 @@ func (r *OccurrenceNotesRepository) Delete(ctx context.Context, id string) error
 func (r *OccurrenceNotesRepository) CountByOccurrence(ctx context.Context, caseID int, seqID int, taskID int, occurrenceID string) (int, error) {
 	var count int64
 	if err := r.db.WithContext(ctx).Model(&types.OccurrenceNote{}).
+		Scopes(WithTenant(ctx)).
 		Where("case_id = ? AND seq_id = ? AND task_id = ? AND occurrence_id = ? AND deleted = false",
 			caseID, seqID, taskID, occurrenceID).
 		Count(&count).Error; err != nil {
@@ -74,7 +77,7 @@ func (r *OccurrenceNotesRepository) CountByOccurrence(ctx context.Context, caseI
 // GetByOccurrence returns all non-deleted notes for the given occurrence, ordered by created_at desc.
 func (r *OccurrenceNotesRepository) GetByOccurrence(ctx context.Context, caseID int, seqID int, taskID int, occurrenceID string) ([]types.OccurrenceNote, error) {
 	var notes []types.OccurrenceNote
-	if err := r.db.WithContext(ctx).
+	if err := r.db.WithContext(ctx).Scopes(WithTenant(ctx)).
 		Where("case_id = ? AND seq_id = ? AND task_id = ? AND occurrence_id = ? AND deleted = false",
 			caseID, seqID, taskID, occurrenceID).
 		Order("created_at DESC").

--- a/backend/internal/repository/occurrence_notes_test.go
+++ b/backend/internal/repository/occurrence_notes_test.go
@@ -118,6 +118,30 @@ func Test_GetByID(t *testing.T) {
 	})
 }
 
+// A note created under the radiant tenant must be invisible to a caller acting in another
+// tenant (the handler surfaces nil as 404), and visible to the radiant tenant itself.
+func Test_GetByID_CrossTenantIsInvisible(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.WritePostgres}, func(t *testing.T, env *testutils.Env) {
+		repo := NewOccurrenceNotesRepository(env.Postgres)
+		created, err := repo.Create(t.Context(), types.OccurrenceNote{
+			CaseID: 2, SeqID: 1, TaskID: 1, OccurrenceID: "10000",
+			UserID: "11111111-1111-1111-1111-111111111111", UserName: "John Doe",
+			TenantCode: types.DefaultTenantCode, Content: "radiant note",
+		})
+		assert.NoError(t, err)
+
+		other := types.ContextWithTenant(t.Context(), "tenant_b")
+		got, err := repo.GetByID(other, created.ID)
+		assert.NoError(t, err)
+		assert.Nil(t, got, "radiant note must be invisible to another tenant")
+
+		radiant := types.ContextWithTenant(t.Context(), types.DefaultTenantCode)
+		got, err = repo.GetByID(radiant, created.ID)
+		assert.NoError(t, err)
+		assert.NotNil(t, got, "radiant note must be visible to the radiant tenant")
+	})
+}
+
 func Test_GetByID_NotFound(t *testing.T) {
 	testutils.SequentialTestWithPostgres(t, func(t *testing.T, db *gorm.DB) {
 		repo := NewOccurrenceNotesRepository(db)

--- a/backend/internal/repository/task.go
+++ b/backend/internal/repository/task.go
@@ -43,7 +43,7 @@ func (r *TaskRepository) GetTaskTypeCodes(ctx context.Context) ([]types.TaskType
 
 func (r *TaskRepository) GetTaskById(ctx context.Context, taskId int) (*Task, error) {
 	var task Task
-	if err := r.db.WithContext(ctx).Table(types.TaskTable.Name).First(&task, taskId).Error; err != nil {
+	if err := r.db.WithContext(ctx).Table(types.TaskTable.Name).Scopes(WithTenant(ctx)).First(&task, taskId).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("error while fetching task: %w", err)
 		} else {

--- a/backend/internal/repository/task.go
+++ b/backend/internal/repository/task.go
@@ -123,6 +123,7 @@ func (r *TaskRepository) ListTasksByCaseSeqAndTaskType(ctx context.Context, case
 	tx := r.db.WithContext(ctx).Table(fmt.Sprintf("%s %s", types.TaskContextTable.Name, types.TaskContextTable.Alias))
 	tx = joinTaskContextWithTask(tx)
 	tx = joinTaskWithTaskType(tx)
+	tx = tx.Scopes(WithTenantOn(ctx, types.TaskTable.Alias)) // task_context has no tenant_code; scope the joined task
 	tx = tx.Select("id, task_type_code, name_en AS task_type_name, pipeline_name, pipeline_version, genome_build, created_on")
 	tx = tx.Where("sequencing_experiment_id = ? AND (case_id = ? OR case_id IS NULL) AND task_type_code = ?", seqId, caseId, taskTypeCode)
 	tx = tx.Order("created_on DESC, id DESC")

--- a/backend/internal/repository/tenant_scope.go
+++ b/backend/internal/repository/tenant_scope.go
@@ -1,0 +1,24 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/radiant-network/radiant-api/internal/types"
+	"gorm.io/gorm"
+)
+
+// WithTenant is a GORM scope that constrains a PostgreSQL query to the active tenant when one is
+// bound to the context (set by server.RequireTenantAccess). It adds `tenant_code = ?` so that a
+// row belonging to another tenant is invisible to reads/updates/deletes — handlers surface that
+// as 404. When no tenant is bound it is a no-op: the worker (which processes every tenant's
+// batches) and any path running before tenant isolation is enabled keep their current behavior.
+//
+// Use it only on single tenant-scoped tables, where the unqualified `tenant_code` is unambiguous.
+func WithTenant(ctx context.Context) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		if code, ok := types.TenantFromContext(ctx); ok && code != "" {
+			return db.Where("tenant_code = ?", code)
+		}
+		return db
+	}
+}

--- a/backend/internal/repository/tenant_scope.go
+++ b/backend/internal/repository/tenant_scope.go
@@ -22,3 +22,16 @@ func WithTenant(ctx context.Context) func(*gorm.DB) *gorm.DB {
 		return db
 	}
 }
+
+// WithTenantOn is WithTenant for queries where tenant_code must be qualified by a table
+// alias — e.g. a join driven by a non-tenant-scoped table (task_context) onto a tenant-scoped
+// one (task), where unqualified `tenant_code` would be fragile. qualifier is a static table
+// alias, never user input.
+func WithTenantOn(ctx context.Context, qualifier string) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		if code, ok := types.TenantFromContext(ctx); ok && code != "" {
+			return db.Where(qualifier+".tenant_code = ?", code)
+		}
+		return db
+	}
+}

--- a/backend/internal/repository/tenant_scope_test.go
+++ b/backend/internal/repository/tenant_scope_test.go
@@ -1,0 +1,48 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/radiant-network/radiant-api/internal/types"
+	"github.com/radiant-network/radiant-api/test/testutils"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+// builtSQL renders the SQL a tenant-scoped query produces under WithTenant, without executing it
+// (DryRun), so the scope's effect can be asserted on the statement.
+func builtSQL(ctx context.Context, db *gorm.DB) (string, []any) {
+	var rows []map[string]any
+	tx := db.Session(&gorm.Session{DryRun: true}).
+		WithContext(ctx).
+		Table("interpretation_germline").
+		Scopes(WithTenant(ctx)).
+		Where("locus_id = ?", 1).
+		Find(&rows)
+	return tx.Statement.SQL.String(), tx.Statement.Vars
+}
+
+func Test_WithTenant_AddsTenantPredicate_WhenTenantBound(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
+		ctx := types.ContextWithTenant(context.Background(), "demo")
+		sql, vars := builtSQL(ctx, env.Postgres)
+		assert.Contains(t, sql, "tenant_code", "a bound tenant must add a tenant_code predicate")
+		assert.Contains(t, vars, "demo", "the bound tenant code must be the predicate value")
+	})
+}
+
+func Test_WithTenant_NoPredicate_WhenNoTenant(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
+		sql, _ := builtSQL(context.Background(), env.Postgres)
+		assert.NotContains(t, sql, "tenant_code", "no tenant in context (e.g. the worker) must not add a tenant filter")
+	})
+}
+
+func Test_WithTenant_NoPredicate_WhenEmptyTenant(t *testing.T) {
+	testutils.RunTest(t, testutils.Need{Postgres: testutils.ReadPostgres}, func(t *testing.T, env *testutils.Env) {
+		ctx := types.ContextWithTenant(context.Background(), "")
+		sql, _ := builtSQL(ctx, env.Postgres)
+		assert.NotContains(t, sql, "tenant_code", "an empty tenant code must not produce a degenerate filter")
+	})
+}


### PR DESCRIPTION
# feat: SJRA-1461 — tenant-scope PostgreSQL-direct reads/writes

## 📌 Context

Clinical reads are already isolated at the StarRocks layer via per-tenant view databases (`<code>_tenant.*`, merged in #1434). But several API paths read/write **PostgreSQL directly** — interpretations, occurrence notes/flags, tasks, batches — and those queries did not filter on `tenant_code`. PostgreSQL has no DB-level tenant isolation, so without a `tenant_code = ?` predicate a caller who is a member of tenant A could fetch (or mutate) a tenant-B row by ID. This PR closes that gap: it is the correctness layer for the PG-direct paths.

## 📝 Changes

- **`repository.WithTenant(ctx)`** ([tenant_scope.go](backend/internal/repository/tenant_scope.go)) — a GORM scope that adds `WHERE tenant_code = ?` from the tenant bound to the request context. It is a **no-op when no tenant is bound**, so the worker (which processes every tenant's batches) and the pre-rollout/default path are unaffected. `WithTenantOn(ctx, alias)` is the qualified variant for joins driven by a non-tenant-scoped table.
- **Applied to every PG-direct read/update/delete on a tenant-scoped table:** interpretations (First/Search/ClassificationCounts/CreateOrUpdate, germline + somatic), occurrence_notes (GetByID/Update/Delete/CountByOccurrence/GetByOccurrence), occurrence_flags (Delete), batch (GetBatchByID), task (`ListTasksByCaseSeqAndTaskType` via `WithTenantOn("task")`, GetTaskById). Inserts already carry `tenant_code` in VALUES (NOT NULL column).
- **Activation** is coupled to `TENANT_VIEWS_READ_ENABLED`: `RequireTenantAccess` binds the tenant to the request context only when that flag is on, so PG filtering and the StarRocks tenant-views read path turn on together as one "tenant isolation" switch. Off → tenant not bound → `WithTenant` is inert → behavior unchanged.
- **Cross-tenant = invisible → 404:** repositories return nil on no-rows, handlers map nil to 404 (no existence leak).
- **Docs** ([backend/CLAUDE.md](backend/CLAUDE.md)) — new "Read-path tenant isolation" subsection documenting both layers and the convention that any new tenant-scoped PG query must add `.Scopes(repository.WithTenant(ctx))`; removed a stale line claiming the worker attaches records via `DefaultTenantCode` (it derives `tenant_code` from the batch).

## ☑️ TO-DOs

- [ ] None blocking. Flip `TENANT_VIEWS_READ_ENABLED=true` (already the switch for the StarRocks read path) to activate tenant isolation end-to-end, once tenants' views are provisioned.

## 🧪 Tests

- **Cross-tenant 404 (≥3 PG-backed endpoints):** `Test_Interpretations_FirstGermline_CrossTenantIsInvisible`, `Test_GetByID_CrossTenantIsInvisible` (occurrence note), `Test_GetBatchByID_CrossTenantIsInvisible` — a radiant row is invisible to another tenant and visible to radiant.
- **Scope unit tests:** `Test_WithTenant_*` — adds `tenant_code` with the bound value when present; no predicate when absent/empty (worker-safe).
- Writes deriving `tenant_code` from context (body can't override) verified in the interpretation/notes/flags/batch handlers.
- `go build`, `gofmt`, `golangci-lint`, and the full test suite are green.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1461](https://d3b.atlassian.net/browse/SJRA-1461)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Why a context scope and not an explicit `tenantCode` param:** `GetBatchByID` is shared by the API (must filter) and the worker (`ClaimNextBatch` must see all tenants). A ctx-based scope self-adjusts — filters for API requests, no-op for the worker — without forcing a `tenantCode` param through signatures.
- **Worker is intentionally unscoped:** `ClaimNextBatch`/`UpdateBatch`/`ReleaseBatch`/`UpdateStuckBatch` run with no tenant in context, so they keep processing all tenants.
- **`WithTenantOn` for tasks:** `ListTasksByCaseSeqAndTaskType` selects from the `task_context` junction (no `tenant_code`) and joins `task`, so the predicate must be qualified (`task.tenant_code = ?`); unqualified would be fragile.
- Junction tables (`task_context`, `task_has_document`) and value-set/dictionary tables have no `tenant_code` and are intentionally not scoped.

[SJRA-1461]: https://d3b.atlassian.net/browse/SJRA-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ