### PR TITLE
fix: SJRA-1681 Fix filtering on `task_id` when listing occurrences

### DIFF
--- a/backend/internal/repository/germline_snv_occurrences.go
+++ b/backend/internal/repository/germline_snv_occurrences.go
@@ -54,14 +54,14 @@ func (r *GermlineSNVOccurrencesRepository) GetOccurrences(ctx context.Context, c
 	// 		LEFT JOIN <schema>.occurrence_flag flag ON flag.occurrence_id = g_snv_o.locus_id AND flag.task_id = g_snv_o.task_id AND flag.seq_id = ? AND flag.case_id = ?
 	// WHERE g_snv_o.locus_id in (
 	//	SELECT g_snv_o.locus_id FROM germline__snv__occurrence JOIN ... WHERE quality > 100 ORDER BY ad_ratio DESC LIMIT 10
-	// ) AND g_snv_o.seq_id=? AND g_snv_o.part=? AND v.locus_id=g_snv_o.locus_id ORDER BY ad_ratio DESC
+	// ) AND g_snv_o.seq_id=? AND g_snv_o.task_id=? AND g_snv_o.part=? AND v.locus_id=g_snv_o.locus_id ORDER BY ad_ratio DESC
 	tx = tx.Select("g_snv_o.locus_id")
 	tx = db.Table("(germline__snv__occurrence g_snv_o, snv__variant v)").
 		Joins(fmt.Sprintf("LEFT JOIN (SELECT DISTINCT locus_id, case_id, sequencing_id FROM %s.interpretation_germline) i ON i.locus_id = g_snv_o.locus_id AND i.sequencing_id = ? AND i.case_id = ?", schema), fmt.Sprintf("%d", seqId), fmt.Sprintf("%d", caseId)).
 		Joins(fmt.Sprintf("LEFT JOIN (SELECT DISTINCT occurrence_id, case_id, seq_id, task_id FROM %s.occurrence_note WHERE deleted = false) note ON note.occurrence_id = g_snv_o.locus_id AND note.task_id = g_snv_o.task_id AND note.seq_id = ? AND note.case_id = ?", schema), seqId, caseId).
 		Joins(fmt.Sprintf("LEFT JOIN %s.occurrence_flag flag ON flag.occurrence_id = g_snv_o.locus_id AND flag.task_id = g_snv_o.task_id AND flag.seq_id = ? AND flag.case_id = ?", schema), seqId, caseId).
 		Select(columns).
-		Where("g_snv_o.seq_id = ? and part=? and v.locus_id = g_snv_o.locus_id and g_snv_o.locus_id in (?)", seqId, part, tx)
+		Where("g_snv_o.seq_id = ? and g_snv_o.task_id = ? and part=? and v.locus_id = g_snv_o.locus_id and g_snv_o.locus_id in (?)", seqId, taskId, part, tx)
 
 	utils.AddSort(tx, userQuery) //We re-apply the sort on the outer query
 

--- a/backend/internal/repository/germline_snv_occurrences_test.go
+++ b/backend/internal/repository/germline_snv_occurrences_test.go
@@ -190,31 +190,41 @@ func Test_Germline_SNV_GetOccurrences_Return_Occurrences_That_Match_Filters(t *t
 	})
 }
 
-// Reproduces the cross-case leak scenario: the `multiple` fixture has two rows
-// at seq_id=1 with different task_ids — task_id=1 for case 1's annotation,
-// task_id=200 simulating a second case that reuses the same sequencing. The
-// repository must filter on task_id so each case sees only its own occurrence.
+// Reproduces the cross-task leak scenario: the `multiple` fixture has, at the
+// same seq_id=1/part, locus 2000 under BOTH task_id=5 (case 1's annotation) and
+// task_id=200 (a second case reusing the same sequencing). Because the list
+// query's outer SELECT re-joins the occurrence table, filtering only on seq_id +
+// `locus_id IN (<task-filtered subquery>)` is not enough — locus 2000 is IN both
+// subqueries, so without an explicit task_id on the outer query each case leaks
+// the other's row for that locus.
 func Test_Germline_SNV_GetOccurrences_TaskIdScopesToOwningCase(t *testing.T) {
 	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 		repo := NewGermlineSNVOccurrencesRepository(db)
 		query, err := types.NewListQueryFromSqon(GermlineSNVQueryConfigForTest, allGermlineSNVFields, nil, nil, nil)
 		assert.NoError(t, err)
 
-		// Case 1 (annotation task_id=5) sees its own loci at seq_id=1, not the
-		// row attached to task_id=200.
+		// Case 1 (task_id=5) sees only its own loci {1000,2000} at seq_id=1, each
+		// stamped task_id=5 — never the task_id=200 row for shared locus 2000.
 		case1Occurrences, err := repo.GetOccurrences(t.Context(), 1, 1, 5, query)
 		assert.NoError(t, err)
+		case1Locus := make([]string, 0, len(case1Occurrences))
 		for _, occ := range case1Occurrences {
-			assert.NotEqual(t, "5000", occ.LocusId, "task_id=5 query must not return case 2's occurrence (locus 5000)")
+			assert.Equal(t, 5, occ.TaskId, "task_id=5 query leaked an occurrence from another task")
+			case1Locus = append(case1Locus, occ.LocusId)
 		}
+		assert.ElementsMatch(t, []string{"1000", "2000"}, case1Locus)
 
-		// Case 2 (annotation task_id=200, reusing seq_id=1) sees only the
-		// task_id=200 row, not case 1's loci 1000/2000.
+		// Case 2 (task_id=200, reusing seq_id=1) sees only its locus_id {2000,5000},
+		// each stamped task_id=200 — never case 1's task_id=5 row for shared
+		// locus 2000.
 		case2Occurrences, err := repo.GetOccurrences(t.Context(), 2, 1, 200, query)
 		assert.NoError(t, err)
-		if assert.Len(t, case2Occurrences, 1) {
-			assert.EqualValues(t, "5000", case2Occurrences[0].LocusId)
+		case2Locus := make([]string, 0, len(case2Occurrences))
+		for _, occ := range case2Occurrences {
+			assert.Equal(t, 200, occ.TaskId, "task_id=200 query leaked an occurrence from another task")
+			case2Locus = append(case2Locus, occ.LocusId)
 		}
+		assert.ElementsMatch(t, []string{"2000", "5000"}, case2Locus)
 	})
 }
 

--- a/backend/internal/repository/germline_snv_occurrences_test.go
+++ b/backend/internal/repository/germline_snv_occurrences_test.go
@@ -207,24 +207,24 @@ func Test_Germline_SNV_GetOccurrences_TaskIdScopesToOwningCase(t *testing.T) {
 		// stamped task_id=5 — never the task_id=200 row for shared locus 2000.
 		case1Occurrences, err := repo.GetOccurrences(t.Context(), 1, 1, 5, query)
 		assert.NoError(t, err)
-		case1Locus := make([]string, 0, len(case1Occurrences))
+		case1LocusIds := make([]string, 0, len(case1Occurrences))
 		for _, occ := range case1Occurrences {
 			assert.Equal(t, 5, occ.TaskId, "task_id=5 query leaked an occurrence from another task")
-			case1Locus = append(case1Locus, occ.LocusId)
+			case1LocusIds = append(case1LocusIds, occ.LocusId)
 		}
-		assert.ElementsMatch(t, []string{"1000", "2000"}, case1Locus)
+		assert.ElementsMatch(t, []string{"1000", "2000"}, case1LocusIds)
 
-		// Case 2 (task_id=200, reusing seq_id=1) sees only its locus_id {2000,5000},
+		// Case 2 (task_id=200, reusing seq_id=1) sees only its locus_id(s) {2000,5000},
 		// each stamped task_id=200 — never case 1's task_id=5 row for shared
 		// locus 2000.
 		case2Occurrences, err := repo.GetOccurrences(t.Context(), 2, 1, 200, query)
 		assert.NoError(t, err)
-		case2Locus := make([]string, 0, len(case2Occurrences))
+		case2LocusIds := make([]string, 0, len(case2Occurrences))
 		for _, occ := range case2Occurrences {
 			assert.Equal(t, 200, occ.TaskId, "task_id=200 query leaked an occurrence from another task")
-			case2Locus = append(case2Locus, occ.LocusId)
+			case2LocusIds = append(case2LocusIds, occ.LocusId)
 		}
-		assert.ElementsMatch(t, []string{"2000", "5000"}, case2Locus)
+		assert.ElementsMatch(t, []string{"2000", "5000"}, case2LocusIds)
 	})
 }
 

--- a/backend/internal/repository/somatic_snv_occurrences.go
+++ b/backend/internal/repository/somatic_snv_occurrences.go
@@ -49,14 +49,14 @@ func (r *SomaticSNVOccurrencesRepository) GetOccurrences(ctx context.Context, ca
 	// 		LEFT JOIN <schema>.occurrence_flag flag ON flag.occurrence_id = s_snv_o.locus_id AND flag.task_id = s_snv_o.task_id AND flag.seq_id = ? AND flag.case_id = ?
 	// WHERE s_snv_o.locus_id in (
 	//	SELECT s_snv_o.locus_id FROM somatic__snv__occurrence JOIN ... WHERE quality > 100 ORDER BY ad_ratio DESC LIMIT 10
-	// ) AND s_snv_o.tumor_seq_id=? AND s_snv_o.part=? AND v.locus_id=s_snv_o.locus_id ORDER BY ad_ratio DESC
+	// ) AND s_snv_o.tumor_seq_id=? AND s_snv_o.task_id=? AND s_snv_o.part=? AND v.locus_id=s_snv_o.locus_id ORDER BY ad_ratio DESC
 	tx = tx.Select("s_snv_o.locus_id")
 	tx = db.Table("(somatic__snv__occurrence s_snv_o, snv__variant v)").
 		Joins(fmt.Sprintf("LEFT JOIN (SELECT DISTINCT locus_id, case_id, sequencing_id FROM %s.interpretation_somatic) i ON i.locus_id = s_snv_o.locus_id AND i.sequencing_id = ? AND i.case_id = ?", schema), fmt.Sprintf("%d", seqId), fmt.Sprintf("%d", caseId)).
 		Joins(fmt.Sprintf("LEFT JOIN (SELECT DISTINCT occurrence_id, case_id, seq_id, task_id FROM %s.occurrence_note WHERE deleted = false) note ON note.occurrence_id = s_snv_o.locus_id AND note.task_id = s_snv_o.task_id AND note.seq_id = ? AND note.case_id = ?", schema), seqId, caseId).
 		Joins(fmt.Sprintf("LEFT JOIN %s.occurrence_flag flag ON flag.occurrence_id = s_snv_o.locus_id AND flag.task_id = s_snv_o.task_id AND flag.seq_id = ? AND flag.case_id = ?", schema), seqId, caseId).
 		Select(columns).
-		Where("s_snv_o.tumor_seq_id = ? and part=? and v.locus_id = s_snv_o.locus_id and s_snv_o.locus_id in (?)", seqId, part, tx)
+		Where("s_snv_o.tumor_seq_id = ? and s_snv_o.task_id = ? and part=? and v.locus_id = s_snv_o.locus_id and s_snv_o.locus_id in (?)", seqId, taskId, part, tx)
 
 	utils.AddSort(tx, userQuery) //We re-apply the sort on the outer query
 

--- a/backend/internal/repository/somatic_snv_occurrences_test.go
+++ b/backend/internal/repository/somatic_snv_occurrences_test.go
@@ -161,9 +161,8 @@ func Test_Somatic_SNV_GetOccurrences_TaskIdScopesToOwningCase(t *testing.T) {
 		}
 		assert.ElementsMatch(t, []string{"1000", "2000", "3000"}, case71LocusIds)
 
-		// Case 72 (task_id=202, reusing tumor_seq_id=74) sees only its locus_ids(s)
-		// {2000,5000}, each stamped task_id=202 — never case 71's task_id=74 row
-		// for shared locus 2000.
+		// Case 72 (task_id=202, reusing tumor_seq_id=74) sees only its locus_ids(s) {2000,5000},
+		// each stamped task_id=202 — never case 71's task_id=74 row for shared locus 2000.
 		case72Occurrences, err := repo.GetOccurrences(t.Context(), 72, 74, 202, query)
 		assert.NoError(t, err)
 		case72LocusIds := make([]string, 0, len(case72Occurrences))

--- a/backend/internal/repository/somatic_snv_occurrences_test.go
+++ b/backend/internal/repository/somatic_snv_occurrences_test.go
@@ -137,31 +137,41 @@ func Test_Somatic_SNV_GetOccurrences_Return_Occurrences_That_Match_Filters(t *te
 	})
 }
 
-// Reproduces the cross-case leak scenario: the `multiple` fixture has two
-// rows at tumor_seq_id=74 with different task_ids — task_id=74 for case 71's
-// somatic annotation, task_id=202 simulating a second case (72) that reuses
-// the same sequencing. The repository must filter on task_id so each case
-// sees only its own occurrence.
+// Reproduces the cross-task leak scenario: the `multiple` fixture has, at the
+// same tumor_seq_id=74/part, locus 2000 under BOTH task_id=74 (case 71's
+// somatic annotation) and task_id=202 (a second case 72 reusing the same
+// sequencing). Because the list query's outer SELECT re-joins the occurrence
+// table, filtering only on tumor_seq_id + `locus_id IN (<task-filtered subquery>)`
+// is not enough — locus 2000 is IN both subqueries, so without an explicit
+// task_id on the outer query, each case leaks the other's row for that locus.
 func Test_Somatic_SNV_GetOccurrences_TaskIdScopesToOwningCase(t *testing.T) {
 	testutils.ParallelTestWithStarrocks(t, "multiple", func(t *testing.T, db *gorm.DB) {
 		repo := NewSomaticSNVOccurrencesRepository(db)
 		query, err := types.NewListQueryFromSqon(SomaticSNVQueryConfigForTest, allSomaticSNVFields, nil, nil, nil)
 		assert.NoError(t, err)
 
-		// Case 71 (task_id=74) sees its own loci, not the task_id=202 row.
+		// Case 71 (task_id=74) sees only its own loci {1000,2000,3000}, each
+		// stamped task_id=74 — never the task_id=202 row for shared locus 2000.
 		case71Occurrences, err := repo.GetOccurrences(t.Context(), 71, 74, 74, query)
 		assert.NoError(t, err)
+		case71Loci := make([]string, 0, len(case71Occurrences))
 		for _, occ := range case71Occurrences {
-			assert.NotEqual(t, "5000", occ.LocusId, "task_id=74 query must not return case 72's occurrence (locus 5000)")
+			assert.Equal(t, 74, occ.TaskId, "task_id=74 query leaked an occurrence from another task")
+			case71Loci = append(case71Loci, occ.LocusId)
 		}
+		assert.ElementsMatch(t, []string{"1000", "2000", "3000"}, case71Loci)
 
-		// Case 72 (task_id=202, reusing tumor_seq_id=74) sees only the
-		// task_id=202 row, not case 71's loci 1000/2000/3000.
+		// Case 72 (task_id=202, reusing tumor_seq_id=74) sees only its loci
+		// {2000,5000}, each stamped task_id=202 — never case 71's task_id=74 row
+		// for shared locus 2000.
 		case72Occurrences, err := repo.GetOccurrences(t.Context(), 72, 74, 202, query)
 		assert.NoError(t, err)
-		if assert.Len(t, case72Occurrences, 1) {
-			assert.EqualValues(t, "5000", case72Occurrences[0].LocusId)
+		case72Loci := make([]string, 0, len(case72Occurrences))
+		for _, occ := range case72Occurrences {
+			assert.Equal(t, 202, occ.TaskId, "task_id=202 query leaked an occurrence from another task")
+			case72Loci = append(case72Loci, occ.LocusId)
 		}
+		assert.ElementsMatch(t, []string{"2000", "5000"}, case72Loci)
 	})
 }
 

--- a/backend/internal/repository/somatic_snv_occurrences_test.go
+++ b/backend/internal/repository/somatic_snv_occurrences_test.go
@@ -154,24 +154,24 @@ func Test_Somatic_SNV_GetOccurrences_TaskIdScopesToOwningCase(t *testing.T) {
 		// stamped task_id=74 — never the task_id=202 row for shared locus 2000.
 		case71Occurrences, err := repo.GetOccurrences(t.Context(), 71, 74, 74, query)
 		assert.NoError(t, err)
-		case71Loci := make([]string, 0, len(case71Occurrences))
+		case71LocusIds := make([]string, 0, len(case71Occurrences))
 		for _, occ := range case71Occurrences {
 			assert.Equal(t, 74, occ.TaskId, "task_id=74 query leaked an occurrence from another task")
-			case71Loci = append(case71Loci, occ.LocusId)
+			case71LocusIds = append(case71LocusIds, occ.LocusId)
 		}
-		assert.ElementsMatch(t, []string{"1000", "2000", "3000"}, case71Loci)
+		assert.ElementsMatch(t, []string{"1000", "2000", "3000"}, case71LocusIds)
 
-		// Case 72 (task_id=202, reusing tumor_seq_id=74) sees only its loci
+		// Case 72 (task_id=202, reusing tumor_seq_id=74) sees only its locus_ids(s)
 		// {2000,5000}, each stamped task_id=202 — never case 71's task_id=74 row
 		// for shared locus 2000.
 		case72Occurrences, err := repo.GetOccurrences(t.Context(), 72, 74, 202, query)
 		assert.NoError(t, err)
-		case72Loci := make([]string, 0, len(case72Occurrences))
+		case72LocusIds := make([]string, 0, len(case72Occurrences))
 		for _, occ := range case72Occurrences {
 			assert.Equal(t, 202, occ.TaskId, "task_id=202 query leaked an occurrence from another task")
-			case72Loci = append(case72Loci, occ.LocusId)
+			case72LocusIds = append(case72LocusIds, occ.LocusId)
 		}
-		assert.ElementsMatch(t, []string{"2000", "5000"}, case72Loci)
+		assert.ElementsMatch(t, []string{"2000", "5000"}, case72LocusIds)
 	})
 }
 

--- a/backend/test/data/multiple/germline__snv__occurrence.tsv
+++ b/backend/test/data/multiple/germline__snv__occurrence.tsv
@@ -3,3 +3,4 @@ part	seq_id	task_id	locus_id	gq	filter	zygosity	ad_ratio
 1	2	5	1000	100	PASS	HET	1.0
 1	1	5	2000	100	LowQuality	HET	1.0
 1	1	200	5000	100	PASS	HET	1.0
+1	1	200	2000	100	PASS	HET	1.0

--- a/backend/test/data/multiple/somatic__snv__occurrence.tsv
+++ b/backend/test/data/multiple/somatic__snv__occurrence.tsv
@@ -3,3 +3,4 @@ part	task_id	tumor_seq_id	locus_id	normal_seq_id	tumor_ad_ratio	info_hotspotalle
 1	74	74	2000	73	0.77	0
 1	74	74	3000	73	0.88	1
 1	202	74	5000	73	0.66	1
+1	202	74	2000	73	0.77	0


### PR DESCRIPTION
## 📌 Context

The SNV occurrences `list` endpoint could return rows belonging to the wrong `task_id`. Its query filters `task_id` on an inner subquery but the outer SELECT re-joins the occurrence table and matched only on `seq_id` + `locus_id IN (subquery)`. 

When the same locus exists under more than one task for a sequencing (e.g. two cases reusing the same sequencing, or reprocessing), the outer query leaked the other task's rows and produced duplicate loci. 

## 📝 Changes

- Add the missing `task_id` predicate to the outer WHERE of the `list` query for both somatic and germline SNV occurrences.

## 🧪 Tests

- Extended the existing `TaskIdScopesToOwningCase` repository tests (somatic + germline) with a fixture row that puts the same locus under two `task_id`s at the same seq/part — the collision the old fixtures didn't exercise. Tests now assert every returned occurrence carries the requested `task_id` and the exact loci set. Verified they fail on the pre-fix code and pass after.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- [SJRA-1681](https://d3b.atlassian.net/browse/SJRA-1681)

<!-- End JIRA Issues -->



[SJRA-1681]: https://d3b.atlassian.net/browse/SJRA-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ