### PR TITLE
feat: SJRA-1675 Add missing hyperlink and action button Cypress tests

### DIFF
--- a/cypress/CLAUDE.md
+++ b/cypress/CLAUDE.md
@@ -6,86 +6,44 @@ This file provides guidance to Claude Code when working in the `cypress/` direct
 
 End-to-end (E2E) and API test suite for the Radiant Portal. Tests run against a live QA environment using Cypress with a Page Object Model (POM) pattern.
 
-- **QA base URL**: `https://radiant.qa.juno.cqdg.ferlab.bio/`
-- **API base URL**: `https://radiant-api.qa.juno.cqdg.ferlab.bio/`
-- **Auth**: Keycloak at `https://auth.qa.juno.cqdg.ferlab.bio`
+Base URLs (portal, API, Keycloak) and tenant/realm/client identifiers are **not hardcoded here** — they live in the `expose`/`baseUrl` blocks of `cypress.config.ts` and are overridable through `.env` (see [Environment](#environment) below). Check those sources for the current values rather than trusting any URL pasted into docs.
 
 ## Directory Structure
 
-```
-cypress/
-├── api/                   # API tests (organized by resource)
-│   ├── Batches/           # Batch job management
-│   ├── Cases/
-│   │   ├── Autocomplete/  # Autocomplete suggestions
-│   │   ├── Batch/         # Batch case operations
-│   │   └── Search/        # Case search filtering
-│   ├── Documents/
-│   │   └── Search/        # Document/file search
-│   ├── Occurrences/
-│   │   └── Germline/
-│   │       ├── CNV/
-│   │       │   ├── Count/ # CNV facet counts (Variant, Gene, Frequency, MetricQC)
-│   │       │   └── List/  # CNV list pagination
-│   │       └── SNV/
-│   │           ├── Count/ # SNV facet counts (Variant, Gene, Pathogenicity, Frequency, Occurrence)
-│   │           └── List/  # SNV list pagination
-│   ├── Patients/
-│   │   └── Batch/         # Batch patient creation (Valid, BlankFields, InvalidValues, etc.)
-│   │       └── ProcessWorker/
-│   ├── Samples/
-│   │   └── Batch/         # Batch sample operations
-│   │       └── ProcessWorker/
-│   └── Sequencing/
-│       └── Batch/         # Batch sequencing operations
-│           └── ProcessWorker/
-├── e2e/                   # E2E UI tests (organized by feature/page)
-│   ├── Cases/             # Case list table tests
-│   ├── CaseEntity/        # Case detail page (Details, Files, Variants SNV/CNV)
-│   ├── Connexion/         # Login tests
-│   ├── Files/             # Files list tests
-│   └── VariantEntity/     # Variant detail page (EvidCond, Frequency, Patients)
-├── pom/                   # Page Object Model
-│   ├── pages/             # 18 page objects (one per page/component)
-│   └── shared/            # Selectors.ts, Data.ts, Utils.ts, Texts.ts
-├── support/               # Custom commands and global setup
-│   ├── commands.ts        # UI commands (login, navigation, table ops, assertions)
-│   ├── apiCommands.ts     # API commands (getToken, apiCall, validators)
-│   ├── e2e.js             # Global before() hook, token caching
-│   ├── globalData.js      # Runtime shared data (token, batch IDs, counts)
-│   └── index.d.ts         # TypeScript definitions for custom commands
-├── fixtures/
-│   └── RequestBody/       # JSON templates (ApplyFacet, Sort payloads)
-└── plugins/
-    └── index.ts           # Env var loading from dotenv
-```
+Top-level layout (browse the actual folders for the current feature/resource breakdown — the per-feature subfolders evolve and aren't enumerated here):
+
+| Folder | Role |
+|---|---|
+| `api/` | API tests, organized by resource (one subfolder per resource, nested by operation: search, count, batch, …) |
+| `e2e/` | E2E UI tests, organized by feature/page (one subfolder per page or entity tab) |
+| `pom/pages/` | Page Object Model — one file per page/component |
+| `pom/shared/` | Cross-page POM utilities: `Selectors.ts`, `Data.ts`, `Utils.ts`, `Texts.ts` |
+| `support/` | Custom commands (`commands.ts` UI, `apiCommands.ts` API), global setup (`e2e.js`), runtime shared data (`globalData.js`), and TS command defs (`index.d.ts`) |
+| `fixtures/` | JSON request/response templates |
+| `plugins/` | Cypress plugin setup (env var loading) |
 
 Config lives at repo root: `cypress.config.ts`.
 
 ## Running Tests
 
+Core Cypress invocation patterns (the `--spec` glob targets any folder/file under `cypress/`):
+
 ```bash
-# Open Cypress UI (interactive)
-npx cypress open
-
-# Run all tests headless
-npx cypress run
-
-# Run a specific spec
-npx cypress run --spec "cypress/e2e/Cases/Columns.cy.ts"
-
-# Run only API tests
-npx cypress run --spec "cypress/api/**/*.cy.ts"
-
-# Formatting and type-checking (from repo root)
-npm run format:cypress
-npm run format:cypress:check
-npm run type-check:cypress
+npx cypress open                                          # interactive UI
+npx cypress run                                           # all tests headless
+npx cypress run --spec "cypress/e2e/Cases/Columns.cy.ts"  # a single spec
+npx cypress run --spec "cypress/api/**/*.cy.ts"           # a subtree (e.g. API only)
 ```
 
-Environment variables are loaded from `.env` at repo root. Required:
+Cypress-related npm scripts (formatting, type-checking, CI runs) are defined in the repo-root `package.json` — run `npm run` to list the current ones rather than relying on a copy here.
+
+## Environment
+
+Config and env wiring: `cypress.config.ts` (defaults in `expose`/`baseUrl`) and `cypress/plugins/index.ts` (reads env vars with fallbacks). Environment variables are loaded from `.env` at repo root. Sensitive values required:
 - `CYPRESS_USER_USERNAME`, `CYPRESS_USER_PASSWORD` — test user credentials
 - `KEYCLOAK_CLIENT_SECRET` — OAuth client secret
+
+Non-sensitive values (URLs, tenant, realm, client) have defaults in config and can be overridden via the corresponding env vars (`CYPRESS_API_BASE_URL`, `CYPRESS_API_TENANT`, `KEYCLOAK_HOST`, …).
 
 ## Page Object Model (POM) Pattern
 

--- a/cypress/e2e/VariantEntity/EvidCond/ClinVar_Hyperlinks.cy.ts
+++ b/cypress/e2e/VariantEntity/EvidCond/ClinVar_Hyperlinks.cy.ts
@@ -1,0 +1,18 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { VariantEntity_EvidCond } from 'pom/pages/VariantEntity_EvidCond';
+
+describe('VariantEntity - EvidCond - ClinVar - Hyperlinks', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitVariantEvidCondPage(data.variantGermline.locus_id);
+    VariantEntity_EvidCond.clinvarCard.actions.sortColumn('condition');
+    VariantEntity_EvidCond.clinvarCard.actions.sortColumn('condition');
+  };
+
+  it('RCV Link', () => {
+    setupTest();
+    VariantEntity_EvidCond.clinvarCard.validations.shouldHaveTableCellLink(data.variantGermline.clinvar_evidence, 'rcv_link');
+  });
+});

--- a/cypress/e2e/VariantEntity/EvidCond/CondPhen_Hpo_Hyperlinks.cy.ts
+++ b/cypress/e2e/VariantEntity/EvidCond/CondPhen_Hpo_Hyperlinks.cy.ts
@@ -1,0 +1,17 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { VariantEntity_EvidCond } from 'pom/pages/VariantEntity_EvidCond';
+
+describe('VariantEntity - EvidCond - CondPhen - Hpo - Hyperlinks', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitVariantEvidCondPage(data.variantGermline.locus_id);
+    VariantEntity_EvidCond.condPhenCard.hpo.actions.selectTab();
+  };
+
+  it('Link', () => {
+    setupTest();
+    VariantEntity_EvidCond.condPhenCard.hpo.validations.shouldHaveTableCellLink(data.variantGermline.hpo, 'link');
+  });
+});

--- a/cypress/e2e/VariantEntity/EvidCond/CondPhen_Omim_Hyperlinks.cy.ts
+++ b/cypress/e2e/VariantEntity/EvidCond/CondPhen_Omim_Hyperlinks.cy.ts
@@ -1,0 +1,16 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { VariantEntity_EvidCond } from 'pom/pages/VariantEntity_EvidCond';
+
+describe('VariantEntity - EvidCond - CondPhen - Omim - Hyperlinks', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitVariantEvidCondPage(data.variantGermline.locus_id);
+  };
+
+  it('Link', () => {
+    setupTest();
+    VariantEntity_EvidCond.condPhenCard.omim.validations.shouldHaveTableCellLink(data.variantGermline.omim, 'link');
+  });
+});

--- a/cypress/e2e/VariantEntity/EvidCond/CondPhen_Orphanet_Hyperlinks.cy.ts
+++ b/cypress/e2e/VariantEntity/EvidCond/CondPhen_Orphanet_Hyperlinks.cy.ts
@@ -1,0 +1,17 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { VariantEntity_EvidCond } from 'pom/pages/VariantEntity_EvidCond';
+
+describe('VariantEntity - EvidCond - CondPhen - Orphanet - Hyperlinks', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitVariantEvidCondPage(data.variantGermline.locus_id);
+    VariantEntity_EvidCond.condPhenCard.orphanet.actions.selectTab();
+  };
+
+  it('Link', () => {
+    setupTest();
+    VariantEntity_EvidCond.condPhenCard.orphanet.validations.shouldHaveTableCellLink(data.variantGermline.orphanet, 'link');
+  });
+});

--- a/cypress/e2e/VariantEntity/Patients/Uninterpreted_ActionButtons.cy.ts
+++ b/cypress/e2e/VariantEntity/Patients/Uninterpreted_ActionButtons.cy.ts
@@ -1,0 +1,27 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { VariantEntity_Patients } from 'pom/pages/VariantEntity_Patients';
+import { CaseEntity_Details } from 'pom/pages/CaseEntity_Details';
+import { CaseEntity_Variants_SNV_Table } from 'pom/pages/CaseEntity_Variants_SNV_Table';
+
+describe('VariantEntity - Patients - Uninterpreted - Action Buttons', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitVariantPatientsPage(data.variantGermline.locus_id);
+    VariantEntity_Patients.uninterpreted.actions.selectTab();
+  };
+
+  it('View Case', () => {
+    setupTest();
+    VariantEntity_Patients.uninterpreted.actions.selectAction('case');
+    CaseEntity_Details.validations.shouldHaveTitle(data.variantGermline.uninterpreted);
+  });
+
+  it('View Variants', () => {
+    setupTest();
+    VariantEntity_Patients.uninterpreted.actions.selectAction('variants');
+    CaseEntity_Variants_SNV_Table.validations.shouldHaveTitle(data.variantGermline.uninterpreted);
+    CaseEntity_Variants_SNV_Table.validations.shouldHaveActiveTabAndToggle();
+  });
+});

--- a/cypress/pom/pages/VariantEntity_EvidCond.ts
+++ b/cypress/pom/pages/VariantEntity_EvidCond.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress"/>
 import { CommonSelectors } from 'pom/shared/Selectors';
-import { getColumnPosition, stringToRegExp } from 'pom/shared/Utils';
+import { getColumnPosition, getUrlLink, stringToRegExp } from 'pom/shared/Utils';
 
 const selectors = {
   tab: '[data-cy="evidence-tab"]',
@@ -262,6 +262,22 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
     cy.then(() =>
       getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
         cy.validateTableFirstRowContent(value, position);
+      })
+    );
+  },
+  /**
+   * Validates the link in a specific table cell for a given data and column.
+   * @param dataVariant The variant object.
+   * @param columnID The ID of the column.
+   */
+  shouldHaveTableCellLink(dataVariant: any, columnID: string) {
+    cy.then(() =>
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+        if (position !== -1) {
+          cy.get(CommonSelectors.tableRow(tableId)).eq(0).find(CommonSelectors.tableCellData).eq(position).find(CommonSelectors.link).should('have.attr', 'href', getUrlLink(columnID, dataVariant));
+        } else {
+          cy.handleColumnNotFound(columnID);
+        }
       })
     );
   },

--- a/cypress/pom/pages/VariantEntity_Patients.ts
+++ b/cypress/pom/pages/VariantEntity_Patients.ts
@@ -721,6 +721,22 @@ export const VariantEntity_Patients = {
       return {
         ...baseActions,
         /**
+         * Select an object view with the table action button of the first row.
+         * @param object The object to view (case | variants).
+         */
+        selectAction(object: string) {
+          cy.then(() =>
+            getColumnPosition(CommonSelectors.tableHead(selectors.uninterpreted.tableId), tableColumns.uninterpreted, 'actions').then(position => {
+              if (position !== -1) {
+                cy.get(CommonSelectors.tableRow(selectors.uninterpreted.tableId)).eq(0).find(CommonSelectors.tableCellData).eq(position).find('button').clickAndWait({ force: true });
+                cy.get(`${CommonSelectors.menuPopper} ${CommonSelectors.menuItem(object)}`).clickAndWait({ force: true });
+              } else {
+                cy.handleColumnNotFound('actions');
+              }
+            })
+          );
+        },
+        /**
          * Select the tab to show the table.
          */
         selectTab() {

--- a/cypress/pom/shared/Data.ts
+++ b/cypress/pom/shared/Data.ts
@@ -101,6 +101,7 @@ export const data = {
       status: 0,
       origin: 'Germline',
       rcv_link: 'RCV003916198',
+      version: 2,
     },
     clinvar_name: '784210',
     exomiser: '0.438',

--- a/cypress/pom/shared/Utils.ts
+++ b/cypress/pom/shared/Utils.ts
@@ -282,11 +282,18 @@ export const getUrlLink = (columnID: string, data: any): string | undefined => {
       return data.gene ? `https://www.omim.org/search?index=entry&start=1&limit=10&sort=score+desc%2C+prefix_sort+desc&search=${data.gene}` : undefined;
     case 'gnomad':
       return data.locus ? `https://gnomad.broadinstitute.org/variant/${data.locus}?dataset=gnomad_r3` : undefined;
+    case 'link':
+      if (data.omim_id) return `https://omim.org/entry/${data.omim_id}`;
+      if (data.orphanet_id) return `https://www.orpha.net/en/disease/detail/${data.orphanet_id}`;
+      if (data.hpo_id) return `https://hpo.jax.org/app/browse/term/${data.hpo_id}`;
+      return undefined;
     case 'omim_phenotype':
       return data.omim_id ? `https://www.omim.org/entry/${data.omim_id}` : undefined;
     case 'primary_condition':
       const conditionId = data.primary_condition_id.replace(/:/g, '_');
       return `http://purl.obolibrary.org/obo/${conditionId}`;
+    case 'rcv_link':
+      return data.rcv_link ? `https://www.ncbi.nlm.nih.gov/clinvar/${data.rcv_link}.${data.version}` : undefined;
     case 'transcript_id':
       return data.transcript_id ? `https://www.ensembl.org/id/${data.transcript_id}` : undefined;
     default:

--- a/frontend/apps/variant/src/entity/cases/table/cells/uninterpreted-case-actions-cell.tsx
+++ b/frontend/apps/variant/src/entity/cases/table/cells/uninterpreted-case-actions-cell.tsx
@@ -26,6 +26,7 @@ function UninterpretedCaseActionsCell({ row }: CellContext<VariantUninterpretedC
         </DropdownMenuTrigger>
         <DropdownMenuContent>
           <DropdownMenuItem
+            data-cy="menu-item-case"
             onClick={() => {
               navigate(`/case/entity/${row.original.case_id}`);
             }}
@@ -34,6 +35,7 @@ function UninterpretedCaseActionsCell({ row }: CellContext<VariantUninterpretedC
             {t('variant_entity.cases.other_table.view_case')}
           </DropdownMenuItem>
           <DropdownMenuItem
+            data-cy="menu-item-variants"
             onClick={() => {
               navigate(
                 `/case/entity/${row.original.case_id}?tab=${CaseEntityTabs.Variants}&seq_id=${row.original.seq_id}`,


### PR DESCRIPTION
# feat: SJRA-1675 Add missing hyperlink and action button Cypress tests

## 📌 Context

Cette PR comble des trous de couverture E2E sur la page **Variant Entity**. Plusieurs liens externes affichés dans les tableaux (ClinVar, OMIM, Orphanet, HPO) et les boutons d'action de l'onglet *Patients > Uninterpreted* n'étaient pas couverts par des tests Cypress. On ajoute les specs manquants ainsi que les utilitaires POM nécessaires.

## 📝 Changes

- **Nouveaux tests d'hyperliens (`e2e/VariantEntity/EvidCond/`)** : validation des `href` des liens dans les tableaux ClinVar (lien RCV), Condition/Phénotype HPO, OMIM et Orphanet.
- **Nouveau test d'actions (`e2e/VariantEntity/Patients/Uninterpreted_ActionButtons.cy.ts`)** : vérifie les boutons « View Case » et « View Variants » de la première ligne de l'onglet *Uninterpreted*, et l'arrivée sur la bonne page de cas.
- **POM `VariantEntity_EvidCond.ts`** : ajout de la validation `shouldHaveTableCellLink` qui compare le `href` d'une cellule au lien attendu via `getUrlLink`.
- **POM `VariantEntity_Patients.ts`** : ajout de l'action `selectAction(object)` qui ouvre le menu d'actions de la première ligne et sélectionne `case` ou `variants`.
- **`pom/shared/Utils.ts`** (`getUrlLink`) : ajout des cas `link` (OMIM / Orphanet / HPO selon l'identifiant présent) et `rcv_link` (lien ClinVar NCBI incluant la version du RCV).
- **`pom/shared/Data.ts`** : ajout du champ `version: 2` à `clinvar_evidence` pour construire le lien RCV versionné.
- **Frontend `uninterpreted-case-actions-cell.tsx`** : ajout des attributs `data-cy="menu-item-case"` et `data-cy="menu-item-variants"` pour rendre les items du menu ciblables par les tests (changement non fonctionnel).
- **`cypress/CLAUDE.md`** : réécriture de la doc pour ne plus coder en dur les URLs/identifiants (renvoi vers `cypress.config.ts` et `.env`) et alléger l'arborescence détaillée au profit d'un tableau de haut niveau.

## 🧪 Tests

- 5 nouveaux specs E2E ajoutés ; exécutés localement, ils passent avec succès.

```bash
npx cypress run --spec "cypress/e2e/VariantEntity/EvidCond/*_Hyperlinks.cy.ts"
npx cypress run --spec "cypress/e2e/VariantEntity/Patients/Uninterpreted_ActionButtons.cy.ts"
```

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1675](https://d3b.atlassian.net/browse/SJRA-1675)<!-- End JIRA Issues -->

[SJRA-1675]: https://d3b.atlassian.net/browse/SJRA-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ