### PR TITLE
feat: SJRA-1676 Add CNV overlapping genes table Cypress tests

### DIFF
--- a/cypress/e2e/CaseEntity/Variants/CNV/OverlappingGenes/Columns.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/OverlappingGenes/Columns.cy.ts
@@ -1,0 +1,45 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { CaseEntity_Variants_CNV_Table } from 'pom/pages/CaseEntity_Variants_CNV_Table';
+import { OverlappingGenesModal } from 'pom/pages/OverlappingGenesModal';
+
+describe('Case Entity - Variants - CNV - Overlapping Genes - Columns', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.resetTablePreferences();
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV', data.cnvGermline.sqon);
+    CaseEntity_Variants_CNV_Table.actions.clickTableCellLink(data.cnvGermline, 'nb_genes');
+    OverlappingGenesModal.validations.shouldModalOpen();
+  };
+
+  it('Default display', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldMatchDefaultColumnVisibility();
+  });
+
+  it('Order', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowAllColumns();
+  });
+
+  it('Pin', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowPinnableColumns();
+  });
+
+  it('Default pin state', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldMatchDefaultPinnedColumns();
+  });
+
+  it('Sort', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowSortableColumns();
+  });
+
+  it('Tooltip', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowColumnTooltips();
+  });
+});

--- a/cypress/e2e/CaseEntity/Variants/CNV/OverlappingGenes/Hyperlinks.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/OverlappingGenes/Hyperlinks.cy.ts
@@ -1,0 +1,24 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { CaseEntity_Variants_CNV_Table } from 'pom/pages/CaseEntity_Variants_CNV_Table';
+import { OverlappingGenesModal } from 'pom/pages/OverlappingGenesModal';
+
+describe('Case Entity - Variants - CNV - Overlapping Genes - Hyperlinks', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV', data.cnvGermline.sqon);
+    CaseEntity_Variants_CNV_Table.actions.clickTableCellLink(data.cnvGermline, 'nb_genes');
+    OverlappingGenesModal.validations.shouldModalOpen();
+  };
+
+  it('Gene', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldHaveTableCellLink(data.cnvOverlappingGenes, 'gene');
+  });
+
+  it('ClinGen', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldHaveTableCellLink(data.cnvOverlappingGenes, 'clingen');
+  });
+});

--- a/cypress/e2e/CaseEntity/Variants/CNV/OverlappingGenes/InformationDisplayed.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/OverlappingGenes/InformationDisplayed.cy.ts
@@ -1,0 +1,59 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { CaseEntity_Variants_CNV_Table } from 'pom/pages/CaseEntity_Variants_CNV_Table';
+import { OverlappingGenesModal } from 'pom/pages/OverlappingGenesModal';
+
+describe('Case Entity - Variants - CNV - Overlapping Genes - Information displayed', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV', data.cnvGermline.sqon);
+    CaseEntity_Variants_CNV_Table.actions.clickTableCellLink(data.cnvGermline, 'nb_genes');
+    OverlappingGenesModal.validations.shouldModalOpen();
+  };
+
+  it('Gene', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowColumnContent('gene', data.cnvOverlappingGenes);
+  });
+
+  it('Cytoband', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowColumnContent('cytoband', data.cnvOverlappingGenes);
+  });
+
+  it('ClinGen', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowColumnContent('clingen', data.cnvOverlappingGenes);
+  });
+
+  it('Length', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowColumnContent('length', data.cnvOverlappingGenes);
+  });
+
+  it('# Bases', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowColumnContent('nb_overlap_bases', data.cnvOverlappingGenes);
+  });
+
+  it('# Exons', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowColumnContent('nb_exons', data.cnvOverlappingGenes);
+  });
+
+  it('% Gene', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowColumnContent('overlapping_gene_percent', data.cnvOverlappingGenes);
+  });
+
+  it('% CNV', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowColumnContent('overlapping_cnv_percent', data.cnvOverlappingGenes);
+  });
+
+  it('Type', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldShowColumnContent('overlap_type', data.cnvOverlappingGenes);
+  });
+});

--- a/cypress/e2e/CaseEntity/Variants/CNV/OverlappingGenes/Sort.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/CNV/OverlappingGenes/Sort.cy.ts
@@ -1,0 +1,37 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { CaseEntity_Variants_CNV_Table } from 'pom/pages/CaseEntity_Variants_CNV_Table';
+import { OverlappingGenesModal } from 'pom/pages/OverlappingGenesModal';
+
+describe('Case Entity - Variants - CNV - Overlapping Genes - Sort', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV', data.cnvGermline.sqon);
+    CaseEntity_Variants_CNV_Table.actions.clickTableCellLink(data.cnvGermline, 'nb_genes');
+    OverlappingGenesModal.validations.shouldModalOpen();
+  };
+
+  it('Number', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldSortColumn('nb_exons', false /*hasUniqueValues*/, false /*isReverseSorting*/);
+  });
+
+  it('Kilobases', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldSortColumn('length', false /*hasUniqueValues*/, false /*isReverseSorting*/);
+  });
+
+  it('Percentage', () => {
+    setupTest();
+    OverlappingGenesModal.validations.shouldSortColumn('overlapping_cnv_percent', false /*hasUniqueValues*/, false /*isReverseSorting*/);
+  });
+
+  it('Multiple', () => {
+    setupTest();
+    OverlappingGenesModal.actions.sortColumn('nb_exons');
+    OverlappingGenesModal.actions.sortColumn('length');
+    OverlappingGenesModal.actions.sortColumn('length');
+    OverlappingGenesModal.validations.shouldHaveFirstRowValue('86.8 kb', 'length');
+  });
+});

--- a/cypress/pom/pages/OverlappingGenesModal.ts
+++ b/cypress/pom/pages/OverlappingGenesModal.ts
@@ -1,10 +1,335 @@
 /// <reference types="cypress"/>
 import { CommonSelectors } from 'pom/shared/Selectors';
+import { getColumnPosition, getUrlLink, oneMinute, stringToRegExp } from 'pom/shared/Utils';
 
-const selectors = {};
+const selectors = {
+  tableId: '[id="overlapping-genes-table"]',
+  tableHeadRow: 'tr:eq(1)',
+  leafHeadCell: () => `${CommonSelectors.tableHead(selectors.tableId)} ${selectors.tableHeadRow} ${CommonSelectors.tableCellHead}`,
+};
+
+const tableColumns = [
+  {
+    id: 'gene',
+    name: 'Gene',
+    apiField: 'symbol',
+    isVisibleByDefault: true,
+    pinByDefault: null,
+    isSortable: false,
+    isPinnable: false,
+    position: 0,
+    tooltip: null,
+  },
+  {
+    id: 'cytoband',
+    name: 'Cytoband',
+    apiField: 'cytoband',
+    isVisibleByDefault: true,
+    pinByDefault: null,
+    isSortable: false,
+    isPinnable: false,
+    position: 1,
+    tooltip: null,
+  },
+  {
+    id: 'clingen',
+    name: 'ClinGen',
+    apiField: null,
+    isVisibleByDefault: true,
+    pinByDefault: null,
+    isSortable: false,
+    isPinnable: false,
+    position: 2,
+    tooltip: null,
+  },
+  {
+    id: 'length',
+    name: 'Length',
+    apiField: 'gene_length',
+    isVisibleByDefault: true,
+    pinByDefault: null,
+    isSortable: true,
+    isPinnable: false,
+    position: 3,
+    tooltip: 'Gene base length',
+  },
+  {
+    id: 'nb_overlap_bases',
+    name: '# Bases',
+    apiField: 'nb_overlap_bases',
+    isVisibleByDefault: true,
+    pinByDefault: null,
+    isSortable: true,
+    isPinnable: false,
+    position: 4,
+    tooltip: 'Overlap in bases',
+  },
+  {
+    id: 'nb_exons',
+    name: '# Exons',
+    apiField: 'nb_exons',
+    isVisibleByDefault: true,
+    pinByDefault: null,
+    isSortable: true,
+    isPinnable: false,
+    position: 5,
+    tooltip: 'Overlapped exon number',
+  },
+  {
+    id: 'overlapping_gene_percent',
+    name: '% Gene',
+    apiField: 'overlapping_gene_percent',
+    isVisibleByDefault: true,
+    pinByDefault: null,
+    isSortable: true,
+    isPinnable: false,
+    position: 6,
+    tooltip: '% overlapped gene length',
+  },
+  {
+    id: 'overlapping_cnv_percent',
+    name: '% CNV',
+    apiField: 'overlapping_cnv_percent',
+    isVisibleByDefault: true,
+    pinByDefault: null,
+    isSortable: true,
+    isPinnable: false,
+    position: 7,
+    tooltip: '% overlapped CNV length',
+  },
+  {
+    id: 'overlap_type',
+    name: 'Type',
+    apiField: 'overlap_type',
+    isVisibleByDefault: true,
+    pinByDefault: null,
+    isSortable: true,
+    isPinnable: false,
+    position: 8,
+    tooltip: 'Gene and CNV overlapping type',
+  },
+];
+
+const columnContentHandler = (columnID: string, dataGene: any, position: number) => {
+  const tableId = selectors.tableId;
+  switch (columnID) {
+    case 'clingen':
+      cy.validateTableFirstRowClass(CommonSelectors.anchorIcon, position, tableId);
+      break;
+    case 'gene':
+      cy.validateTableFirstRowContent(dataGene[columnID], position, tableId);
+      cy.validateTableFirstRowClass(CommonSelectors.anchorIcon, position, tableId);
+      break;
+    case 'overlap_type':
+      cy.validateTableFirstRowClass('svg', position, tableId);
+      break;
+    default:
+      cy.validateTableFirstRowContent(dataGene[columnID], position, tableId);
+      break;
+  }
+};
 
 export const OverlappingGenesModal = {
-  actions: {},
+  actions: {
+    /**
+     * Sorts a column.
+     * @param columnID The ID of the column to sort.
+     */
+    sortColumn(columnID: string) {
+      cy.then(() =>
+        getColumnPosition(CommonSelectors.tableHead(selectors.tableId), tableColumns, columnID).then(position => {
+          if (position !== -1) {
+            cy.sortTableAndWait(position, selectors.tableId);
+          } else {
+            cy.handleColumnNotFound(columnID);
+          }
+        })
+      );
+    },
+  },
 
-  validations: {},
+  validations: {
+    /**
+     * Checks that the overlapping genes modal (and its table) is displayed.
+     */
+    shouldModalOpen() {
+      cy.get(CommonSelectors.animateIn).contains('Overlapping Genes with CNV').should('exist');
+    },
+    /**
+     * Validates the value of the first row for a given column.
+     * @param value The expected value (string or RegExp).
+     * @param columnID The ID of the column to check.
+     */
+    shouldHaveFirstRowValue(value: string | RegExp, columnID: string) {
+      cy.then(() =>
+        getColumnPosition(CommonSelectors.tableHead(selectors.tableId), tableColumns, columnID, selectors.tableHeadRow).then(position => {
+          cy.validateTableFirstRowContent(value, position, selectors.tableId);
+        })
+      );
+    },
+    /**
+     * Validates the link in a specific table cell for a given gene and column.
+     * @param dataGene The overlapping gene object.
+     * @param columnID The ID of the column.
+     */
+    shouldHaveTableCellLink(dataGene: any, columnID: string) {
+      cy.then(() =>
+        getColumnPosition(CommonSelectors.tableHead(selectors.tableId), tableColumns, columnID, selectors.tableHeadRow).then(position => {
+          if (position !== -1) {
+            cy.get(CommonSelectors.tableRow(selectors.tableId)).eq(0).find(CommonSelectors.tableCellData).eq(position).find(CommonSelectors.link).should('have.attr', 'href', getUrlLink(columnID, dataGene));
+          } else {
+            cy.handleColumnNotFound(columnID);
+          }
+        })
+      );
+    },
+    /**
+     * Validates the default visibility of each column.
+     */
+    shouldMatchDefaultColumnVisibility() {
+      tableColumns.forEach(column => {
+        const expectedExist = column.isVisibleByDefault ? 'exist' : 'not.exist';
+        cy.get(`${CommonSelectors.tableHead(selectors.tableId)} ${selectors.tableHeadRow}`).contains(stringToRegExp(column.name, true /*exact*/)).should(expectedExist);
+      });
+    },
+    /**
+     * Validates the default pin state of each column (none are pinnable).
+     */
+    shouldMatchDefaultPinnedColumns() {
+      tableColumns.forEach(column => {
+        cy.then(() =>
+          getColumnPosition(CommonSelectors.tableHead(selectors.tableId), tableColumns, column.id, selectors.tableHeadRow).then(position => {
+            if (position !== -1) {
+              cy.get(selectors.leafHeadCell())
+                .eq(position)
+                .shouldBePinned(column.pinByDefault as 'right' | 'left' | null);
+            } else {
+              cy.handleColumnNotFound(column.id);
+            }
+          })
+        );
+      });
+    },
+    /**
+     * Validates that all columns are displayed in the correct order in the table.
+     */
+    shouldShowAllColumns() {
+      tableColumns.forEach(column => {
+        cy.get(selectors.leafHeadCell()).eq(column.position).contains(stringToRegExp(column.name, true /*exact*/)).should('exist');
+      });
+    },
+    /**
+     * Validates the content of a specific column in the table for a given data.
+     * @param columnID The ID of the column to validate.
+     * @param dataGene The overlapping gene object containing the expected values.
+     */
+    shouldShowColumnContent(columnID: string, dataGene: any) {
+      getColumnPosition(CommonSelectors.tableHead(selectors.tableId), tableColumns, columnID, selectors.tableHeadRow).then(position => {
+        if (position !== -1) {
+          columnContentHandler(columnID, dataGene, position);
+        } else {
+          cy.handleColumnNotFound(columnID);
+        }
+      });
+    },
+    /**
+     * Validates the tooltips on columns.
+     */
+    shouldShowColumnTooltips() {
+      tableColumns.forEach(column => {
+        cy.then(() =>
+          getColumnPosition(CommonSelectors.tableHead(selectors.tableId), tableColumns, column.id, selectors.tableHeadRow).then(position => {
+            if (position !== -1) {
+              cy.get(selectors.leafHeadCell()).eq(position).invoke('css', 'width', '125px' /*Widen column for tooltip access*/).scrollIntoView().should('be.visible');
+              if (column.tooltip) {
+                cy.get(selectors.leafHeadCell()).eq(position).find(CommonSelectors.underlineHeader).should('be.visible').realHover();
+                cy.get(CommonSelectors.tooltipPopper).contains(column.tooltip).first().should('exist');
+                cy.get(`${CommonSelectors.tableHead(selectors.tableId)} tr`).eq(0).click(); // Close the popper
+                cy.get(CommonSelectors.tooltipPopper).should('not.exist');
+              } else {
+                cy.get(selectors.leafHeadCell()).eq(position).realHover();
+                cy.get(CommonSelectors.tooltipPopper).should('not.exist');
+              }
+            } else {
+              cy.handleColumnNotFound(column.id);
+            }
+          })
+        );
+      });
+    },
+    /**
+     * Validates that pinnable columns are correctly marked as pinnable.
+     */
+    shouldShowPinnableColumns() {
+      tableColumns.forEach(column => {
+        cy.then(() =>
+          getColumnPosition(CommonSelectors.tableHead(selectors.tableId), tableColumns, column.id, selectors.tableHeadRow).then(position => {
+            if (position !== -1) {
+              cy.get(selectors.leafHeadCell()).eq(position).shouldBePinnable(column.isPinnable);
+            } else {
+              cy.handleColumnNotFound(column.id);
+            }
+          })
+        );
+      });
+    },
+    /**
+     * Validates that sortable columns are correctly marked as sortable.
+     */
+    shouldShowSortableColumns() {
+      tableColumns.forEach(column => {
+        cy.then(() =>
+          getColumnPosition(CommonSelectors.tableHead(selectors.tableId), tableColumns, column.id, selectors.tableHeadRow).then(position => {
+            if (position !== -1) {
+              cy.get(selectors.leafHeadCell()).eq(position).shouldBeSortable(column.isSortable);
+            } else {
+              cy.handleColumnNotFound(column.id);
+            }
+          })
+        );
+      });
+    },
+    /**
+     * Validates the client-side sorting functionality of a column.
+     * @param columnID The ID of the column to sort.
+     * @param hasUniqueValues The data of the column to sort has unique values.
+     * @param isReverseSorting The first sort of the column is Ascending (compared to Descending by default).
+     */
+    shouldSortColumn(columnID: string, hasUniqueValues: boolean, isReverseSorting: boolean) {
+      cy.then(() =>
+        getColumnPosition(CommonSelectors.tableHead(selectors.tableId), tableColumns, columnID, selectors.tableHeadRow).then(position => {
+          if (position !== -1) {
+            OverlappingGenesModal.actions.sortColumn(columnID);
+            cy.get(CommonSelectors.tableRow(selectors.tableId))
+              .eq(0)
+              .find(CommonSelectors.tableCellData)
+              .eq(position)
+              .invoke('text')
+              .then(biggestValue => {
+                const biggest = biggestValue.trim();
+
+                OverlappingGenesModal.actions.sortColumn(columnID);
+                cy.get(CommonSelectors.tableRow(selectors.tableId))
+                  .eq(0)
+                  .find(CommonSelectors.tableCellData)
+                  .eq(position)
+                  .invoke('text')
+                  .then(smallestValue => {
+                    const smallest = smallestValue.trim();
+                    if (hasUniqueValues) {
+                      if (biggest.localeCompare(smallest) !== 0) {
+                        throw new Error(`Error: "${biggest}" should be equal to "${smallest}" (unique values expected)`);
+                      }
+                    } else if (!isReverseSorting && biggest.localeCompare(smallest) <= 0) {
+                      throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
+                    } else if (isReverseSorting && biggest.localeCompare(smallest) >= 0) {
+                      throw new Error(`Error: "${biggest}" should be < "${smallest}"`);
+                    }
+                  });
+              });
+          }
+        })
+      );
+    },
+  },
 };

--- a/cypress/pom/pages/VariantEntity_Frequency.ts
+++ b/cypress/pom/pages/VariantEntity_Frequency.ts
@@ -172,12 +172,12 @@ const generateTableActionsFunctions = (tableId: string, columns: any[], headRowS
     );
   },
   /**
-   * Sorts a column, optionally using an intercept.
+   * Sorts a column.
    * @param columnID The ID of the column to sort.
    */
   sortColumn(columnID: string) {
     cy.then(() =>
-      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
         if (position !== -1) {
           cy.sortTableAndWait(position, tableId);
         } else {
@@ -290,7 +290,6 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
         if (customColumnContent) {
           customColumnContent(columnID, data, position);
         } else {
-          // Comportement par défaut
           cy.validateTableFirstRowContent(data[columnID], position, tableId);
         }
       } else {

--- a/cypress/pom/shared/Data.ts
+++ b/cypress/pom/shared/Data.ts
@@ -197,4 +197,14 @@ export const data = {
     pe: '2836',
     sqon: '{"content":[{"content":{"field":"name","value":["DRAGEN:GAIN:chr22:23709618-23720246"]},"op":"in"}],"op":"and"}',
   },
+  cnvOverlappingGenes: {
+    gene: 'GUSBP11',
+    cytoband: 'q11.23',
+    length: '57.4 kb',
+    nb_overlap_bases: '7.7 kb',
+    nb_exons: '4',
+    overlapping_gene_percent: '13',
+    overlapping_cnv_percent: '72.24',
+    overlap_type: 'partial',
+  },
 };

--- a/cypress/pom/shared/Selectors.ts
+++ b/cypress/pom/shared/Selectors.ts
@@ -70,7 +70,7 @@ export const CommonSelectors = {
   settingsPopper: '[class*="radix-dropdown-menu-content"]',
   sidebarSection: (section: string) => `[data-sidebar="menu-item"]:contains("${section}") svg`,
   shareIcon: '[class*="lucide-share2"]',
-  sortIcon: '[class*="lucide-arrow-up"], [class*="lucide lucide-arrow-down"]',
+  sortIcon: '[class*="lucide-arrow-up"], [class*="lucide-arrow-down"]',
   starEmptyIcon: '[class*="lucide-star text-bookmark-off"]',
   starFillIcon: '[class*="lucide-star text-bookmark-amber"]',
   statusIcon: (icon: string) => `[class*="lucide-${icon}"]`,

--- a/cypress/pom/shared/Utils.ts
+++ b/cypress/pom/shared/Utils.ts
@@ -268,7 +268,9 @@ export const getUrlLink = (columnID: string, data: any): string | undefined => {
   const strEnd = data.end ? data.end.replace(/,/g, '') : '';
   switch (columnID) {
     case 'clingen':
-      return data.cnv_variant ? `https://search.clinicalgenome.org/kb/regions?page=1&type=GRCh38&region=chr${data.chromosome}%3A${strStart}-${strEnd}&size=25&search=` : undefined;
+      if (data.cnv_variant) return `https://search.clinicalgenome.org/kb/regions?page=1&type=GRCh38&region=chr${data.chromosome}%3A${strStart}-${strEnd}&size=25&search=`;
+      if (data.gene) return `https://search.clinicalgenome.org/kb/genes?search=${data.gene}`;
+      return undefined;
     case 'clinvar':
       return data.clinvar_name ? `https://www.ncbi.nlm.nih.gov/clinvar/variation/${data.clinvar_name}` : undefined;
     case 'cnv_variant':


### PR DESCRIPTION
# feat: SJRA-1676 Add CNV overlapping genes table Cypress tests

## 📌 Context

La modale « Overlapping Genes with CNV » (accessible depuis la table des CNV d'un cas via la cellule `nb_genes`) ne disposait d'aucune couverture E2E. Ce PR ajoute les tests Cypress de cette modale et complète le Page Object Model correspondant, jusque-là vide.

## 📝 Changes

- **Nouveaux specs E2E** sous `cypress/e2e/CaseEntity/Variants/CNV/OverlappingGenes/` :
  - `Columns.cy.ts` : affichage par défaut, ordre, état d'épinglage, tri et tooltips des colonnes.
  - `Hyperlinks.cy.ts` : liens des colonnes `Gene` et `ClinGen`.
  - `InformationDisplayed.cy.ts` : contenu de chaque colonne (Gene, Cytoband, ClinGen, Length, # Bases, # Exons, % Gene, % CNV, Type).
  - `Sort.cy.ts` : tri numérique, en kilobases, en pourcentage et tri multiple.
- **`pom/pages/OverlappingGenesModal.ts`** : implémentation complète du POM (définition des 9 colonnes, action de tri et validations) qui n'était qu'un squelette.
- **`pom/shared/Data.ts`** : ajout du jeu de données `cnvOverlappingGenes` (valeurs attendues pour le gène `GUSBP11`).
- **`pom/shared/Utils.ts`** : `getUrlLink` gère désormais le lien ClinGen au niveau du gène (`/kb/genes?search=`) en plus du lien par région CNV.
- **`pom/shared/Selectors.ts`** : correction du sélecteur `sortIcon` (`lucide lucide-arrow-down` → `lucide-arrow-down`).
- **`pom/pages/VariantEntity_Frequency.ts`** : nettoyage mineur — `sortColumn` n'utilise plus le `headRowSelector` et retrait de commentaires obsolètes.

## 🧪 Tests

- 4 nouveaux specs Cypress couvrant la modale des gènes chevauchant le CNV.
- Tests exécutés localement avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1676](https://d3b.atlassian.net/browse/SJRA-1676)<!-- End JIRA Issues -->

[SJRA-1676]: https://d3b.atlassian.net/browse/SJRA-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ