### PR TITLE
feat: SJRA-1680 Add missing sort Cypress tests on My Network table

### DIFF
--- a/cypress/e2e/VariantEntity/Frequency/MyNetwork_Sort.cy.ts
+++ b/cypress/e2e/VariantEntity/Frequency/MyNetwork_Sort.cy.ts
@@ -1,0 +1,27 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { VariantEntity_Frequency } from 'pom/pages/VariantEntity_Frequency';
+
+describe('VariantEntity - Frequency - MyNetwork - Sort', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.resetTablePreferences();
+    cy.visitVariantFrequencyPage(data.variantGermline.locus_id);
+  };
+
+  it('Alphanumeric', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldSortColumn('primary_condition', false /*hasUniqueValues*/, true /*isReverseSorting*/);
+  });
+
+  it('Frequency', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldSortColumn('freq_all', false /*hasUniqueValues*/, false /*isReverseSorting*/);
+  });
+
+  it('Number', () => {
+    setupTest();
+    VariantEntity_Frequency.myNetwork.validations.shouldSortColumn('homo_all', true /*hasUniqueValues*/, true /*isReverseSorting*/);
+  });
+});

--- a/cypress/pom/pages/VariantEntity_Frequency.ts
+++ b/cypress/pom/pages/VariantEntity_Frequency.ts
@@ -167,7 +167,7 @@ const generateTableActionsFunctions = (tableId: string, columns: any[], headRowS
   pinColumn(columnID: string) {
     cy.then(() =>
       getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
-        cy.pinColumn(position, tableId);
+        cy.pinColumn(position, tableId, headRowSelector);
       })
     );
   },
@@ -177,9 +177,9 @@ const generateTableActionsFunctions = (tableId: string, columns: any[], headRowS
    */
   sortColumn(columnID: string) {
     cy.then(() =>
-      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID).then(position => {
+      getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
         if (position !== -1) {
-          cy.sortTableAndWait(position, tableId);
+          cy.sortTableAndWait(position, tableId, headRowSelector);
         } else {
           cy.handleColumnNotFound(columnID);
         }
@@ -193,7 +193,7 @@ const generateTableActionsFunctions = (tableId: string, columns: any[], headRowS
   unpinColumn(columnID: string) {
     cy.then(() =>
       getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
-        cy.unpinColumn(position, tableId);
+        cy.unpinColumn(position, tableId, headRowSelector);
       })
     );
   },
@@ -337,7 +337,8 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
   shouldPinnedColumn(columnID: string) {
     cy.then(() =>
       getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
-        cy.get(CommonSelectors.tableHeadCell(tableId)).eq(position).shouldBePinned('left');
+        const baseSelector = headRowSelector ? `${CommonSelectors.tableHead(tableId)} ${headRowSelector} ${CommonSelectors.tableCellHead}` : CommonSelectors.tableHeadCell(tableId);
+        cy.get(baseSelector).eq(position).shouldBePinned('left');
       })
     );
   },
@@ -365,7 +366,8 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
   shouldUnpinnedColumn(columnID: string) {
     cy.then(() =>
       getColumnPosition(CommonSelectors.tableHead(tableId), columns, columnID, headRowSelector).then(position => {
-        cy.get(CommonSelectors.tableHeadCell(tableId)).eq(position).shouldBePinned(null);
+        const baseSelector = headRowSelector ? `${CommonSelectors.tableHead(tableId)} ${headRowSelector} ${CommonSelectors.tableCellHead}` : CommonSelectors.tableHeadCell(tableId);
+        cy.get(baseSelector).eq(position).shouldBePinned(null);
       })
     );
   },
@@ -401,7 +403,6 @@ const generateTableValidationsFunctions = (tableId: string, columns: any[], cust
                       throw new Error(`Error: "${biggest}" should be equal to "${smallest}" (unique values expected)`);
                     }
                   } else if (!isReverseSorting && biggest.localeCompare(smallest) <= 0) {
-                    throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
                     throw new Error(`Error: "${biggest}" should be > "${smallest}"`);
                   } else if (isReverseSorting && biggest.localeCompare(smallest) >= 0) {
                     throw new Error(`Error: "${biggest}" should be < "${smallest}"`);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -110,9 +110,13 @@ Cypress.Commands.add('logout', () => {
  * Pins a column in the table to the left side.
  * @param position The column position index to pin.
  * @param tableId The table ID to pin the column in (default: '').
+ * @param headRowSelector Optional selector to scope the lookup to a specific header row (e.g. `'tr:eq(1)'`) for tables with multi-level headers.
  */
-Cypress.Commands.add('pinColumn', (position: number, tableId: string = '') => {
-  cy.get(`${CommonSelectors.tableHeadCell(tableId)}`)
+Cypress.Commands.add('pinColumn', (position: number, tableId: string = '', headRowSelector?: string) => {
+  const headCellSelector = headRowSelector
+    ? `${CommonSelectors.tableHead(tableId)} ${headRowSelector} ${CommonSelectors.tableCellHead}`
+    : CommonSelectors.tableHeadCell(tableId);
+  cy.get(headCellSelector)
     .eq(position)
     .find(CommonSelectors.pinIcon)
     .click({ force: true });
@@ -277,13 +281,17 @@ Cypress.Commands.add('sortTableAndIntercept', (position: number, routeMatcher: s
  * Sorts a table column and waits for a fixed duration.
  * @param position The column position index to sort.
  * @param tableId The table ID to sort (default: '').
+ * @param headRowSelector Optional selector to scope the lookup to a specific header row (e.g. `'tr:eq(1)'`) for tables with multi-level headers.
  */
-Cypress.Commands.add('sortTableAndWait', (position: number, tableId: string = '') => {
-  cy.get(`${CommonSelectors.tableHeadCell(tableId)}`)
+Cypress.Commands.add('sortTableAndWait', (position: number, tableId: string = '', headRowSelector?: string) => {
+  const headCellSelector = headRowSelector
+    ? `${CommonSelectors.tableHead(tableId)} ${headRowSelector} ${CommonSelectors.tableCellHead}`
+    : CommonSelectors.tableHeadCell(tableId);
+  cy.get(headCellSelector)
     .eq(position)
     .find(CommonSelectors.sortIcon)
     .click({ force: true });
-  cy.get(`${CommonSelectors.tableHeadCell(tableId)}`)
+  cy.get(headCellSelector)
     .eq(position)
     .find(CommonSelectors.sortIcon)
     .should('exist');
@@ -293,9 +301,13 @@ Cypress.Commands.add('sortTableAndWait', (position: number, tableId: string = ''
  * Unpins a column in the table.
  * @param position The column position index to unpin.
  * @param tableId The table ID to unpin the column in (default: '').
+ * @param headRowSelector Optional selector to scope the lookup to a specific header row (e.g. `'tr:eq(1)'`) for tables with multi-level headers.
  */
-Cypress.Commands.add('unpinColumn', (position: number, tableId: string = '') => {
-  cy.get(`${CommonSelectors.tableHeadCell(tableId)}`)
+Cypress.Commands.add('unpinColumn', (position: number, tableId: string = '', headRowSelector?: string) => {
+  const headCellSelector = headRowSelector
+    ? `${CommonSelectors.tableHead(tableId)} ${headRowSelector} ${CommonSelectors.tableCellHead}`
+    : CommonSelectors.tableHeadCell(tableId);
+  cy.get(headCellSelector)
     .eq(position)
     .find(CommonSelectors.pinIcon)
     .click({ force: true });

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -21,7 +21,7 @@ declare namespace Cypress {
     hideColumn(column: string): cy & CyEventEmitter;
     login(): cy & CyEventEmitter;
     logout(): cy & CyEventEmitter;
-    pinColumn(position: number, tableId: string = ''): cy & CyEventEmitter;
+    pinColumn(position: number, tableId: string = '', headRowSelector?: string): cy & CyEventEmitter;
     resetColumns(): cy & CyEventEmitter;
     setLang(lang: string): cy & CyEventEmitter;
     setTenant(): cy & CyEventEmitter;
@@ -33,8 +33,8 @@ declare namespace Cypress {
     shouldHaveTooltip(column: any): cy & CyEventEmitter;
     showColumn(column: string | RegExp): cy & CyEventEmitter;
     sortTableAndIntercept(position: number, routeMatcher: string, nbCalls: number, tableId: string = ''): cy & CyEventEmitter;
-    sortTableAndWait(position: number, tableId: string = ''): cy & CyEventEmitter;
-    unpinColumn(position: number, tableId: string = ''): cy & CyEventEmitter;
+    sortTableAndWait(position: number, tableId: string = '', headRowSelector?: string): cy & CyEventEmitter;
+    unpinColumn(position: number, tableId: string = '', headRowSelector?: string): cy & CyEventEmitter;
     validatePillSelectedQuery(facetTitle: string | RegExp, values: (string | RegExp)[], eq?: number): cy & CyEventEmitter;
     validateTableFirstRowAttr(expectedAttr: string, expectedValue: string, columnIndex: number, tableId: string = ''): cy & CyEventEmitter;
     validateTableFirstRowClass(expectedClass: string, columnIndex: number, tableId: string = ''): cy & CyEventEmitter;


### PR DESCRIPTION
# feat: SJRA-1680 Add missing sort Cypress tests on My Network table

## 📌 Context

La table **My Network** de la page Variant Entity (onglet Frequency) ne disposait pas de tests Cypress couvrant le tri de ses colonnes. Cette table utilise un en-tête multi-niveaux, ce qui empêchait les commandes de tri/épinglage existantes de cibler la bonne rangée d'en-tête. Ce PR ajoute les tests de tri manquants et adapte les utilitaires partagés pour supporter ce type de table.

## 📝 Changes

- Ajout du spec `cypress/e2e/VariantEntity/Frequency/MyNetwork_Sort.cy.ts` couvrant trois cas de tri sur la table My Network : alphanumérique (`primary_condition`), fréquence (`freq_all`) et numérique (`homo_all`).
- Ajout d'un paramètre optionnel `headRowSelector` aux commandes `pinColumn`, `sortTableAndWait` et `unpinColumn` ([commands.ts](cypress/support/commands.ts)) afin de cibler une rangée d'en-tête précise dans les tables à en-têtes multi-niveaux.
- Propagation de `headRowSelector` dans les fonctions du POM [VariantEntity_Frequency.ts](cypress/pom/pages/VariantEntity_Frequency.ts) (`sortColumn`, `pinColumn`, `unpinColumn`, `shouldPinnedColumn`, `shouldUnpinnedColumn`), avec construction du sélecteur de cellule d'en-tête adapté.
- Mise à jour des déclarations de types [index.d.ts](cypress/support/index.d.ts) pour refléter le nouveau paramètre.
- Suppression d'une ligne `throw new Error` dupliquée (code mort) dans la validation de tri du POM.

## 🧪 Tests

- Nouveau spec `MyNetwork_Sort.cy.ts` (3 tests : Alphanumeric, Frequency, Number).
- Tests exécutés localement avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1680](https://d3b.atlassian.net/browse/SJRA-1680)<!-- End JIRA Issues -->

[SJRA-1680]: https://d3b.atlassian.net/browse/SJRA-1680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ