### PR TITLE
feat(grid): SJRA-1627 add resizable-grid component

### DIFF
--- a/frontend/components/.storybook/main.ts
+++ b/frontend/components/.storybook/main.ts
@@ -36,6 +36,9 @@ const config: StorybookConfig = {
   viteFinal: async (config) => {
     return mergeConfig(config, {
       plugins: [tsConfigPaths()],
+      define: {
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? 'development'),
+      },
     });
   },
   typescript: {

--- a/frontend/components/base/grids/grid-card.tsx
+++ b/frontend/components/base/grids/grid-card.tsx
@@ -1,0 +1,107 @@
+import { forwardRef, type ReactNode } from 'react';
+import { GripVerticalIcon, XIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Button } from '../shadcn/button';
+import { Card, CardContent, CardHeader } from '../shadcn/card';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../shadcn/tooltip';
+import { useI18n } from '@/components/hooks/i18n';
+
+export type CardLayoutItem = {
+  id: string;
+  isStatic: boolean;
+  isDraggable: boolean;
+  isResizable: boolean;
+};
+
+type CloseProps = {
+  id: string;
+  onClose: (id: string) => void;
+  closeText?: string;
+};
+
+export type GridCardProps = {
+  title: ReactNode;
+  content: ReactNode;
+  children?: ReactNode;
+} & CardLayoutItem &
+  CloseProps;
+
+function GridCardCloseButton({ id, onClose, closeText }: CloseProps) {
+  const { t } = useI18n();
+  if (closeText) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="2xs"
+              iconOnly
+              aria-label={closeText}
+              onClick={e => {
+                e.preventDefault();
+                onClose(id);
+              }}
+            >
+              <XIcon />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{closeText}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="2xs"
+      iconOnly
+      aria-label={t('common.close')}
+      onClick={e => {
+        e.preventDefault();
+        onClose(id);
+      }}
+    >
+      <XIcon />
+    </Button>
+  );
+}
+
+/**
+ * forwardRef is needed for react-grid-layout
+ * children: used by react-grid-layout to add resize handle
+ */
+const GridCard = forwardRef<HTMLDivElement, GridCardProps>(function GridCard(
+  { title, content, onClose, closeText, children, id, isStatic, isDraggable, ...rest },
+  ref,
+) {
+  const withHandle = !isStatic && isDraggable;
+  const closable = !isStatic;
+
+  return (
+    <div ref={ref} className="h-full w-full" {...rest}>
+      <Card size="sm" className="h-full w-full overflow-hidden">
+        <CardHeader
+          size="sm"
+          className={cn('flex flex-row items-center gap-2 py-1', {
+            'rgl-drag-zone cursor-move': withHandle,
+          })}
+        >
+          {withHandle && <GripVerticalIcon size={16} />}
+          <span className="flex-1 truncate text-sm font-semibold">{title}</span>
+          {closable && <GridCardCloseButton id={id} onClose={onClose} closeText={closeText} />}
+        </CardHeader>
+        <CardContent className="flex-1 min-h-0 p-2 overflow-hidden **:data-[slot=chart]:aspect-auto! **:data-[slot=chart]:h-full **:data-[slot=chart]:w-full">
+          {content}
+        </CardContent>
+      </Card>
+      {children}
+    </div>
+  );
+});
+
+export default GridCard;

--- a/frontend/components/base/grids/grid-options-menu-settings.tsx
+++ b/frontend/components/base/grids/grid-options-menu-settings.tsx
@@ -1,0 +1,72 @@
+import { SettingsIcon } from 'lucide-react';
+import { Button } from '../shadcn/button';
+import { Checkbox } from '../shadcn/checkbox';
+import { Popover, PopoverContent, PopoverTrigger } from '../shadcn/popover';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../shadcn/tooltip';
+import { GridCards } from './grid';
+import { useI18n } from '@/components/hooks/i18n';
+
+type GridOptionsMenuSettingsProps = {
+  activeCards: string[];
+  cards: GridCards;
+  tooltipText: string;
+  isPristine: boolean;
+  onCheckedChange: (id: string, checked: boolean) => void;
+  onReset: () => void;
+};
+
+export function GridOptionsMenuSettings({
+  cards,
+  activeCards,
+  isPristine,
+  tooltipText,
+  onCheckedChange,
+  onReset,
+}: GridOptionsMenuSettingsProps) {
+  const { t } = useI18n();
+  return (
+    <Popover>
+      <TooltipProvider>
+        <Tooltip>
+          <PopoverTrigger asChild>
+            <TooltipTrigger asChild>
+              <Button type="button" variant="ghost" size="2xs" iconOnly aria-label={tooltipText}>
+                <SettingsIcon />
+              </Button>
+            </TooltipTrigger>
+          </PopoverTrigger>
+          <TooltipContent>{tooltipText}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <PopoverContent align="start" sideOffset={4} className="w-auto p-3">
+        <div className="flex flex-col gap-2">
+          <div className="flex max-h-78.75 flex-col gap-2 overflow-auto">
+            {cards.map(card => (
+              <label key={card.id} className="flex cursor-pointer items-center gap-2 text-sm">
+                <Checkbox
+                  checked={activeCards.includes(card.id)}
+                  onCheckedChange={checked => onCheckedChange(card.id, checked as boolean)}
+                />
+                {card.title}
+              </label>
+            ))}
+          </div>
+          <div className="text-right">
+            <Button
+              type="button"
+              variant="link"
+              size="xs"
+              className="h-auto p-0"
+              disabled={isPristine}
+              onClick={onReset}
+            >
+              {t('common.grid.reset')}
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default GridOptionsMenuSettings;

--- a/frontend/components/base/grids/grid-skeleton.tsx
+++ b/frontend/components/base/grids/grid-skeleton.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import { Responsive, useContainerWidth, ResponsiveLayouts } from 'react-grid-layout';
+import { Skeleton } from '../shadcn/skeleton';
+import GridCard from './grid-card';
+import { GridCards } from './grid';
+
+type GridSkeletonProps = {
+  cards: GridCards;
+  defaultLayouts: ResponsiveLayouts;
+  hasMenuOptionsSettings: boolean;
+};
+
+/**
+ * In loading state, disable drag and resize by forcing static to every card.
+ */
+function GridSkeleton({ defaultLayouts, cards, hasMenuOptionsSettings }: GridSkeletonProps) {
+  const { width, containerRef, mounted } = useContainerWidth();
+  const skeletonLayouts = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(defaultLayouts).map(([breakpoint, items]) => [
+          breakpoint,
+          (items ?? []).map(item => ({ ...item, static: true })),
+        ]),
+      ) as ResponsiveLayouts,
+
+    [defaultLayouts],
+  );
+
+  return (
+    <div ref={containerRef} className="w-full">
+      {mounted && (
+        <div>
+          {hasMenuOptionsSettings && (
+            <div className="flex justify-end">
+              <Skeleton className="h-8 w-8" />
+            </div>
+          )}
+          <Responsive layouts={skeletonLayouts} width={width}>
+            {cards.map(card => (
+              <GridCard
+                key={card.id}
+                id={card.id}
+                title={<Skeleton className="h-4 w-32" />}
+                content={<Skeleton className="h-full w-full" />}
+                onClose={() => {}}
+                isStatic={true}
+                isResizable={false}
+                isDraggable={false}
+              />
+            ))}
+          </Responsive>
+        </div>
+      )}
+    </div>
+  );
+}
+export default GridSkeleton;

--- a/frontend/components/base/grids/grid.tsx
+++ b/frontend/components/base/grids/grid.tsx
@@ -1,0 +1,353 @@
+import { Responsive, useContainerWidth, ResponsiveLayouts, Layout } from 'react-grid-layout';
+import GridCard, { CardLayoutItem } from './grid-card';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import 'react-grid-layout/css/styles.css';
+import 'react-resizable/css/styles.css';
+import GridOptionsMenuSettings from './grid-options-menu-settings';
+import { userPreferenceApi } from '@/utils/api';
+import { UserPreference } from '@/api/api';
+
+import useSWRMutation from 'swr/mutation';
+import useSWRImmutable from 'swr/immutable';
+import GridSkeleton from './grid-skeleton';
+
+export type GridCards = {
+  id: string;
+  content: React.ReactNode;
+  title: string | React.ReactNode;
+}[];
+
+type OptionsMenuSettings = { visible: true; tooltipText: string } | { visible: false; tooltipText?: string };
+
+type GridProps = {
+  id: string;
+  cards: GridCards;
+  defaultLayouts: ResponsiveLayouts;
+  optionsMenuSettings: OptionsMenuSettings;
+  gridCardProps?: {
+    closeText: string;
+  };
+};
+
+type FetchUserPreferenceInput = {
+  key: string;
+};
+
+type PostUserPreferenceInput = FetchUserPreferenceInput & {
+  userPreference: UserPreference;
+};
+
+type UserPreferenceContent = {
+  layouts: ResponsiveLayouts;
+  defaultLayouts: ResponsiveLayouts;
+  activeCards: string[];
+};
+
+/**
+ * Get user preference
+ */
+async function fetchUserPreference(input: FetchUserPreferenceInput) {
+  const response = await userPreferenceApi.getUserPreferences(input.key);
+  return response.data;
+}
+
+/**
+ * Post user preference
+ */
+async function postUserPreference(_url: string, { arg }: { arg: PostUserPreferenceInput }) {
+  const response = await userPreferenceApi.postUserPreferences(arg.key, arg.userPreference);
+  return response.data;
+}
+
+/**
+ * A LayoutItem config can change the card behavior (static, isDraggable etc.)
+ * It must be passed as a prop to card to reflect those changes.
+ *
+ * each props used default react-grid-layout values of response-grid
+ * - isStatic: false
+ * - isDraggable: true
+ * - isResizable: true
+ * - isBounded: false
+ */
+export function getLayoutPropsFromCard(layouts: ResponsiveLayouts, id: string): CardLayoutItem {
+  const breakpoints = Object.keys(layouts) as Array<keyof ResponsiveLayouts>;
+
+  const defaultProps = { id, isStatic: false, isDraggable: true, isResizable: true };
+
+  for (const breakpoint of breakpoints) {
+    const item = (layouts[breakpoint] ?? []).find(entry => entry.i === id);
+    if (item) {
+      return {
+        id,
+        isStatic: item.static ?? defaultProps.isStatic,
+        isDraggable: item.isDraggable ?? defaultProps.isDraggable,
+        isResizable: item.isResizable ?? defaultProps.isResizable,
+      };
+    }
+  }
+
+  console.warn(`grid: ${id} has not been found in layouts`);
+  return defaultProps;
+}
+
+/**
+ * Breakpoints should only contain active cards.
+ */
+export function getActiveLayouts(layouts: ResponsiveLayouts, activeCards: string[]): ResponsiveLayouts {
+  const breakpoints = Object.keys(layouts) as Array<keyof ResponsiveLayouts>;
+  const activeLayouts: ResponsiveLayouts = {};
+
+  for (const breakpoint of breakpoints) {
+    activeLayouts[breakpoint] = (layouts[breakpoint] ?? []).filter(item => activeCards.includes(item.i));
+  }
+
+  return activeLayouts;
+}
+
+/**
+ * MergeLayouts is used to keep the previous config of an inactive card.
+ * If it's not used, the card size and position will not behave as expected.
+ */
+export function mergeLayouts(prev: ResponsiveLayouts, allLayouts: ResponsiveLayouts): ResponsiveLayouts {
+  const mergedLayouts: ResponsiveLayouts = {};
+  const breakpoints = Object.keys(allLayouts) as Array<keyof ResponsiveLayouts>;
+
+  for (const breakpoint of breakpoints) {
+    const layout = allLayouts[breakpoint] ?? [];
+    const layoutIds = layout.map(card => card.i);
+    const result = (prev[breakpoint] ?? []).filter(card => !layoutIds.includes(card.i));
+    mergedLayouts[breakpoint] = [...layout, ...result];
+  }
+
+  return mergedLayouts;
+}
+
+/**
+ * Compare remote/locale defaultLayouts for deprecated values
+ */
+export function isRemoteDefaultLayoutsDeprecated(
+  remoteDefaultLayouts: ResponsiveLayouts,
+  localDefaultLayouts: ResponsiveLayouts,
+): boolean {
+  const breakpoints = Object.keys(localDefaultLayouts) as Array<keyof ResponsiveLayouts>;
+
+  for (const breakpoint of breakpoints) {
+    const localLayout = localDefaultLayouts[breakpoint] ?? [];
+    const remoteLayout = remoteDefaultLayouts[breakpoint] ?? [];
+
+    if (localLayout.length !== remoteLayout.length) {
+      return true;
+    }
+
+    for (const localItem of localLayout) {
+      const remoteItem = remoteLayout.find(item => item.i === localItem.i);
+      if (!remoteItem) {
+        return true;
+      }
+
+      const samePosition = remoteItem.x === localItem.x && remoteItem.y === localItem.y;
+      const sameSize = remoteItem.w === localItem.w && remoteItem.h === localItem.h;
+      if (!samePosition || !sameSize) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * react-grid-layout enriches items with extra props (moved, static, etc.)
+ * We only compare layouts by position (x, y), size (w, h) and presence in config.
+ */
+function isPristine(
+  currentLayouts: ResponsiveLayouts,
+  defaultLayouts: ResponsiveLayouts,
+  activeCards: string[],
+): boolean {
+  const breakpoints = Object.keys(defaultLayouts) as Array<keyof ResponsiveLayouts>;
+
+  for (const breakpoint of breakpoints) {
+    const defaultLayout = defaultLayouts[breakpoint] ?? [];
+    const layout = currentLayouts[breakpoint] ?? [];
+
+    if (defaultLayout.length !== layout.length) {
+      return false;
+    }
+
+    if (layout.length !== activeCards.length) {
+      return false;
+    }
+
+    for (const defaultItem of defaultLayout) {
+      const currentItem = layout.find(item => item.i === defaultItem.i);
+      if (!currentItem) {
+        return false;
+      }
+
+      const samePosition = currentItem.x === defaultItem.x && currentItem.y === defaultItem.y;
+      const sameSize = currentItem.w === defaultItem.w && currentItem.h === defaultItem.h;
+      if (!samePosition || !sameSize) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * React-grid-layout default values
+ * Breakpoints
+ *  lg: 12 cols
+ *  md: 10 cols
+ *  sm: 6 cols
+ *  xs: 4 cols
+ *  xxs: 2 cols
+ *
+ * Layout
+ *  i: string; Unique identifier (must match child key)
+ *  x: number; X position in grid units
+ *  y: number; Y position in grid units
+ *  w: number; Width in grid units
+ *  h: number; Height in grid units
+ *  minW?: number; Minimum width (default: 0)
+ *  maxW?: number; Maximum width (default: Infinity)
+ *  minH?: number; Minimum height (default: 0)
+ *  maxH?: number; Maximum height (default: Infinity)
+ *  static?: boolean; If true, not draggable or resizable
+ *  isDraggable?: boolean; Override grid isDraggable
+ *  isResizable?: boolean; Override grid isResizable
+ *  isBounded?: boolean; Override grid isBounded
+ *
+ */
+function Grid({ id, defaultLayouts, optionsMenuSettings, cards, gridCardProps }: GridProps) {
+  const preferenceKey = useMemo(() => `resizable-grid-${id}`, [id]);
+  const defaultActiveCards = useMemo(() => cards.map(card => card.id), [cards]);
+  const { width, containerRef, mounted } = useContainerWidth();
+  const [activeCards, setActiveCards] = useState<string[]>(defaultActiveCards);
+  const [layouts, setLayouts] = useState<ResponsiveLayouts>(defaultLayouts);
+  const [isReady, setIsReady] = useState(false);
+  const preferences = useSWRImmutable(preferenceKey, () => fetchUserPreference({ key: preferenceKey }), {
+    shouldRetryOnError: false,
+  });
+  const { trigger } = useSWRMutation(preferenceKey, postUserPreference, {
+    revalidate: false,
+    populateCache: false,
+  });
+
+  const handleLayoutChange = useCallback((_currentLayout: Layout, allLayouts: ResponsiveLayouts) => {
+    setLayouts(prev => mergeLayouts(prev, allLayouts));
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setLayouts(defaultLayouts);
+    setActiveCards(defaultActiveCards);
+  }, [defaultLayouts, defaultActiveCards]);
+
+  const handleClose = useCallback((id: string) => {
+    setActiveCards(prev => prev.filter(cardId => cardId !== id));
+  }, []);
+
+  const handleCheckedChange = useCallback((id: string, checked: boolean) => {
+    setActiveCards(prev => (checked ? [...prev, id] : prev.filter(cardId => cardId !== id)));
+  }, []);
+
+  /**
+   * Loading user-preference.
+   * Use defaultLayouts if user-preference has never been set or if the request failed.
+   * If defaultLayouts changes (new card, new layout etc.), the local layout will be used instead
+   * of the remote one.
+   */
+  useEffect(() => {
+    if (isReady || preferences.isLoading) return;
+    const content = preferences.data?.content as UserPreferenceContent | undefined;
+    const hasDeprecatedLayouts =
+      content?.defaultLayouts && isRemoteDefaultLayoutsDeprecated(content.defaultLayouts, defaultLayouts);
+
+    if (!hasDeprecatedLayouts) {
+      if (content?.layouts) {
+        setLayouts(content.layouts);
+      }
+      if (content?.activeCards) {
+        setActiveCards(content.activeCards);
+      }
+    }
+    setIsReady(true);
+  }, [isReady, preferences.isLoading, preferences.data, activeCards]);
+
+  /**
+   * Save layouts to user-preference api
+   */
+  useEffect(() => {
+    if (!isReady) return;
+    const handler = setTimeout(() => {
+      const content: UserPreferenceContent = { layouts, defaultLayouts, activeCards };
+      trigger({
+        key: preferenceKey,
+        userPreference: {
+          key: preferenceKey,
+          content,
+        },
+      });
+    }, 350);
+
+    return () => {
+      if (handler) clearTimeout(handler);
+    };
+  }, [layouts, activeCards, isReady]);
+
+  return (
+    <div ref={containerRef} className="w-full">
+      {!isReady || preferences.isLoading ? (
+        <GridSkeleton
+          defaultLayouts={defaultLayouts}
+          cards={cards}
+          hasMenuOptionsSettings={optionsMenuSettings.visible}
+        />
+      ) : (
+        mounted && (
+          <div>
+            {optionsMenuSettings.visible && (
+              <div className="flex justify-end">
+                <GridOptionsMenuSettings
+                  cards={cards}
+                  activeCards={activeCards}
+                  isPristine={isPristine(layouts, defaultLayouts, activeCards)}
+                  onCheckedChange={handleCheckedChange}
+                  onReset={handleReset}
+                  tooltipText={optionsMenuSettings.tooltipText}
+                />
+              </div>
+            )}
+            <Responsive
+              layouts={getActiveLayouts(layouts, activeCards)}
+              width={width}
+              onLayoutChange={handleLayoutChange}
+            >
+              {cards
+                .filter(card => activeCards.includes(card.id))
+                .map(card => {
+                  const layoutItemProps = getLayoutPropsFromCard(layouts, card.id);
+                  return (
+                    <GridCard
+                      key={card.id}
+                      id={layoutItemProps.id}
+                      content={card.content}
+                      title={card.title}
+                      onClose={handleClose}
+                      closeText={gridCardProps?.closeText}
+                      isStatic={layoutItemProps.isStatic}
+                      isDraggable={layoutItemProps.isDraggable}
+                      isResizable={layoutItemProps.isResizable}
+                    />
+                  );
+                })}
+            </Responsive>
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+export default Grid;

--- a/frontend/components/package-lock.json
+++ b/frontend/components/package-lock.json
@@ -10,6 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/helpers": "^0.5.0",
+        "@dnd-kit/react": "^0.5.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@hookform/resolvers": "^5.4.0",
         "@radix-ui/react-accordion": "^1.2.2",
@@ -421,6 +423,17 @@
         "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0"
       }
     },
+    "node_modules/@dnd-kit/abstract": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/abstract/-/abstract-0.5.0.tgz",
+      "integrity": "sha512-hi13iMJgjPX/KDYVKg5VeDIhmYiV6buc9bAX+tCLYf4QdyYjPbsXjn2sPo6m7fQ6SGJBEFgHJ2PemeKDUbwBaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/geometry": "^0.5.0",
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -431,6 +444,17 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/collision": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/collision/-/collision-0.5.0.tgz",
+      "integrity": "sha512-xUqRn3lS7oqLkT0AnnHS/STh/Czvwe1UapZFYiLbsUGxopMsQd4teaPCzPouOThoMdGEe+dHWjfqJl6t9iG4mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "@dnd-kit/geometry": "^0.5.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@dnd-kit/core": {
@@ -448,6 +472,55 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@dnd-kit/dom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/dom/-/dom-0.5.0.tgz",
+      "integrity": "sha512-f2xFJp5SYQ8EW/Fbtaa8iBb66hpkWc7qa8vU826KW11/tb44sH+AisZnGtwOOTWTQ0GraqBDr5ixTErww+eKXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "@dnd-kit/collision": "^0.5.0",
+        "@dnd-kit/geometry": "^0.5.0",
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/geometry": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/geometry/-/geometry-0.5.0.tgz",
+      "integrity": "sha512-ubHQS1CiSDH8ssYH2xG5BnpwPSFP1tStXXjug7/Ba6qnQdu/EUH47l6QXKIksQnnanfVfDf0aGeevRxgZlj28A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/helpers": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/helpers/-/helpers-0.5.0.tgz",
+      "integrity": "sha512-i4y+51/icSw+OHMr/su19qhnmNhAzh8PnBwXvapFYTd+64oodIyJRiRkB+hhfxAfnur7RYSW8qacDTrXjg2XOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/react": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/react/-/react-0.5.0.tgz",
+      "integrity": "sha512-abQPLI8lmfVE+v/n+pqy5WFxrw6T2Yg0UQZsL78dp5DKci7dKTVDjvLWqvass+XTFtzJmsZEjk1NdqE6xG8Jiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "@dnd-kit/dom": "^0.5.0",
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@dnd-kit/sortable": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
@@ -460,6 +533,16 @@
       "peerDependencies": {
         "@dnd-kit/core": "^6.3.0",
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/state": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/state/-/state-0.5.0.tgz",
+      "integrity": "sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.10.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@dnd-kit/utilities": {
@@ -2126,6 +2209,16 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.3.tgz",
+      "integrity": "sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.2",
@@ -7918,6 +8011,18 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -8182,6 +8287,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/open": {
       "version": "10.2.0",
@@ -8527,6 +8641,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/prosemirror-changeset": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.0.tgz",
@@ -8826,6 +8957,44 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.7.0.tgz",
+      "integrity": "sha512-kTpANmKWVnFXiZ76Ag2ZowiFStuBYnJ606PI1TbUsOg29/400/JNIxI9+CuenhiAqFuXWJffz6F4UI3R51kUug==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.3.tgz",
+      "integrity": "sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout/node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/react-hook-form": {
       "version": "7.78.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.78.0.tgz",
@@ -8955,6 +9124,20 @@
         }
       }
     },
+    "node_modules/react-resizable": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.2.0.tgz",
+      "integrity": "sha512-3NKQ0SLZV7rs3LQHeXlOzDSRQfFrkX6TVet77/Qk03zqiZyee37b7N8/gwDJAA8UUjRz7PdWCCy49hcso45SMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -9080,6 +9263,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/frontend/components/package.json
+++ b/frontend/components/package.json
@@ -36,6 +36,8 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/helpers": "^0.5.0",
+    "@dnd-kit/react": "^0.5.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@hookform/resolvers": "^5.4.0",
     "@radix-ui/react-accordion": "^1.2.2",
@@ -80,6 +82,7 @@
     "next-themes": "^0.4.6",
     "query-string": "^9.4.0",
     "radix-ui": "^1.6.0",
+    "react-grid-layout": "^2.2.3",
     "react-i18next": "^17.0.8",
     "recharts": "^3.8.0",
     "sonner": "^2.0.7",

--- a/frontend/components/stories/charts/horizontal-bar-chart.stories.tsx
+++ b/frontend/components/stories/charts/horizontal-bar-chart.stories.tsx
@@ -9,7 +9,7 @@ import { StorySection } from '../story-section';
 
 import { biospecimensData, filesByDataTypesData, hpoData, mondoData } from './data';
 
-const hpoProps = {
+export const hpoProps = {
   axis: {
     x: {
       dataKey: 'count',
@@ -39,7 +39,7 @@ const hpoProps = {
     </div>
   ),
 };
-const mondoProps = {
+export const mondoProps = {
   axis: {
     x: {
       dataKey: 'count',
@@ -70,7 +70,7 @@ const mondoProps = {
   ),
 };
 
-const filesByDataTypesProps = {
+export const filesByDataTypesProps = {
   axis: {
     x: {
       dataKey: 'count',
@@ -91,7 +91,7 @@ const filesByDataTypesProps = {
   ),
 };
 
-const biospecimensProps = {
+export const biospecimensProps = {
   axis: {
     x: {
       dataKey: 'count',

--- a/frontend/components/stories/charts/pie-chart.stories.tsx
+++ b/frontend/components/stories/charts/pie-chart.stories.tsx
@@ -9,7 +9,7 @@ import { StorySection } from '../story-section';
 
 import { ethnicityData, familyTypeData, raceData, sexData, studiesData } from './data';
 
-const studiesProps = {
+export const studiesProps = {
   data: studiesData,
   pies: studiesData.map(d => d.label),
   onClick: (data: any) => {
@@ -23,7 +23,7 @@ const studiesProps = {
   ),
 };
 
-const sexProps = {
+export const sexProps = {
   title: 'Sex',
   data: sexData,
   pies: sexData.map(d => d.label),
@@ -35,7 +35,7 @@ const sexProps = {
   ),
 };
 
-const raceProps = {
+export const raceProps = {
   title: 'Race',
   data: raceData,
   pies: raceData.map(d => d.label),
@@ -47,7 +47,7 @@ const raceProps = {
   ),
 };
 
-const ethnicityProps = {
+export const ethnicityProps = {
   title: 'ethnicity',
   data: ethnicityData,
   pies: ethnicityData.map(d => d.label),
@@ -59,7 +59,7 @@ const ethnicityProps = {
   ),
 };
 
-const familyTypeProps = {
+export const familyTypeProps = {
   title: 'Family Composition',
   data: familyTypeData,
   pies: familyTypeData.map(d => d.label),

--- a/frontend/components/stories/charts/vertical-bar-chart.stories.tsx
+++ b/frontend/components/stories/charts/vertical-bar-chart.stories.tsx
@@ -10,7 +10,7 @@ import { StorySection } from '../story-section';
 
 import { ageAtFirstEngagementIncludeData, ageAtFirstEngagementKFData } from './data';
 
-const ageAtFirstEngagementFKProps = {
+export const ageAtFirstEngagementFKProps = {
   axis: {
     x: {
       dataKey: 'age',
@@ -33,7 +33,7 @@ const ageAtFirstEngagementFKProps = {
   ),
 };
 
-const ageAtFirstEngagementIncludeProps = {
+export const ageAtFirstEngagementIncludeProps = {
   axis: {
     x: {
       dataKey: 'age',

--- a/frontend/components/stories/grids/grid.stories.tsx
+++ b/frontend/components/stories/grids/grid.stories.tsx
@@ -1,0 +1,692 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Grid from '@/components/base/grids/grid';
+
+import { StorySection } from '../story-section';
+import { hpoProps, mondoProps } from '../charts/horizontal-bar-chart.stories';
+import HorizontalBarChart from '@/components/base/charts/bar-charts/horizontal-bar-chart';
+import { sexProps, ethnicityProps, raceProps, studiesProps } from '../charts/pie-chart.stories';
+import PieChart from '@/components/base/charts/pie-charts/pie-chart';
+import VerticalBarChart from '@/components/base/charts/bar-charts/vertical-bar-chart';
+import { ageAtFirstEngagementFKProps, ageAtFirstEngagementIncludeProps } from '../charts/vertical-bar-chart.stories';
+import GroupedVerticalBarChart from '@/components/base/charts/bar-charts/grouped-vertical-bar-chart';
+import { userPreferenceApi } from '../api/api-user-preference';
+import { delay, http, HttpResponse } from 'msw';
+
+const meta = {
+  title: 'Components/Grids/Grid',
+  component: Grid,
+  args: {
+    id: 'storybook-default',
+    cards: [
+      {
+        id: '1',
+        title: 'Most Frequent Phenotype (HPO)',
+        content: <HorizontalBarChart {...hpoProps} />,
+      },
+      {
+        id: '2',
+        title: 'Most Frequent Diagnoses (MONDO)',
+        content: <HorizontalBarChart {...mondoProps} />,
+      },
+      {
+        id: '3',
+        title: 'Demographics',
+        content: (
+          <div className="flex gap-2 h-full p-2">
+            {[sexProps, ethnicityProps, raceProps].map((props, i) => (
+              <div key={i} className="flex-1 min-w-0 h-full">
+                <PieChart {...props} />
+              </div>
+            ))}
+          </div>
+        ),
+      },
+      {
+        id: '4',
+        title: 'Studies',
+        content: <PieChart {...studiesProps} />,
+      },
+      {
+        id: '5',
+        title: 'Age at First Patient Engagement (years)',
+        content: <VerticalBarChart {...ageAtFirstEngagementFKProps} />,
+      },
+      {
+        id: '6',
+        title: 'Age at First Patient Engagement (years) (Include)',
+        content: <GroupedVerticalBarChart {...ageAtFirstEngagementIncludeProps} />,
+      },
+    ],
+    defaultLayouts: {
+      lg: [
+        { i: '1', x: 0, y: 0, w: 6, h: 3 },
+        { i: '2', x: 6, y: 0, w: 6, h: 3 },
+        { i: '3', x: 0, y: 3, w: 4, h: 2 },
+        { i: '4', x: 4, y: 3, w: 2, h: 2 },
+        { i: '5', x: 6, y: 3, w: 6, h: 2 },
+        { i: '6', x: 0, y: 5, w: 6, h: 3 },
+      ],
+      md: [
+        { i: '1', x: 0, y: 0, w: 5, h: 3 },
+        { i: '2', x: 5, y: 0, w: 5, h: 3 },
+        { i: '3', x: 0, y: 3, w: 3, h: 2 },
+        { i: '4', x: 3, y: 3, w: 2, h: 2 },
+        { i: '5', x: 5, y: 3, w: 5, h: 2 },
+        { i: '6', x: 0, y: 5, w: 5, h: 3 },
+      ],
+      sm: [
+        { i: '1', x: 0, y: 0, w: 3, h: 3 },
+        { i: '2', x: 3, y: 0, w: 3, h: 3 },
+        { i: '3', x: 0, y: 3, w: 4, h: 2 },
+        { i: '4', x: 4, y: 3, w: 2, h: 2 },
+        { i: '5', x: 0, y: 5, w: 3, h: 2 },
+        { i: '6', x: 3, y: 5, w: 3, h: 2 },
+      ],
+      xs: [
+        { i: '1', x: 0, y: 0, w: 4, h: 3 },
+        { i: '2', x: 0, y: 3, w: 4, h: 3 },
+        { i: '3', x: 0, y: 6, w: 4, h: 2 },
+        { i: '4', x: 0, y: 8, w: 4, h: 2 },
+        { i: '5', x: 0, y: 10, w: 4, h: 2 },
+        { i: '6', x: 0, y: 12, w: 4, h: 3 },
+      ],
+      xxs: [
+        { i: '1', x: 0, y: 0, w: 2, h: 3 },
+        { i: '2', x: 0, y: 3, w: 2, h: 3 },
+        { i: '3', x: 0, y: 6, w: 2, h: 2 },
+        { i: '4', x: 0, y: 8, w: 2, h: 2 },
+        { i: '5', x: 0, y: 10, w: 2, h: 2 },
+        { i: '6', x: 0, y: 12, w: 2, h: 3 },
+      ],
+    },
+    optionsMenuSettings: {
+      visible: true,
+      tooltipText: 'Charts',
+    },
+    gridCardProps: {
+      closeText: 'Remove Chart',
+    },
+  },
+} satisfies Meta<typeof Grid>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(userPreferenceApi, async () => {
+          await delay(10000);
+          return HttpResponse.json({
+            content: {
+              layouts: {
+                lg: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 4 },
+                  { i: '2', x: 4, y: 0, w: 8, h: 2 },
+                  { i: '3', x: 4, y: 2, w: 8, h: 2 },
+                  { i: '4', x: 0, y: 4, w: 3, h: 2 },
+                  { i: '5', x: 3, y: 4, w: 9, h: 3 },
+                  { i: '6', x: 0, y: 7, w: 12, h: 4 },
+                ],
+                md: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 4 },
+                  { i: '2', x: 4, y: 0, w: 6, h: 2 },
+                  { i: '3', x: 4, y: 2, w: 6, h: 2 },
+                  { i: '4', x: 0, y: 4, w: 3, h: 2 },
+                  { i: '5', x: 3, y: 4, w: 7, h: 3 },
+                  { i: '6', x: 0, y: 7, w: 10, h: 4 },
+                ],
+                sm: [
+                  { i: '1', x: 0, y: 0, w: 6, h: 3 },
+                  { i: '2', x: 0, y: 3, w: 3, h: 2 },
+                  { i: '3', x: 3, y: 3, w: 3, h: 2 },
+                  { i: '4', x: 0, y: 5, w: 2, h: 2 },
+                  { i: '5', x: 2, y: 5, w: 4, h: 3 },
+                  { i: '6', x: 0, y: 8, w: 6, h: 4 },
+                ],
+                xs: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 4 },
+                  { i: '2', x: 0, y: 4, w: 4, h: 2 },
+                  { i: '3', x: 0, y: 6, w: 4, h: 2 },
+                  { i: '4', x: 0, y: 8, w: 4, h: 2 },
+                  { i: '5', x: 0, y: 10, w: 4, h: 3 },
+                  { i: '6', x: 0, y: 13, w: 4, h: 4 },
+                ],
+                xxs: [
+                  { i: '1', x: 0, y: 0, w: 2, h: 4 },
+                  { i: '2', x: 0, y: 4, w: 2, h: 2 },
+                  { i: '3', x: 0, y: 6, w: 2, h: 2 },
+                  { i: '4', x: 0, y: 8, w: 2, h: 2 },
+                  { i: '5', x: 0, y: 10, w: 2, h: 3 },
+                  { i: '6', x: 0, y: 13, w: 2, h: 4 },
+                ],
+              },
+            },
+          });
+        }),
+        http.post(userPreferenceApi, async () => {
+          return new HttpResponse({ status: 200 });
+        }),
+      ],
+    },
+  },
+  args: {
+    id: 'storybook-loading',
+  },
+  render: args => (
+    <StorySection title="Grid - Loading state: skeleton is shown while user preferences are being fetched (10s delay). Refresh to replay.">
+      <Grid {...args} />
+    </StorySection>
+  ),
+};
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post(userPreferenceApi, async () => {
+          return new HttpResponse({ status: 200 });
+        }),
+      ],
+    },
+  },
+  render: args => (
+    <StorySection title="Grid - Fresh state: no saved user preferences, so the grid renders from the defaultLayouts prop with every card active.">
+      <Grid {...args} />
+    </StorySection>
+  ),
+};
+
+export const Edited: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(userPreferenceApi, async () => {
+          await delay(250);
+          return HttpResponse.json({
+            content: {
+              layouts: {
+                lg: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 4 },
+                  { i: '2', x: 4, y: 0, w: 8, h: 2 },
+                  { i: '3', x: 4, y: 2, w: 8, h: 2 },
+                  { i: '4', x: 0, y: 4, w: 3, h: 2 },
+                  { i: '5', x: 3, y: 4, w: 9, h: 3 },
+                  { i: '6', x: 0, y: 7, w: 12, h: 4 },
+                ],
+                md: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 4 },
+                  { i: '2', x: 4, y: 0, w: 6, h: 2 },
+                  { i: '3', x: 4, y: 2, w: 6, h: 2 },
+                  { i: '4', x: 0, y: 4, w: 3, h: 2 },
+                  { i: '5', x: 3, y: 4, w: 7, h: 3 },
+                  { i: '6', x: 0, y: 7, w: 10, h: 4 },
+                ],
+                sm: [
+                  { i: '1', x: 0, y: 0, w: 6, h: 3 },
+                  { i: '2', x: 0, y: 3, w: 3, h: 2 },
+                  { i: '3', x: 3, y: 3, w: 3, h: 2 },
+                  { i: '4', x: 0, y: 5, w: 2, h: 2 },
+                  { i: '5', x: 2, y: 5, w: 4, h: 3 },
+                  { i: '6', x: 0, y: 8, w: 6, h: 4 },
+                ],
+                xs: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 4 },
+                  { i: '2', x: 0, y: 4, w: 4, h: 2 },
+                  { i: '3', x: 0, y: 6, w: 4, h: 2 },
+                  { i: '4', x: 0, y: 8, w: 4, h: 2 },
+                  { i: '5', x: 0, y: 10, w: 4, h: 3 },
+                  { i: '6', x: 0, y: 13, w: 4, h: 4 },
+                ],
+                xxs: [
+                  { i: '1', x: 0, y: 0, w: 2, h: 4 },
+                  { i: '2', x: 0, y: 4, w: 2, h: 2 },
+                  { i: '3', x: 0, y: 6, w: 2, h: 2 },
+                  { i: '4', x: 0, y: 8, w: 2, h: 2 },
+                  { i: '5', x: 0, y: 10, w: 2, h: 3 },
+                  { i: '6', x: 0, y: 13, w: 2, h: 4 },
+                ],
+              },
+              defaultLayouts: {
+                lg: [
+                  { i: '1', x: 0, y: 0, w: 6, h: 3 },
+                  { i: '2', x: 6, y: 0, w: 6, h: 3 },
+                  { i: '3', x: 0, y: 3, w: 4, h: 2 },
+                  { i: '4', x: 4, y: 3, w: 2, h: 2 },
+                  { i: '5', x: 6, y: 3, w: 6, h: 2 },
+                  { i: '6', x: 0, y: 5, w: 6, h: 3 },
+                ],
+                md: [
+                  { i: '1', x: 0, y: 0, w: 5, h: 3 },
+                  { i: '2', x: 5, y: 0, w: 5, h: 3 },
+                  { i: '3', x: 0, y: 3, w: 3, h: 2 },
+                  { i: '4', x: 3, y: 3, w: 2, h: 2 },
+                  { i: '5', x: 5, y: 3, w: 5, h: 2 },
+                  { i: '6', x: 0, y: 5, w: 5, h: 3 },
+                ],
+                sm: [
+                  { i: '1', x: 0, y: 0, w: 3, h: 3 },
+                  { i: '2', x: 3, y: 0, w: 3, h: 3 },
+                  { i: '3', x: 0, y: 3, w: 4, h: 2 },
+                  { i: '4', x: 4, y: 3, w: 2, h: 2 },
+                  { i: '5', x: 0, y: 5, w: 3, h: 2 },
+                  { i: '6', x: 3, y: 5, w: 3, h: 2 },
+                ],
+                xs: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 3 },
+                  { i: '2', x: 0, y: 3, w: 4, h: 3 },
+                  { i: '3', x: 0, y: 6, w: 4, h: 2 },
+                  { i: '4', x: 0, y: 8, w: 4, h: 2 },
+                  { i: '5', x: 0, y: 10, w: 4, h: 2 },
+                  { i: '6', x: 0, y: 12, w: 4, h: 3 },
+                ],
+                xxs: [
+                  { i: '1', x: 0, y: 0, w: 2, h: 3 },
+                  { i: '2', x: 0, y: 3, w: 2, h: 3 },
+                  { i: '3', x: 0, y: 6, w: 2, h: 2 },
+                  { i: '4', x: 0, y: 8, w: 2, h: 2 },
+                  { i: '5', x: 0, y: 10, w: 2, h: 2 },
+                  { i: '6', x: 0, y: 12, w: 2, h: 3 },
+                ],
+              },
+              activeCards: ['1', '2', '4', '5', '6'],
+            },
+          });
+        }),
+        http.post(userPreferenceApi, async () => {
+          return new HttpResponse({ status: 200 });
+        }),
+      ],
+    },
+  },
+  args: {
+    id: 'storybook-edited',
+  },
+  render: args => (
+    <StorySection title="Grid - Restored state: saved defaultLayouts match the current config, so the user's custom layouts and activeCards are loaded from preferences (Demographics is inactive).">
+      <Grid {...args} />
+    </StorySection>
+  ),
+};
+
+export const OutdatedLayouts: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(userPreferenceApi, async () => {
+          await delay(250);
+          return HttpResponse.json({
+            content: {
+              layouts: {
+                lg: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 4 },
+                  { i: '2', x: 4, y: 0, w: 8, h: 2 },
+                  { i: '3', x: 4, y: 2, w: 8, h: 2 },
+                  { i: '4', x: 0, y: 4, w: 3, h: 2 },
+                  { i: '5', x: 3, y: 4, w: 9, h: 3 },
+                ],
+                md: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 4 },
+                  { i: '2', x: 4, y: 0, w: 6, h: 2 },
+                  { i: '3', x: 4, y: 2, w: 6, h: 2 },
+                  { i: '4', x: 0, y: 4, w: 3, h: 2 },
+                  { i: '5', x: 3, y: 4, w: 7, h: 3 },
+                ],
+                sm: [
+                  { i: '1', x: 0, y: 0, w: 6, h: 3 },
+                  { i: '2', x: 0, y: 3, w: 3, h: 2 },
+                  { i: '3', x: 3, y: 3, w: 3, h: 2 },
+                  { i: '4', x: 0, y: 5, w: 2, h: 2 },
+                  { i: '5', x: 2, y: 5, w: 4, h: 3 },
+                ],
+                xs: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 4 },
+                  { i: '2', x: 0, y: 4, w: 4, h: 2 },
+                  { i: '3', x: 0, y: 6, w: 4, h: 2 },
+                  { i: '4', x: 0, y: 8, w: 4, h: 2 },
+                  { i: '5', x: 0, y: 10, w: 4, h: 3 },
+                ],
+                xxs: [
+                  { i: '1', x: 0, y: 0, w: 2, h: 4 },
+                  { i: '2', x: 0, y: 4, w: 2, h: 2 },
+                  { i: '3', x: 0, y: 6, w: 2, h: 2 },
+                  { i: '4', x: 0, y: 8, w: 2, h: 2 },
+                  { i: '5', x: 0, y: 10, w: 2, h: 3 },
+                ],
+              },
+              defaultLayouts: {
+                lg: [
+                  { i: '1', x: 0, y: 0, w: 6, h: 3 },
+                  { i: '2', x: 6, y: 0, w: 6, h: 3 },
+                  { i: '3', x: 0, y: 3, w: 4, h: 2 },
+                  { i: '4', x: 4, y: 3, w: 2, h: 2 },
+                  { i: '5', x: 6, y: 3, w: 6, h: 2 },
+                ],
+                md: [
+                  { i: '1', x: 0, y: 0, w: 5, h: 3 },
+                  { i: '2', x: 5, y: 0, w: 5, h: 3 },
+                  { i: '3', x: 0, y: 3, w: 3, h: 2 },
+                  { i: '4', x: 3, y: 3, w: 2, h: 2 },
+                  { i: '5', x: 5, y: 3, w: 5, h: 2 },
+                ],
+                sm: [
+                  { i: '1', x: 0, y: 0, w: 3, h: 3 },
+                  { i: '2', x: 3, y: 0, w: 3, h: 3 },
+                  { i: '3', x: 0, y: 3, w: 4, h: 2 },
+                  { i: '4', x: 4, y: 3, w: 2, h: 2 },
+                  { i: '5', x: 0, y: 5, w: 3, h: 2 },
+                ],
+                xs: [
+                  { i: '1', x: 0, y: 0, w: 4, h: 3 },
+                  { i: '2', x: 0, y: 3, w: 4, h: 3 },
+                  { i: '3', x: 0, y: 6, w: 4, h: 2 },
+                  { i: '4', x: 0, y: 8, w: 4, h: 2 },
+                  { i: '5', x: 0, y: 10, w: 4, h: 2 },
+                ],
+                xxs: [
+                  { i: '1', x: 0, y: 0, w: 2, h: 3 },
+                  { i: '2', x: 0, y: 3, w: 2, h: 3 },
+                  { i: '3', x: 0, y: 6, w: 2, h: 2 },
+                  { i: '4', x: 0, y: 8, w: 2, h: 2 },
+                  { i: '5', x: 0, y: 10, w: 2, h: 2 },
+                ],
+              },
+              activeCards: ['1', '2', '4', '5'],
+            },
+          });
+        }),
+        http.post(userPreferenceApi, async () => {
+          return new HttpResponse({ status: 200 });
+        }),
+      ],
+    },
+  },
+  args: {
+    id: 'storybook-default-layouts-updated',
+  },
+  render: args => (
+    <StorySection title="Grid - Conflict recovery: saved defaultLayouts are stale (missing card '6'), so the local defaultLayouts win and the saved layouts/activeCards are discarded to prevent inconsistencies.">
+      <Grid {...args} />
+    </StorySection>
+  ),
+};
+
+export const WithoutOptionsMenuSettings: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post(userPreferenceApi, async () => {
+          return new HttpResponse({ status: 200 });
+        }),
+      ],
+    },
+  },
+  args: {
+    id: 'storybook-hidden',
+    cards: [
+      {
+        id: '1',
+        title: 'Most Frequent Phenotype (HPO)',
+        content: <HorizontalBarChart {...hpoProps} />,
+      },
+      {
+        id: '2',
+        title: 'Most Frequent Diagnoses (MONDO)',
+        content: <HorizontalBarChart {...mondoProps} />,
+      },
+      {
+        id: '3',
+        title: 'Demographics',
+        content: (
+          <div className="flex gap-2 h-full p-2">
+            {[sexProps, ethnicityProps, raceProps].map((props, i) => (
+              <div key={i} className="flex-1 min-w-0 h-full">
+                <PieChart {...props} />
+              </div>
+            ))}
+          </div>
+        ),
+      },
+      {
+        id: '4',
+        title: 'Studies',
+        content: <PieChart {...studiesProps} />,
+      },
+      {
+        id: '5',
+        title: 'Age at First Patient Engagement (years)',
+        content: <VerticalBarChart {...ageAtFirstEngagementFKProps} />,
+      },
+      {
+        id: '6',
+        title: 'Age at First Patient Engagement (years) (Include)',
+        content: <GroupedVerticalBarChart {...ageAtFirstEngagementIncludeProps} />,
+      },
+    ],
+    optionsMenuSettings: {
+      visible: false,
+    },
+  },
+
+  render: args => (
+    <StorySection title="Grid - optionsMenuSettings.visible is false: the top-right settings menu (toggle cards, reset layout) is hidden — cards can still be closed individually.">
+      <Grid {...args} />
+    </StorySection>
+  ),
+};
+
+export const StaticGrid: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post(userPreferenceApi, async () => {
+          return new HttpResponse({ status: 200 });
+        }),
+      ],
+    },
+  },
+  args: {
+    id: 'storybook-all-static',
+    cards: [
+      {
+        id: '1',
+        title: 'Most Frequent Phenotype (HPO)',
+        content: <HorizontalBarChart {...hpoProps} />,
+      },
+      {
+        id: '2',
+        title: 'Most Frequent Diagnoses (MONDO)',
+        content: <HorizontalBarChart {...mondoProps} />,
+      },
+      {
+        id: '3',
+        title: 'Studies',
+        content: <PieChart {...studiesProps} />,
+      },
+      {
+        id: '4',
+        title: 'Age at First Patient Engagement (years)',
+        content: <VerticalBarChart {...ageAtFirstEngagementFKProps} />,
+      },
+    ],
+    defaultLayouts: {
+      lg: [
+        { i: '1', x: 0, y: 0, w: 6, h: 3, static: true },
+        { i: '2', x: 6, y: 0, w: 6, h: 3, static: true },
+        { i: '3', x: 0, y: 3, w: 6, h: 3, static: true },
+        { i: '4', x: 6, y: 3, w: 6, h: 3, static: true },
+      ],
+      md: [
+        { i: '1', x: 0, y: 0, w: 5, h: 3, static: true },
+        { i: '2', x: 5, y: 0, w: 5, h: 3, static: true },
+        { i: '3', x: 0, y: 3, w: 5, h: 3, static: true },
+        { i: '4', x: 5, y: 3, w: 5, h: 3, static: true },
+      ],
+      sm: [
+        { i: '1', x: 0, y: 0, w: 3, h: 3, static: true },
+        { i: '2', x: 3, y: 0, w: 3, h: 3, static: true },
+        { i: '3', x: 0, y: 3, w: 3, h: 3, static: true },
+        { i: '4', x: 3, y: 3, w: 3, h: 3, static: true },
+      ],
+      xs: [
+        { i: '1', x: 0, y: 0, w: 4, h: 3, static: true },
+        { i: '2', x: 0, y: 3, w: 4, h: 3, static: true },
+        { i: '3', x: 0, y: 6, w: 4, h: 3, static: true },
+        { i: '4', x: 0, y: 9, w: 4, h: 3, static: true },
+      ],
+      xxs: [
+        { i: '1', x: 0, y: 0, w: 2, h: 3, static: true },
+        { i: '2', x: 0, y: 3, w: 2, h: 3, static: true },
+        { i: '3', x: 0, y: 6, w: 2, h: 3, static: true },
+        { i: '4', x: 0, y: 9, w: 2, h: 3, static: true },
+      ],
+    },
+  },
+  render: args => (
+    <StorySection title="Grid - Fully static grid: every card shares the same width/height, and no card can be dragged or resized.">
+      <Grid {...args} />
+    </StorySection>
+  ),
+};
+
+export const DraggableGrid: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post(userPreferenceApi, async () => {
+          return new HttpResponse({ status: 200 });
+        }),
+      ],
+    },
+  },
+  args: {
+    id: 'storybook-draggable-only',
+    defaultLayouts: {
+      lg: [
+        { i: '1', x: 0, y: 0, w: 4, h: 3, isResizable: false },
+        { i: '2', x: 4, y: 0, w: 4, h: 3, isResizable: false },
+        { i: '3', x: 8, y: 0, w: 4, h: 3, isResizable: false },
+        { i: '4', x: 0, y: 3, w: 4, h: 3, isResizable: false },
+        { i: '5', x: 4, y: 3, w: 4, h: 3, isResizable: false },
+        { i: '6', x: 8, y: 3, w: 4, h: 3, isResizable: false },
+      ],
+      md: [
+        { i: '1', x: 0, y: 0, w: 3, h: 3, isResizable: false },
+        { i: '2', x: 3, y: 0, w: 3, h: 3, isResizable: false },
+        { i: '3', x: 6, y: 0, w: 3, h: 3, isResizable: false },
+        { i: '4', x: 0, y: 3, w: 3, h: 3, isResizable: false },
+        { i: '5', x: 3, y: 3, w: 3, h: 3, isResizable: false },
+        { i: '6', x: 6, y: 3, w: 3, h: 3, isResizable: false },
+      ],
+      sm: [
+        { i: '1', x: 0, y: 0, w: 2, h: 3, isResizable: false },
+        { i: '2', x: 2, y: 0, w: 2, h: 3, isResizable: false },
+        { i: '3', x: 4, y: 0, w: 2, h: 3, isResizable: false },
+        { i: '4', x: 0, y: 3, w: 2, h: 3, isResizable: false },
+        { i: '5', x: 2, y: 3, w: 2, h: 3, isResizable: false },
+        { i: '6', x: 4, y: 3, w: 2, h: 3, isResizable: false },
+      ],
+      xs: [
+        { i: '1', x: 0, y: 0, w: 4, h: 3, isResizable: false },
+        { i: '2', x: 0, y: 3, w: 4, h: 3, isResizable: false },
+        { i: '3', x: 0, y: 6, w: 4, h: 3, isResizable: false },
+        { i: '4', x: 0, y: 9, w: 4, h: 3, isResizable: false },
+        { i: '5', x: 0, y: 12, w: 4, h: 3, isResizable: false },
+        { i: '6', x: 0, y: 15, w: 4, h: 3, isResizable: false },
+      ],
+      xxs: [
+        { i: '1', x: 0, y: 0, w: 2, h: 3, isResizable: false },
+        { i: '2', x: 0, y: 3, w: 2, h: 3, isResizable: false },
+        { i: '3', x: 0, y: 6, w: 2, h: 3, isResizable: false },
+        { i: '4', x: 0, y: 9, w: 2, h: 3, isResizable: false },
+        { i: '5', x: 0, y: 12, w: 2, h: 3, isResizable: false },
+        { i: '6', x: 0, y: 15, w: 2, h: 3, isResizable: false },
+      ],
+    },
+  },
+  render: args => (
+    <StorySection title="Grid - Draggable only: cards keep their fixed width/height (isResizable: false), but can still be dragged to reorder the grid.">
+      <Grid {...args} />
+    </StorySection>
+  ),
+};
+
+export const GridCard: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post(userPreferenceApi, async () => {
+          return new HttpResponse({ status: 200 });
+        }),
+      ],
+    },
+  },
+  args: {
+    id: 'storybook-resizable-card',
+    gridCardProps: {
+      closeText: 'Remove Card',
+    },
+    cards: [
+      {
+        id: '1',
+        title: 'static: true',
+        content: <HorizontalBarChart {...hpoProps} />,
+      },
+      {
+        id: '2',
+        title: 'isDraggable: false',
+        content: <HorizontalBarChart {...hpoProps} />,
+      },
+      {
+        id: '3',
+        title: 'isResizable: false',
+        content: <HorizontalBarChart {...hpoProps} />,
+      },
+      {
+        id: '4',
+        title: 'isBounded: false',
+        content: <HorizontalBarChart {...hpoProps} />,
+      },
+    ],
+    defaultLayouts: {
+      lg: [
+        { i: '1', x: 0, y: 0, w: 6, h: 3, static: true },
+        { i: '2', x: 6, y: 0, w: 6, h: 3, isDraggable: false },
+        { i: '3', x: 0, y: 3, w: 6, h: 3, isResizable: false },
+        { i: '4', x: 6, y: 3, w: 6, h: 3, isBounded: false },
+      ],
+      md: [
+        { i: '1', x: 0, y: 0, w: 5, h: 3, static: true },
+        { i: '2', x: 5, y: 0, w: 5, h: 3, isDraggable: false },
+        { i: '3', x: 0, y: 3, w: 5, h: 3, isResizable: false },
+        { i: '4', x: 5, y: 3, w: 5, h: 3, isBounded: false },
+      ],
+      sm: [
+        { i: '1', x: 0, y: 0, w: 3, h: 3, static: true },
+        { i: '2', x: 3, y: 0, w: 3, h: 3, isDraggable: false },
+        { i: '3', x: 0, y: 3, w: 4, h: 3, isResizable: false },
+        { i: '4', x: 4, y: 3, w: 4, h: 3, isBounded: false },
+      ],
+      xs: [
+        { i: '1', x: 0, y: 0, w: 4, h: 3, static: true },
+        { i: '2', x: 0, y: 3, w: 4, h: 3, isDraggable: false },
+        { i: '3', x: 0, y: 6, w: 4, h: 3, isResizable: false },
+        { i: '4', x: 0, y: 9, w: 4, h: 3, isBounded: false },
+      ],
+      xxs: [
+        { i: '1', x: 0, y: 0, w: 2, h: 3, static: true },
+        { i: '2', x: 0, y: 3, w: 2, h: 3, isDraggable: false },
+        { i: '3', x: 0, y: 6, w: 2, h: 3, isResizable: false },
+        { i: '4', x: 0, y: 9, w: 2, h: 3, isBounded: false },
+      ],
+    },
+  },
+  render: args => (
+    <StorySection title="Grid - Per-card LayoutItem flags: each card demonstrates a different behavior (static, isDraggable: false, isResizable: false, isBounded: false). Close text has been changed.">
+      <Grid {...args} />
+    </StorySection>
+  ),
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -392,6 +392,8 @@
       "license": "ISC",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/helpers": "^0.5.0",
+        "@dnd-kit/react": "^0.5.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@hookform/resolvers": "^5.4.0",
         "@radix-ui/react-accordion": "^1.2.2",
@@ -436,6 +438,7 @@
         "next-themes": "^0.4.6",
         "query-string": "^9.4.0",
         "radix-ui": "^1.6.0",
+        "react-grid-layout": "^2.2.3",
         "react-i18next": "^17.0.8",
         "recharts": "^3.8.0",
         "sonner": "^2.0.7",
@@ -3192,6 +3195,23 @@
         }
       }
     },
+    "node_modules/@dnd-kit/abstract": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/abstract/-/abstract-0.5.0.tgz",
+      "integrity": "sha512-hi13iMJgjPX/KDYVKg5VeDIhmYiV6buc9bAX+tCLYf4QdyYjPbsXjn2sPo6m7fQ6SGJBEFgHJ2PemeKDUbwBaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/geometry": "^0.5.0",
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/abstract/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -3205,6 +3225,23 @@
       }
     },
     "node_modules/@dnd-kit/accessibility/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@dnd-kit/collision": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/collision/-/collision-0.5.0.tgz",
+      "integrity": "sha512-xUqRn3lS7oqLkT0AnnHS/STh/Czvwe1UapZFYiLbsUGxopMsQd4teaPCzPouOThoMdGEe+dHWjfqJl6t9iG4mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "@dnd-kit/geometry": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/collision/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
@@ -3231,6 +3268,79 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/@dnd-kit/dom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/dom/-/dom-0.5.0.tgz",
+      "integrity": "sha512-f2xFJp5SYQ8EW/Fbtaa8iBb66hpkWc7qa8vU826KW11/tb44sH+AisZnGtwOOTWTQ0GraqBDr5ixTErww+eKXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "@dnd-kit/collision": "^0.5.0",
+        "@dnd-kit/geometry": "^0.5.0",
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/dom/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@dnd-kit/geometry": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/geometry/-/geometry-0.5.0.tgz",
+      "integrity": "sha512-ubHQS1CiSDH8ssYH2xG5BnpwPSFP1tStXXjug7/Ba6qnQdu/EUH47l6QXKIksQnnanfVfDf0aGeevRxgZlj28A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/geometry/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@dnd-kit/helpers": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/helpers/-/helpers-0.5.0.tgz",
+      "integrity": "sha512-i4y+51/icSw+OHMr/su19qhnmNhAzh8PnBwXvapFYTd+64oodIyJRiRkB+hhfxAfnur7RYSW8qacDTrXjg2XOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@dnd-kit/react": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/react/-/react-0.5.0.tgz",
+      "integrity": "sha512-abQPLI8lmfVE+v/n+pqy5WFxrw6T2Yg0UQZsL78dp5DKci7dKTVDjvLWqvass+XTFtzJmsZEjk1NdqE6xG8Jiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "@dnd-kit/dom": "^0.5.0",
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/react/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@dnd-kit/sortable": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
@@ -3246,6 +3356,22 @@
       }
     },
     "node_modules/@dnd-kit/sortable/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@dnd-kit/state": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/state/-/state-0.5.0.tgz",
+      "integrity": "sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.10.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/state/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
@@ -5266,6 +5392,16 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.3.tgz",
+      "integrity": "sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.2",
@@ -15895,9 +16031,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -16425,9 +16559,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16962,6 +17094,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -17083,9 +17216,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -17474,6 +17605,44 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.7.0.tgz",
+      "integrity": "sha512-kTpANmKWVnFXiZ76Ag2ZowiFStuBYnJ606PI1TbUsOg29/400/JNIxI9+CuenhiAqFuXWJffz6F4UI3R51kUug==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.3.tgz",
+      "integrity": "sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout/node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/react-hook-form": {
       "version": "7.77.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.77.0.tgz",
@@ -17531,8 +17700,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-joyride": {
       "version": "3.1.0",
@@ -17653,6 +17821,20 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/react-resizable": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.2.0.tgz",
+      "integrity": "sha512-3NKQ0SLZV7rs3LQHeXlOzDSRQfFrkX6TVet77/Qk03zqiZyee37b7N8/gwDJAA8UUjRz7PdWCCy49hcso45SMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
+      }
     },
     "node_modules/react-router": {
       "version": "7.16.0",
@@ -18032,6 +18214,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/frontend/portals/radiant/vite.config.mts
+++ b/frontend/portals/radiant/vite.config.mts
@@ -22,6 +22,7 @@ export default defineConfig({
     __PROJECT__: configs[project],
     __THEME__: JSON.stringify(project),
     'import.meta.env.THEME': JSON.stringify(project),
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV ?? 'development'),
   },
   resolve: {
     alias: {

--- a/frontend/translations/common/en.json
+++ b/frontend/translations/common/en.json
@@ -60,6 +60,11 @@
       "type_to_search": "Type to search",
       "no_data": "No data"
     },
+    "grid": {
+      "charts": "Charts",
+      "remove_chart": "Remove chart",
+      "reset": "Reset"
+    },
     "sex": {
       "male": "Male",
       "female": "Female",

--- a/frontend/translations/common/fr.json
+++ b/frontend/translations/common/fr.json
@@ -60,6 +60,11 @@
       "type_to_search": "Tapez pour rechercher",
       "no_data": "Aucune donnée"
     },
+    "grid": {
+      "charts": "Graphiques",
+      "remove_chart": "Retirer le graphique",
+      "reset": "Réinitialiser"
+    },
     "sex": {
       "male": "Masculin",
       "female": "Féminin",


### PR DESCRIPTION
# Pull Request Title

## 📌 Context

Migrate resizable-grid component from ferlab to radiant. 

## 📝 Changes

- Improve config readability and maintainability by directly using react-grid-layout config style.
- Make grid more customization for multiples cases (custom closeText etc.)
- Add dynamic card state based on react-grid-layout config (static, resizable, draggable etc.)
- GET/POST user-preference
- Add a deprecated system to default old layout and update them to a new config (adding card, new layout etc.)

## 🧪 Tests

Resize
https://github.com/user-attachments/assets/147338d2-b195-48d2-a0e1-63200bdcd86f

Close/Toggle visibility
https://github.com/user-attachments/assets/09e5d6ad-78ae-46e0-8a0c-4fd79c59f3ee

Loading
https://github.com/user-attachments/assets/c8129bb9-2acd-4a7f-8bb2-d3c6c469f68e

Without options menu button
<img width="1331" height="958" alt="image" src="https://github.com/user-attachments/assets/1fdfe4f1-3053-4f03-a145-22b8ada2fc22" />



## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1627](https://d3b.atlassian.net/browse/SJRA-1627)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- In previous site, we used react-dnd to manage the web dashboard and resizable-grid for chart summary. Since react-grid-layout can manage both, I just create a grid component. 

[SJRA-1627]: https://d3b.atlassian.net/browse/SJRA-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ