### PR TITLE
feat: SJRA-1468 add mysql proxy

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -4,6 +4,7 @@ name: Build and Push Docker Image
 env:
   BACKEND_API_IMAGE_NAME: radiant-api
   BACKEND_WORKER_IMAGE_NAME: radiant-worker
+  BACKEND_MYSQL_PROXY_IMAGE_NAME: radiant-mysql-proxy
   FRONTEND_IMAGE_NAME: radiant-portal
   NAMESPACE: radiant-network
   REGISTRY: ghcr.io
@@ -98,6 +99,38 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.BACKEND_WORKER_IMAGE_NAME }}
           subject-digest: ${{ steps.push_backend_worker.outputs.digest }}
+          push-to-registry: true
+
+      - name: Extract metadata (tags, labels) for Docker image backend MYSQL-PROXY
+        id: meta_backend_mysql_proxy
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.BACKEND_MYSQL_PROXY_IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{raw}}
+            type=semver,pattern={{version}}
+            type=sha,format=short
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value={{sha}}-{{date 'X'}},enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+          flavor: |
+            latest=auto
+
+      - name: Build and push Docker image backend MYSQL-PROXY
+        id: push_backend_mysql_proxy
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ./backend
+          file: ./backend/mysql-proxy.Dockerfile
+          push: true
+          tags: ${{ steps.meta_backend_mysql_proxy.outputs.tags }}
+          labels: ${{ steps.meta_backend_mysql_proxy.outputs.labels }}
+
+      - name: Generate artifact attestation backend MYSQL-PROXY
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.BACKEND_MYSQL_PROXY_IMAGE_NAME }}
+          subject-digest: ${{ steps.push_backend_mysql_proxy.outputs.digest }}
           push-to-registry: true
 
       - name: Extract metadata (tags, labels) for Docker image frontend

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -35,6 +35,9 @@ Thumbs.db
 
 # binary
 bin/
+# mysql-proxy binary from `go build ./cmd/mysql-proxy` (no -o drops it here). Anchored with a
+# leading slash so it ignores only the root artifact, NOT the cmd/mysql-proxy/ source dir.
+/mysql-proxy
 
 
 #config

--- a/backend/cmd/mysql-proxy/README.md
+++ b/backend/cmd/mysql-proxy/README.md
@@ -1,0 +1,63 @@
+# mysql-proxy
+
+A small TCP proxy that lets **Go / GORM** clients authenticate to StarRocks as a **JWT user**.
+
+Go's `go-sql-driver/mysql` implements a fixed set of auth plugins and has no extension point,
+so it can't speak StarRocks' `authentication_openid_connect_client` plugin — the driver would
+have to be forked. Instead this proxy translates during the login handshake:
+
+```
+Go client ──cleartext (mysql_clear_password: JWT sent as the "password")──▶ proxy
+proxy     ──TLS + authentication_openid_connect_client (JWT as auth data)──▶ StarRocks
+```
+
+After login it's a transparent byte pipe. Because every query then runs as the authenticated
+user, **Ranger enforces per-user masking / row-filter / tenant access** on the API's queries —
+no need to reimplement any of that in the application.
+
+> **Security:** the JWT crosses the client↔proxy hop in **cleartext**. Run the proxy on the same
+> host (or a trusted network) as the Go service and restrict its listen port to that peer.
+
+## Run (local dev)
+
+```bash
+# StarRocks is port-forwarded to 127.0.0.1:9030 by the compose stack; it uses a self-signed
+# cert, so leave STARROCKS_SSL_CA unset to skip verification in dev.
+STARROCKS_ADDR=127.0.0.1:9030 LISTEN_ADDR=:9031 go run ./cmd/mysql-proxy
+```
+
+## Verify
+
+The proxy accepts `mysql_clear_password`, so you can exercise it with the MySQL CLI (no Go
+program needed) — point the client at the **proxy** (`:9031`), not StarRocks, and pass the JWT
+as the password:
+
+```bash
+JWT=$(curl -s -X POST "$KC_URL/realms/$REALM/protocol/openid-connect/token" \
+  -d client_id=radiant -d client_secret=... -d username=<user> -d password=... \
+  -d grant_type=password | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')
+SUB=$(printf %s "$JWT" | cut -d. -f2 | base64 -d 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin)["sub"])')
+
+mysql -h127.0.0.1 -P9031 -u"$SUB" \
+  --default-auth=mysql_clear_password --enable-cleartext-plugin -p"$JWT" \
+  -e "SELECT id, first_name, can_read_pii FROM qlin_tenant.patient ORDER BY id"
+```
+
+A `member` user should see `***`; a `geneticist` should see clear values — same result as a
+native OIDC connection, proving the translation is transparent. From Go, connect with
+`allowCleartextPasswords=true` and the JWT as the DSN password, pointing at the proxy.
+
+## Configuration
+
+| Env | Purpose | Default |
+|-----|---------|---------|
+| `LISTEN_ADDR` | address to accept cleartext clients on | `:9031` |
+| `STARROCKS_ADDR` | StarRocks FE MySQL address | `starrocks:9030` |
+| `STARROCKS_SSL_CA` | CA bundle to verify StarRocks' cert; unset = skip verification (dev only) | — |
+| `PROBE_PORT` | HTTP health-probe port (`GET /status`) | `9998` |
+
+## Scope
+
+This is **Piece 1**: the proxy binary. Wiring the API's StarRocks read path to open per-user
+connections through it (forwarding the request's JWT as the password) is the separate, larger
+follow-on.

--- a/backend/cmd/mysql-proxy/main.go
+++ b/backend/cmd/mysql-proxy/main.go
@@ -1,0 +1,128 @@
+// Command mysql-proxy sits between go-sql-driver clients (the Radiant API/worker via GORM)
+// and StarRocks. Go's MySQL driver can't speak StarRocks' authentication_openid_connect_client
+// plugin, so it can't log in as a JWT user directly. This proxy translates: the Go client
+// connects in cleartext and sends its Keycloak JWT as the "password" (mysql_clear_password),
+// and the proxy performs the real TLS + OIDC handshake to StarRocks on its behalf. Every query
+// then runs as the authenticated user, so Ranger enforces per-user masking / row-filter /
+// tenant access — no need to reimplement any of that in the API.
+//
+// SECURITY: the JWT crosses the client↔proxy hop in cleartext, so run the proxy on the same
+// host (or a trusted network) as the Go service and restrict its listen port to that peer.
+//
+//	LISTEN_ADDR      address to accept cleartext clients on   (default :9031)
+//	STARROCKS_ADDR   StarRocks FE MySQL address               (default starrocks:9030)
+//	STARROCKS_SSL_CA path to a CA bundle to verify StarRocks' cert; unset = skip verification (dev)
+//	PROBE_PORT       HTTP health-probe port                   (default 9998)
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+const authTimeout = 15 * time.Second
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+
+	listenAddr := getenv("LISTEN_ADDR", ":9031")
+	backendAddr := getenv("STARROCKS_ADDR", "starrocks:9030")
+	probePort := getenv("PROBE_PORT", "9998")
+
+	tlsCfg, err := backendTLSConfig(os.Getenv("STARROCKS_SSL_CA"), backendAddr)
+	if err != nil {
+		slog.Error("build backend TLS config", "error", err)
+		os.Exit(1)
+	}
+	p := &proxy{backendAddr: backendAddr, tlsCfg: tlsCfg, authTimeout: authTimeout}
+
+	// Cancel the root context on SIGINT/SIGTERM so the accept loop and health server stop.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go serveHealthProbe(ctx, probePort)
+
+	ln, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		slog.Error("listen failed", "addr", listenAddr, "error", err)
+		os.Exit(1)
+	}
+	slog.Info("mysql-proxy listening", "listen", listenAddr, "backend", backendAddr)
+
+	// Unblock Accept on shutdown by closing the listener.
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				slog.Info("shutting down")
+				return
+			}
+			slog.Error("accept error", "error", err)
+			continue
+		}
+		go p.handle(conn)
+	}
+}
+
+// backendTLSConfig builds the TLS config for the proxy→StarRocks hop. With a CA bundle it
+// verifies StarRocks' certificate (using the backend host as the expected name); without one
+// it skips verification — acceptable for local dev against a self-signed cert, but production
+// should set STARROCKS_SSL_CA.
+func backendTLSConfig(caPath, backendAddr string) (*tls.Config, error) {
+	if caPath == "" {
+		slog.Warn("STARROCKS_SSL_CA not set — not verifying StarRocks certificate (dev only)")
+		return &tls.Config{InsecureSkipVerify: true}, nil //nolint:gosec // documented dev fallback; prod sets STARROCKS_SSL_CA
+	}
+	pem, err := os.ReadFile(caPath) //nolint:gosec // operator-configured path, not attacker input
+	if err != nil {
+		return nil, fmt.Errorf("read STARROCKS_SSL_CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("parse STARROCKS_SSL_CA: no certificates in %s", caPath)
+	}
+	host, _, err := net.SplitHostPort(backendAddr)
+	if err != nil {
+		return nil, fmt.Errorf("parse STARROCKS_ADDR %q: %w", backendAddr, err)
+	}
+	return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: pool, ServerName: host}, nil
+}
+
+// serveHealthProbe runs a minimal HTTP server exposing GET /status for liveness checks,
+// shutting down when ctx is cancelled.
+func serveHealthProbe(ctx context.Context, port string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	srv := &http.Server{Addr: ":" + port, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		slog.Error("health probe server failed", "error", err)
+	}
+}
+
+func getenv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/backend/cmd/mysql-proxy/main.go
+++ b/backend/cmd/mysql-proxy/main.go
@@ -26,11 +26,18 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 )
 
-const authTimeout = 15 * time.Second
+const (
+	authTimeout = 15 * time.Second
+	// drainTimeout bounds how long shutdown waits for in-flight connections. Piped sessions
+	// are long-lived, so this is a grace period for short queries, not a guarantee — after it
+	// elapses remaining connections die with the process.
+	drainTimeout = 10 * time.Second
+)
 
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
@@ -65,17 +72,38 @@ func main() {
 		_ = ln.Close()
 	}()
 
+	var handlers sync.WaitGroup
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
 			if ctx.Err() != nil {
-				slog.Info("shutting down")
+				slog.Info("shutting down, draining connections", "timeout", drainTimeout)
+				waitWithTimeout(&handlers, drainTimeout)
 				return
 			}
 			slog.Error("accept error", "error", err)
 			continue
 		}
-		go p.handle(conn)
+		handlers.Add(1)
+		go func() {
+			defer handlers.Done()
+			p.handle(conn)
+		}()
+	}
+}
+
+// waitWithTimeout waits for wg up to d, then gives up (long-lived piped sessions would
+// otherwise block shutdown forever).
+func waitWithTimeout(wg *sync.WaitGroup, d time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		slog.Warn("drain timeout reached, exiting with active connections")
 	}
 }
 

--- a/backend/cmd/mysql-proxy/proxy.go
+++ b/backend/cmd/mysql-proxy/proxy.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -232,6 +233,10 @@ type proxy struct {
 // handle performs the two-sided login translation for one client connection, then pipes.
 // The numbered steps are the login script described at the top of this file.
 func (p *proxy) handle(clientConn net.Conn) {
+	// Recover per connection: each runs in its own goroutine, and an unrecovered panic in any
+	// goroutine crashes the whole process — one malformed connection must not take the proxy
+	// down. Logged and dropped here; the deferred Close calls still run during unwinding.
+	defer recoverConn(clientConn.RemoteAddr().String())
 	defer func() { _ = clientConn.Close() }()
 	log := slog.With("remote", clientConn.RemoteAddr().String())
 
@@ -332,7 +337,10 @@ func (p *proxy) handle(clientConn net.Conn) {
 		return
 	}
 	if len(authResult) > 0 && authResult[0] == 0xff { // 0xff = ERR
-		code := uint16(authResult[1]) | uint16(authResult[2])<<8
+		code := uint16(0)
+		if len(authResult) >= 3 { // ERR = 0xff + 2-byte code; guard a truncated packet
+			code = uint16(authResult[1]) | uint16(authResult[2])<<8
+		}
 		log.Warn("backend auth failed", "user", username, "code", code)
 		return
 	}
@@ -343,6 +351,15 @@ func (p *proxy) handle(clientConn net.Conn) {
 	_ = backend.conn.SetDeadline(time.Time{})
 	pipe(clientConn, backend.conn)
 	log.Info("connection closed", "user", username)
+}
+
+// recoverConn swallows a panic from a connection handler so one bad connection can't crash the
+// proxy process. Deferred at the top of handle; logs the panic and stack for the given peer.
+func recoverConn(remote string) {
+	if r := recover(); r != nil {
+		slog.Error("recovered from panic in connection handler",
+			"remote", remote, "panic", r, "stack", string(debug.Stack()))
+	}
 }
 
 // pipe copies bytes in both directions until either side closes, then closes both so the

--- a/backend/cmd/mysql-proxy/proxy.go
+++ b/backend/cmd/mysql-proxy/proxy.go
@@ -39,10 +39,9 @@ const (
 )
 
 const (
-	maxPacket    = 16 * 1024 * 1024                       // max packet size we advertise (standard)
-	nativePlugin = "mysql_native_password"                // classic password plugin
-	clearPlugin  = "mysql_clear_password"                 // send-password-in-clear (what we ask the Go client for)
-	oidcPlugin   = "authentication_openid_connect_client" // StarRocks' JWT plugin (backend side)
+	maxPacket    = 16 * 1024 * 1024        // max packet size we advertise (standard)
+	nativePlugin = "mysql_native_password" // classic password plugin
+	clearPlugin  = "mysql_clear_password"  // send-password-in-clear (what we ask the Go client for)
 )
 
 // ---------------------------------------------------------------------------

--- a/backend/cmd/mysql-proxy/proxy.go
+++ b/backend/cmd/mysql-proxy/proxy.go
@@ -180,7 +180,11 @@ func readLenEncInt(b []byte) (n, consumed int) {
 	case b[0] == 0xfd && len(b) >= 4:
 		return int(uint32(b[1]) | uint32(b[2])<<8 | uint32(b[3])<<16), 4
 	case b[0] == 0xfe && len(b) >= 9:
-		return int(binary.LittleEndian.Uint64(b[1:9])), 9
+		v := binary.LittleEndian.Uint64(b[1:9])
+		if v > maxPacket { // longer than any legal MySQL packet payload — malformed
+			return 0, 0
+		}
+		return int(v), 9
 	}
 	return 0, 0
 }

--- a/backend/cmd/mysql-proxy/proxy.go
+++ b/backend/cmd/mysql-proxy/proxy.go
@@ -1,0 +1,366 @@
+package main
+
+// This file implements the MySQL wire-protocol translation that lets a Go client
+// (go-sql-driver, which can't speak StarRocks' JWT auth plugin) log in as a JWT user.
+//
+// The MySQL login handshake is a scripted exchange of "packets". Each packet is a 4-byte
+// header — 3 bytes little-endian payload length + 1 byte sequence number — followed by the
+// payload. Login goes: server sends a Handshake (its capabilities), client replies with a
+// HandshakeResponse (username + auth data), the server may send an AuthSwitchRequest ("use
+// this other auth method"), the client answers, and the server ends with OK or ERR.
+//
+// The proxy speaks two different dialects on its two sides during that handshake:
+//
+//	Go client  ──cleartext (mysql_clear_password: the JWT sent as a "password")──▶  proxy
+//	proxy      ──TLS + authentication_openid_connect_client (the JWT as auth data)──▶  StarRocks
+//
+// Once login succeeds it stops translating and just copies bytes both ways (see pipe).
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/binary"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MySQL capability flags — a bitfield where each bit advertises one feature. We only need
+// to set/clear a handful.
+const (
+	clientSSL        uint32 = 0x00000800 // connection will upgrade to TLS
+	clientProtocol41 uint32 = 0x00000200 // 4.1+ protocol (always on for us)
+	clientSecureConn uint32 = 0x00008000 // secure-auth handshake layout
+	clientPluginAuth uint32 = 0x00080000 // pluggable authentication
+)
+
+const (
+	maxPacket    = 16 * 1024 * 1024                       // max packet size we advertise (standard)
+	nativePlugin = "mysql_native_password"                // classic password plugin
+	clearPlugin  = "mysql_clear_password"                 // send-password-in-clear (what we ask the Go client for)
+	oidcPlugin   = "authentication_openid_connect_client" // StarRocks' JWT plugin (backend side)
+)
+
+// ---------------------------------------------------------------------------
+// Packet framing: read/write one MySQL packet over a connection.
+// ---------------------------------------------------------------------------
+
+type packetConn struct {
+	conn net.Conn
+}
+
+// read returns one packet's sequence number and payload. The 3-byte little-endian length
+// tells us exactly how many payload bytes follow the header.
+func (p *packetConn) read() (seq byte, payload []byte, err error) {
+	hdr := make([]byte, 4)
+	if _, err := io.ReadFull(p.conn, hdr); err != nil {
+		return 0, nil, err
+	}
+	length := int(uint32(hdr[0]) | uint32(hdr[1])<<8 | uint32(hdr[2])<<16)
+	seq = hdr[3]
+	payload = make([]byte, length)
+	if _, err := io.ReadFull(p.conn, payload); err != nil {
+		return 0, nil, err
+	}
+	return seq, payload, nil
+}
+
+// write frames payload with the 4-byte header (length + seq) and sends it.
+func (p *packetConn) write(seq byte, payload []byte) error {
+	pkt := make([]byte, 4+len(payload))
+	pkt[0] = byte(len(payload))
+	pkt[1] = byte(len(payload) >> 8)
+	pkt[2] = byte(len(payload) >> 16)
+	pkt[3] = seq
+	copy(pkt[4:], payload)
+	_, err := p.conn.Write(pkt)
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// Pure protocol helpers (unit-tested in proxy_test.go).
+// ---------------------------------------------------------------------------
+
+// extractUsername reads the null-terminated username from a client HandshakeResponse41.
+// That packet starts with a fixed 32-byte header (capabilities 4 + max_packet 4 +
+// charset 1 + 23 reserved zero bytes); the username follows immediately after.
+func extractUsername(handshakeResponse []byte) string {
+	if len(handshakeResponse) < 33 {
+		return ""
+	}
+	rest := handshakeResponse[32:]
+	if end := bytes.IndexByte(rest, 0); end >= 0 {
+		return string(rest[:end])
+	}
+	return string(rest)
+}
+
+// serverVersionEnd returns the index just past the NUL that terminates the server-version
+// string in a HandshakeV10 packet (byte 0 is protocol_version, then the version string).
+// The fixed-size fields that follow start there.
+func serverVersionEnd(handshake []byte) int {
+	i := 1
+	for i < len(handshake) && handshake[i] != 0 {
+		i++
+	}
+	return i + 1 // skip the NUL
+}
+
+// removeCapability clears one capability bit in a server HandshakeV10 packet. We use it to
+// strip CLIENT_SSL, so the Go client sees a server that "doesn't support TLS" and stays
+// cleartext — the proxy handles TLS toward StarRocks itself.
+//
+// After the server-version string the layout is: connection_id(4) + auth_salt(8) +
+// filler(1) + capability_flags_low(2) + charset(1) + status(2) + capability_flags_high(2).
+// The capability flags are historically split into a low and high 16-bit word, so we clear
+// the bit from whichever word it lives in.
+func removeCapability(handshake []byte, capability uint32) []byte {
+	low := serverVersionEnd(handshake) + 4 + 8 + 1
+	if low+2 > len(handshake) {
+		return handshake
+	}
+	capLow := uint16(handshake[low]) | uint16(handshake[low+1])<<8
+	capLow &^= uint16(capability & 0xffff) // &^= clears the masked bits
+	handshake[low] = byte(capLow)
+	handshake[low+1] = byte(capLow >> 8)
+
+	high := low + 2 + 1 + 2 // past capability_flags_low + charset(1) + status(2)
+	if high+2 <= len(handshake) {
+		capHigh := uint16(handshake[high]) | uint16(handshake[high+1])<<8
+		capHigh &^= uint16((capability >> 16) & 0xffff)
+		handshake[high] = byte(capHigh)
+		handshake[high+1] = byte(capHigh >> 8)
+	}
+	return handshake
+}
+
+// charsetFromHandshake reads the charset byte StarRocks chose (it sits right after the low
+// capability word), so we can echo it back in the packets we build. Defaults to utf8 (0x21).
+func charsetFromHandshake(handshake []byte) byte {
+	charset := serverVersionEnd(handshake) + 4 + 8 + 1 + 2
+	if charset < len(handshake) {
+		return handshake[charset]
+	}
+	return 0x21
+}
+
+// buildSSLRequest is the short packet we send to StarRocks to say "upgrade this connection
+// to TLS." It carries only capability flags (with CLIENT_SSL set) + max_packet + charset +
+// 23 reserved zero bytes; right after sending it we start the TLS handshake.
+func buildSSLRequest(charset byte) []byte {
+	caps := clientSSL | clientProtocol41 | clientSecureConn | clientPluginAuth
+	b := make([]byte, 0, 32)
+	b = binary.LittleEndian.AppendUint32(b, caps)
+	b = binary.LittleEndian.AppendUint32(b, maxPacket)
+	b = append(b, charset)
+	return append(b, make([]byte, 23)...)
+}
+
+// buildNativeHandshakeResponse is the login packet we send to StarRocks: it claims
+// mysql_native_password with EMPTY auth data. This is deliberate — StarRocks looks the user
+// up, sees it's a JWT user, and answers with an AuthSwitchRequest to the OIDC plugin, which
+// is the hook we use to hand over the JWT.
+func buildNativeHandshakeResponse(username string, charset byte) []byte {
+	caps := clientProtocol41 | clientSecureConn | clientPluginAuth
+	b := make([]byte, 0, 64+len(username))
+	b = binary.LittleEndian.AppendUint32(b, caps)
+	b = binary.LittleEndian.AppendUint32(b, maxPacket)
+	b = append(b, charset)
+	b = append(b, make([]byte, 23)...)
+	b = append(b, username...)
+	b = append(b, 0) // username terminator
+	b = append(b, 0) // empty auth data (length 0)
+	b = append(b, nativePlugin...)
+	return append(b, 0) // plugin-name terminator
+}
+
+// buildOIDCAuthResponse is the reply to StarRocks' AuthSwitchRequest: a required 0x01
+// capability-flag byte, then the JWT as a length-encoded string. The leading flag byte is
+// mandatory — StarRocks silently rejects the JWT sent without it.
+func buildOIDCAuthResponse(jwt []byte) []byte {
+	b := []byte{0x01}
+	b = appendLenEncInt(b, len(jwt))
+	return append(b, jwt...)
+}
+
+// appendLenEncInt writes n in MySQL's length-encoded-integer format: a single byte for
+// small values, or a marker byte (0xfc/0xfd/0xfe) followed by 2/3/8 little-endian bytes.
+func appendLenEncInt(b []byte, n int) []byte {
+	switch {
+	case n < 251:
+		return append(b, byte(n))
+	case n < 1<<16:
+		return binary.LittleEndian.AppendUint16(append(b, 0xfc), uint16(n))
+	case n < 1<<24:
+		return append(b, 0xfd, byte(n), byte(n>>8), byte(n>>16))
+	default:
+		return binary.LittleEndian.AppendUint64(append(b, 0xfe), uint64(n))
+	}
+}
+
+// authSwitchPacket tells the client to re-authenticate with mysql_clear_password, so it
+// sends us the raw JWT as if it were a cleartext password. (0xfe = AuthSwitchRequest.)
+func authSwitchPacket() []byte {
+	b := []byte{0xfe}
+	b = append(b, clearPlugin...)
+	return append(b, 0)
+}
+
+// errPacket builds an ERR packet (0xff = error): code + '#' + SQLSTATE + message.
+func errPacket(code uint16, sqlState, msg string) []byte {
+	b := binary.LittleEndian.AppendUint16([]byte{0xff}, code)
+	b = append(b, '#')
+	b = append(b, sqlState...)
+	return append(b, msg...)
+}
+
+// ---------------------------------------------------------------------------
+// Connection handling.
+// ---------------------------------------------------------------------------
+
+// proxy carries the backend target and TLS config shared across all connections.
+type proxy struct {
+	backendAddr string
+	tlsCfg      *tls.Config
+	// authTimeout bounds the login phase so a stalled peer can't pin a goroutine forever;
+	// it is cleared once the transparent pipe starts (piped sessions are long-lived).
+	authTimeout time.Duration
+}
+
+// handle performs the two-sided login translation for one client connection, then pipes.
+// The numbered steps are the login script described at the top of this file.
+func (p *proxy) handle(clientConn net.Conn) {
+	defer func() { _ = clientConn.Close() }()
+	log := slog.With("remote", clientConn.RemoteAddr().String())
+
+	backendTCP, err := net.DialTimeout("tcp", p.backendAddr, p.authTimeout)
+	if err != nil {
+		log.Error("backend connect failed", "error", err)
+		return
+	}
+	defer func() { _ = backendTCP.Close() }()
+
+	deadline := time.Now().Add(p.authTimeout)
+	_ = clientConn.SetDeadline(deadline)
+	_ = backendTCP.SetDeadline(deadline)
+
+	backend := &packetConn{conn: backendTCP}
+	client := &packetConn{conn: clientConn}
+
+	// 1. Read StarRocks' opening handshake.
+	_, hs, err := backend.read()
+	if err != nil {
+		log.Error("read backend handshake failed", "error", err)
+		return
+	}
+	charset := charsetFromHandshake(hs)
+
+	// 2. Tell StarRocks we want TLS, then upgrade the proxy→backend socket.
+	if err := backend.write(1, buildSSLRequest(charset)); err != nil {
+		log.Error("send SSL request failed", "error", err)
+		return
+	}
+	tlsConn := tls.Client(backendTCP, p.tlsCfg)
+	if err := tlsConn.Handshake(); err != nil {
+		log.Error("backend TLS handshake failed", "error", err)
+		return
+	}
+	backend.conn = tlsConn
+
+	// 3. Forward the handshake to the Go client, but with CLIENT_SSL stripped so it stays
+	//    cleartext and hands us the raw JWT. Copy first — removeCapability mutates in place.
+	if err := client.write(0, removeCapability(append([]byte(nil), hs...), clientSSL)); err != nil {
+		log.Error("send handshake to client failed", "error", err)
+		return
+	}
+
+	// 4. Read the client's first response — we only need the username from it.
+	_, clientResp, err := client.read()
+	if err != nil {
+		log.Error("read client response failed", "error", err)
+		return
+	}
+	username := extractUsername(clientResp)
+
+	// 5. Ask the client to switch to cleartext so it resends the "password" (the JWT) raw.
+	if err := client.write(2, authSwitchPacket()); err != nil {
+		log.Error("auth switch to client failed", "error", err)
+		return
+	}
+
+	// 6. Read the JWT (a cleartext-plugin payload is the password + a trailing NUL).
+	_, jwtPayload, err := client.read()
+	if err != nil {
+		log.Error("read JWT failed", "error", err)
+		return
+	}
+	jwt := strings.TrimRight(string(jwtPayload), "\x00")
+	if !strings.HasPrefix(jwt, "ey") { // every JWT starts with base64url({"alg"... → "ey"
+		log.Warn("client did not send a JWT", "user", username)
+		_ = client.write(4, errPacket(1045, "28000", "expected JWT as password"))
+		return
+	}
+
+	// 7. Log in to StarRocks with native_password + empty auth; it will ask us to switch.
+	if err := backend.write(2, buildNativeHandshakeResponse(username, charset)); err != nil {
+		log.Error("send auth to backend failed", "error", err)
+		return
+	}
+	seq, authResult, err := backend.read()
+	if err != nil {
+		log.Error("read backend auth result failed", "error", err)
+		return
+	}
+
+	// 8. On the AuthSwitchRequest (0xfe), send the JWT in OIDC format and read the verdict.
+	if len(authResult) > 0 && authResult[0] == 0xfe {
+		if err := backend.write(seq+1, buildOIDCAuthResponse([]byte(jwt))); err != nil {
+			log.Error("send OIDC auth response failed", "error", err)
+			return
+		}
+		if _, authResult, err = backend.read(); err != nil {
+			log.Error("read final auth result failed", "error", err)
+			return
+		}
+	}
+
+	// 9. Relay StarRocks' verdict (OK or ERR) back to the client.
+	if err := client.write(4, authResult); err != nil {
+		log.Error("forward auth result failed", "error", err)
+		return
+	}
+	if len(authResult) > 0 && authResult[0] == 0xff { // 0xff = ERR
+		code := uint16(authResult[1]) | uint16(authResult[2])<<8
+		log.Warn("backend auth failed", "user", username, "code", code)
+		return
+	}
+	log.Info("authenticated, piping", "user", username)
+
+	// 10. Login done. Clear the deadline (sessions are long-lived) and become a dumb tube.
+	_ = clientConn.SetDeadline(time.Time{})
+	_ = backend.conn.SetDeadline(time.Time{})
+	pipe(clientConn, backend.conn)
+	log.Info("connection closed", "user", username)
+}
+
+// pipe copies bytes in both directions until either side closes, then closes both so the
+// other copy goroutine unblocks and returns.
+func pipe(a, b net.Conn) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	copyOneWay := func(dst, src net.Conn) {
+		defer wg.Done()
+		if _, err := io.Copy(dst, src); err != nil && !errors.Is(err, net.ErrClosed) {
+			slog.Debug("pipe copy ended", "error", err)
+		}
+		_ = dst.Close()
+		_ = src.Close()
+	}
+	go copyOneWay(a, b)
+	go copyOneWay(b, a)
+	wg.Wait()
+}

--- a/backend/cmd/mysql-proxy/proxy.go
+++ b/backend/cmd/mysql-proxy/proxy.go
@@ -123,17 +123,16 @@ func removeCapability(handshake []byte, capability uint32) []byte {
 	if low+2 > len(handshake) {
 		return handshake
 	}
-	capLow := uint16(handshake[low]) | uint16(handshake[low+1])<<8
-	capLow &^= uint16(capability & 0xffff) // &^= clears the masked bits
-	handshake[low] = byte(capLow)
-	handshake[low+1] = byte(capLow >> 8)
+	// Clear the capability's set bits from the little-endian field byte by byte (&^= clears
+	// bits), avoiding any 16-bit narrowing conversion. Low word = bytes [low], [low+1].
+	handshake[low] &^= byte(capability)
+	handshake[low+1] &^= byte(capability >> 8)
 
 	high := low + 2 + 1 + 2 // past capability_flags_low + charset(1) + status(2)
 	if high+2 <= len(handshake) {
-		capHigh := uint16(handshake[high]) | uint16(handshake[high+1])<<8
-		capHigh &^= uint16((capability >> 16) & 0xffff)
-		handshake[high] = byte(capHigh)
-		handshake[high+1] = byte(capHigh >> 8)
+		// High word (bits 16-31) = bytes [high], [high+1].
+		handshake[high] &^= byte(capability >> 16)
+		handshake[high+1] &^= byte(capability >> 24)
 	}
 	return handshake
 }
@@ -194,7 +193,7 @@ func appendLenEncInt(b []byte, n int) []byte {
 	case n < 251:
 		return append(b, byte(n))
 	case n < 1<<16:
-		return binary.LittleEndian.AppendUint16(append(b, 0xfc), uint16(n))
+		return append(b, 0xfc, byte(n), byte(n>>8))
 	case n < 1<<24:
 		return append(b, 0xfd, byte(n), byte(n>>8), byte(n>>16))
 	default:

--- a/backend/cmd/mysql-proxy/proxy.go
+++ b/backend/cmd/mysql-proxy/proxy.go
@@ -45,6 +45,19 @@ const (
 	clearPlugin  = "mysql_clear_password"  // send-password-in-clear (what we ask the Go client for)
 )
 
+// HandshakeV10 fixed-field byte sizes, in wire order after the NUL-terminated server_version
+// string. Used to locate the capability flags / charset by offset (see removeCapability and
+// charsetFromHandshake) instead of magic numbers.
+const (
+	hsConnIDLen  = 4 // connection_id
+	hsSaltLen    = 8 // auth-plugin-data part 1 (salt)
+	hsFillerLen  = 1 // filler byte
+	hsCapLowLen  = 2 // capability_flags, low 16 bits
+	hsCharsetLen = 1 // charset
+	hsStatusLen  = 2 // status_flags
+	hsCapHighLen = 2 // capability_flags, high 16 bits
+)
+
 // ---------------------------------------------------------------------------
 // Packet framing: read/write one MySQL packet over a connection.
 // ---------------------------------------------------------------------------
@@ -119,8 +132,8 @@ func serverVersionEnd(handshake []byte) int {
 // The capability flags are historically split into a low and high 16-bit word, so we clear
 // the bit from whichever word it lives in.
 func removeCapability(handshake []byte, capability uint32) []byte {
-	low := serverVersionEnd(handshake) + 4 + 8 + 1
-	if low+2 > len(handshake) {
+	low := serverVersionEnd(handshake) + hsConnIDLen + hsSaltLen + hsFillerLen
+	if low+hsCapLowLen > len(handshake) {
 		return handshake
 	}
 	// Clear the capability's set bits from the little-endian field byte by byte (&^= clears
@@ -128,8 +141,8 @@ func removeCapability(handshake []byte, capability uint32) []byte {
 	handshake[low] &^= byte(capability)
 	handshake[low+1] &^= byte(capability >> 8)
 
-	high := low + 2 + 1 + 2 // past capability_flags_low + charset(1) + status(2)
-	if high+2 <= len(handshake) {
+	high := low + hsCapLowLen + hsCharsetLen + hsStatusLen
+	if high+hsCapHighLen <= len(handshake) {
 		// High word (bits 16-31) = bytes [high], [high+1].
 		handshake[high] &^= byte(capability >> 16)
 		handshake[high+1] &^= byte(capability >> 24)
@@ -140,7 +153,7 @@ func removeCapability(handshake []byte, capability uint32) []byte {
 // charsetFromHandshake reads the charset byte StarRocks chose (it sits right after the low
 // capability word), so we can echo it back in the packets we build. Defaults to utf8 (0x21).
 func charsetFromHandshake(handshake []byte) byte {
-	charset := serverVersionEnd(handshake) + 4 + 8 + 1 + 2
+	charset := serverVersionEnd(handshake) + hsConnIDLen + hsSaltLen + hsFillerLen + hsCapLowLen
 	if charset < len(handshake) {
 		return handshake[charset]
 	}

--- a/backend/cmd/mysql-proxy/proxy.go
+++ b/backend/cmd/mysql-proxy/proxy.go
@@ -33,16 +33,20 @@ import (
 // MySQL capability flags — a bitfield where each bit advertises one feature. We only need
 // to set/clear a handful.
 const (
-	clientSSL        uint32 = 0x00000800 // connection will upgrade to TLS
-	clientProtocol41 uint32 = 0x00000200 // 4.1+ protocol (always on for us)
-	clientSecureConn uint32 = 0x00008000 // secure-auth handshake layout
-	clientPluginAuth uint32 = 0x00080000 // pluggable authentication
+	clientConnectWithDB    uint32 = 0x00000008 // handshake response carries a default database
+	clientSSL              uint32 = 0x00000800 // connection will upgrade to TLS
+	clientProtocol41       uint32 = 0x00000200 // 4.1+ protocol (always on for us)
+	clientSecureConn       uint32 = 0x00008000 // secure-auth handshake layout
+	clientPluginAuth       uint32 = 0x00080000 // pluggable authentication
+	clientConnectAttrs     uint32 = 0x00100000 // handshake response carries key/value attributes
+	clientPluginAuthLenEnc uint32 = 0x00200000 // auth response is length-encoded (vs 1-byte length)
 )
 
 const (
 	maxPacket    = 16 * 1024 * 1024        // max packet size we advertise (standard)
 	nativePlugin = "mysql_native_password" // classic password plugin
 	clearPlugin  = "mysql_clear_password"  // send-password-in-clear (what we ask the Go client for)
+	oidcPlugin   = "authentication_openid_connect_client"
 )
 
 // HandshakeV10 fixed-field byte sizes, in wire order after the NUL-terminated server_version
@@ -98,18 +102,87 @@ func (p *packetConn) write(seq byte, payload []byte) error {
 // Pure protocol helpers (unit-tested in proxy_test.go).
 // ---------------------------------------------------------------------------
 
-// extractUsername reads the null-terminated username from a client HandshakeResponse41.
-// That packet starts with a fixed 32-byte header (capabilities 4 + max_packet 4 +
-// charset 1 + 23 reserved zero bytes); the username follows immediately after.
-func extractUsername(handshakeResponse []byte) string {
-	if len(handshakeResponse) < 33 {
-		return ""
+// clientHello is what we keep from the client's HandshakeResponse41: its capability flags and
+// charset (mirrored toward StarRocks so both hops agree on the post-auth wire format), the
+// username, and the default database when the DSN carries one (CLIENT_CONNECT_WITH_DB).
+type clientHello struct {
+	caps     uint32
+	charset  byte
+	username string
+	database string
+}
+
+// parseClientHello decodes a HandshakeResponse41: a fixed 32-byte header (capabilities 4 +
+// max_packet 4 + charset 1 + 23 reserved zero bytes), then the NUL-terminated username, then
+// the auth response (whose length prefix depends on the capability bits), then the database
+// (NUL-terminated) if CLIENT_CONNECT_WITH_DB is set.
+func parseClientHello(resp []byte) (clientHello, error) {
+	var h clientHello
+	if len(resp) < 33 {
+		return h, errors.New("handshake response too short")
 	}
-	rest := handshakeResponse[32:]
-	if end := bytes.IndexByte(rest, 0); end >= 0 {
-		return string(rest[:end])
+	h.caps = binary.LittleEndian.Uint32(resp[0:4])
+	h.charset = resp[8]
+
+	i := 32
+	end := bytes.IndexByte(resp[i:], 0)
+	if end < 0 {
+		return h, errors.New("unterminated username")
 	}
-	return string(rest)
+	h.username = string(resp[i : i+end])
+	i += end + 1
+
+	// Skip the auth response — we replace it anyway; we only parse past it to reach the database.
+	switch {
+	case h.caps&clientPluginAuthLenEnc != 0:
+		n, consumed := readLenEncInt(resp[i:])
+		if consumed == 0 {
+			return h, errors.New("malformed auth-response length")
+		}
+		i += consumed + n
+	case h.caps&clientSecureConn != 0:
+		if i >= len(resp) {
+			return h, errors.New("missing auth-response length")
+		}
+		i += 1 + int(resp[i])
+	default:
+		nul := bytes.IndexByte(resp[i:], 0)
+		if nul < 0 {
+			return h, errors.New("unterminated auth response")
+		}
+		i += nul + 1
+	}
+	if i > len(resp) {
+		return h, errors.New("auth response overruns packet")
+	}
+
+	if h.caps&clientConnectWithDB != 0 && i < len(resp) {
+		if nul := bytes.IndexByte(resp[i:], 0); nul >= 0 {
+			h.database = string(resp[i : i+nul])
+		} else {
+			h.database = string(resp[i:])
+		}
+	}
+	return h, nil
+}
+
+// readLenEncInt decodes a MySQL length-encoded integer, returning the value and the number of
+// bytes consumed (consumed == 0 means malformed/truncated).
+func readLenEncInt(b []byte) (n, consumed int) {
+	if len(b) == 0 {
+		return 0, 0
+	}
+	switch {
+	case b[0] < 0xfb:
+		return int(b[0]), 1
+	case b[0] == 0xfc && len(b) >= 3:
+		return int(binary.LittleEndian.Uint16(b[1:3])), 3
+	case b[0] == 0xfd && len(b) >= 4:
+		return int(uint32(b[1]) | uint32(b[2])<<8 | uint32(b[3])<<16), 4
+	case b[0] == 0xfe && len(b) >= 9:
+		return int(binary.LittleEndian.Uint64(b[1:9])), 9
+	}
+	return 0, 0
 }
 
 // serverVersionEnd returns the index just past the NUL that terminates the server-version
@@ -160,13 +233,43 @@ func charsetFromHandshake(handshake []byte) byte {
 	return 0x21
 }
 
+// serverCapabilities reassembles the split low/high capability words of a HandshakeV10 packet
+// (same layout removeCapability walks). Returns 0 on a truncated packet.
+func serverCapabilities(handshake []byte) uint32 {
+	low := serverVersionEnd(handshake) + hsConnIDLen + hsSaltLen + hsFillerLen
+	if low+hsCapLowLen > len(handshake) {
+		return 0
+	}
+	caps := uint32(binary.LittleEndian.Uint16(handshake[low:]))
+	high := low + hsCapLowLen + hsCharsetLen + hsStatusLen
+	if high+hsCapHighLen <= len(handshake) {
+		caps |= uint32(binary.LittleEndian.Uint16(handshake[high:])) << 16
+	}
+	return caps
+}
+
+// backendCaps derives the capability flags the proxy presents to StarRocks from what the
+// client negotiated with us. After login the pipe is a dumb byte copier, so a capability
+// active on one hop but not the other (COMPRESS, DEPRECATE_EOF, MULTI_STATEMENTS, ...)
+// corrupts the framing — mirroring the client's flags keeps both hops in agreement. We strip:
+// CLIENT_SSL (the proxy does its own TLS), lenenc-auth (our auth data is empty, 1-byte
+// length), and connect-attrs (we don't forward the client's attributes).
+func backendCaps(clientCaps uint32, database string) uint32 {
+	caps := clientCaps &^ (clientSSL | clientPluginAuthLenEnc | clientConnectAttrs)
+	caps |= clientProtocol41 | clientSecureConn | clientPluginAuth
+	if database == "" {
+		caps &^= clientConnectWithDB
+	}
+	return caps
+}
+
 // buildSSLRequest is the short packet we send to StarRocks to say "upgrade this connection
-// to TLS." It carries only capability flags (with CLIENT_SSL set) + max_packet + charset +
-// 23 reserved zero bytes; right after sending it we start the TLS handshake.
-func buildSSLRequest(charset byte) []byte {
-	caps := clientSSL | clientProtocol41 | clientSecureConn | clientPluginAuth
+// to TLS." It carries only capability flags (caps must be the same set later sent in the
+// handshake response, plus CLIENT_SSL) + max_packet + charset + 23 reserved zero bytes; right
+// after sending it we start the TLS handshake.
+func buildSSLRequest(caps uint32, charset byte) []byte {
 	b := make([]byte, 0, 32)
-	b = binary.LittleEndian.AppendUint32(b, caps)
+	b = binary.LittleEndian.AppendUint32(b, caps|clientSSL)
 	b = binary.LittleEndian.AppendUint32(b, maxPacket)
 	b = append(b, charset)
 	return append(b, make([]byte, 23)...)
@@ -175,10 +278,10 @@ func buildSSLRequest(charset byte) []byte {
 // buildNativeHandshakeResponse is the login packet we send to StarRocks: it claims
 // mysql_native_password with EMPTY auth data. This is deliberate — StarRocks looks the user
 // up, sees it's a JWT user, and answers with an AuthSwitchRequest to the OIDC plugin, which
-// is the hook we use to hand over the JWT.
-func buildNativeHandshakeResponse(username string, charset byte) []byte {
-	caps := clientProtocol41 | clientSecureConn | clientPluginAuth
-	b := make([]byte, 0, 64+len(username))
+// is the hook we use to hand over the JWT. caps/charset/database mirror the client's own
+// handshake response (see backendCaps) so the DSN's default database survives the proxy.
+func buildNativeHandshakeResponse(caps uint32, charset byte, username, database string) []byte {
+	b := make([]byte, 0, 64+len(username)+len(database))
 	b = binary.LittleEndian.AppendUint32(b, caps)
 	b = binary.LittleEndian.AppendUint32(b, maxPacket)
 	b = append(b, charset)
@@ -186,6 +289,10 @@ func buildNativeHandshakeResponse(username string, charset byte) []byte {
 	b = append(b, username...)
 	b = append(b, 0) // username terminator
 	b = append(b, 0) // empty auth data (length 0)
+	if caps&clientConnectWithDB != 0 {
+		b = append(b, database...)
+		b = append(b, 0) // database terminator
+	}
 	b = append(b, nativePlugin...)
 	return append(b, 0) // plugin-name terminator
 }
@@ -220,6 +327,16 @@ func authSwitchPacket() []byte {
 	b := []byte{0xfe}
 	b = append(b, clearPlugin...)
 	return append(b, 0)
+}
+
+// authSwitchPluginName extracts the plugin name from an AuthSwitchRequest
+// (0xfe + NUL-terminated name + plugin data).
+func authSwitchPluginName(pkt []byte) string {
+	rest := pkt[1:]
+	if nul := bytes.IndexByte(rest, 0); nul >= 0 {
+		return string(rest[:nul])
+	}
+	return string(rest)
 }
 
 // errPacket builds an ERR packet (0xff = error): code + '#' + SQLSTATE + message.
@@ -267,16 +384,65 @@ func (p *proxy) handle(clientConn net.Conn) {
 	backend := &packetConn{conn: backendTCP}
 	client := &packetConn{conn: clientConn}
 
-	// 1. Read StarRocks' opening handshake.
+	// 1. Read StarRocks' opening handshake; it must offer TLS or the OIDC hop can't happen.
 	_, hs, err := backend.read()
 	if err != nil {
 		log.Error("read backend handshake failed", "error", err)
 		return
 	}
-	charset := charsetFromHandshake(hs)
+	if serverCapabilities(hs)&clientSSL == 0 {
+		log.Error("backend does not advertise CLIENT_SSL — enable TLS on the StarRocks FE")
+		return
+	}
 
-	// 2. Tell StarRocks we want TLS, then upgrade the proxy→backend socket.
-	if err := backend.write(1, buildSSLRequest(charset)); err != nil {
+	// 2. Forward the handshake to the Go client, but with CLIENT_SSL stripped so it stays
+	//    cleartext and hands us the raw JWT. Copy first — removeCapability mutates in place.
+	if err := client.write(0, removeCapability(append([]byte(nil), hs...), clientSSL)); err != nil {
+		log.Error("send handshake to client failed", "error", err)
+		return
+	}
+
+	// 3. Read the client's response: its capabilities, charset, username and — when the DSN
+	//    carries one — the default database, all mirrored toward StarRocks below.
+	_, clientResp, err := client.read()
+	if err != nil {
+		log.Error("read client response failed", "error", err)
+		return
+	}
+	hello, err := parseClientHello(clientResp)
+	if err != nil {
+		log.Warn("malformed client handshake response", "error", err)
+		_ = client.write(2, errPacket(1045, "28000", "malformed handshake response"))
+		return
+	}
+
+	// 4. Ask the client to switch to cleartext so it resends the "password" (the JWT) raw.
+	if err := client.write(2, authSwitchPacket()); err != nil {
+		log.Error("auth switch to client failed", "error", err)
+		return
+	}
+
+	// 5. Read the JWT (a cleartext-plugin payload is the password + a trailing NUL).
+	_, jwtPayload, err := client.read()
+	if err != nil {
+		log.Error("read JWT failed", "error", err)
+		return
+	}
+	jwt := strings.TrimRight(string(jwtPayload), "\x00")
+	if !strings.HasPrefix(jwt, "ey") { // every JWT starts with base64url({"alg"... → "ey"
+		log.Warn("client did not send a JWT", "user", hello.username)
+		_ = client.write(4, errPacket(1045, "28000", "expected JWT as password"))
+		return
+	}
+
+	// 6. Tell StarRocks we want TLS (mirroring the client's capabilities so both hops agree on
+	//    the post-auth wire format), then upgrade the proxy→backend socket.
+	caps := backendCaps(hello.caps, hello.database)
+	charset := hello.charset
+	if charset == 0 {
+		charset = charsetFromHandshake(hs)
+	}
+	if err := backend.write(1, buildSSLRequest(caps, charset)); err != nil {
 		log.Error("send SSL request failed", "error", err)
 		return
 	}
@@ -287,42 +453,8 @@ func (p *proxy) handle(clientConn net.Conn) {
 	}
 	backend.conn = tlsConn
 
-	// 3. Forward the handshake to the Go client, but with CLIENT_SSL stripped so it stays
-	//    cleartext and hands us the raw JWT. Copy first — removeCapability mutates in place.
-	if err := client.write(0, removeCapability(append([]byte(nil), hs...), clientSSL)); err != nil {
-		log.Error("send handshake to client failed", "error", err)
-		return
-	}
-
-	// 4. Read the client's first response — we only need the username from it.
-	_, clientResp, err := client.read()
-	if err != nil {
-		log.Error("read client response failed", "error", err)
-		return
-	}
-	username := extractUsername(clientResp)
-
-	// 5. Ask the client to switch to cleartext so it resends the "password" (the JWT) raw.
-	if err := client.write(2, authSwitchPacket()); err != nil {
-		log.Error("auth switch to client failed", "error", err)
-		return
-	}
-
-	// 6. Read the JWT (a cleartext-plugin payload is the password + a trailing NUL).
-	_, jwtPayload, err := client.read()
-	if err != nil {
-		log.Error("read JWT failed", "error", err)
-		return
-	}
-	jwt := strings.TrimRight(string(jwtPayload), "\x00")
-	if !strings.HasPrefix(jwt, "ey") { // every JWT starts with base64url({"alg"... → "ey"
-		log.Warn("client did not send a JWT", "user", username)
-		_ = client.write(4, errPacket(1045, "28000", "expected JWT as password"))
-		return
-	}
-
 	// 7. Log in to StarRocks with native_password + empty auth; it will ask us to switch.
-	if err := backend.write(2, buildNativeHandshakeResponse(username, charset)); err != nil {
+	if err := backend.write(2, buildNativeHandshakeResponse(caps, charset, hello.username, hello.database)); err != nil {
 		log.Error("send auth to backend failed", "error", err)
 		return
 	}
@@ -334,6 +466,13 @@ func (p *proxy) handle(clientConn net.Conn) {
 
 	// 8. On the AuthSwitchRequest (0xfe), send the JWT in OIDC format and read the verdict.
 	if len(authResult) > 0 && authResult[0] == 0xfe {
+		if plugin := authSwitchPluginName(authResult); plugin != oidcPlugin {
+			// Non-JWT user (or misconfigured FE): our OIDC-formatted reply would only produce a
+			// confusing backend error, so fail fast with a clear one.
+			log.Error("backend requested unsupported auth plugin", "plugin", plugin, "user", hello.username)
+			_ = client.write(4, errPacket(1045, "28000", "backend requested unsupported auth plugin: "+plugin))
+			return
+		}
 		if err := backend.write(seq+1, buildOIDCAuthResponse([]byte(jwt))); err != nil {
 			log.Error("send OIDC auth response failed", "error", err)
 			return
@@ -354,16 +493,16 @@ func (p *proxy) handle(clientConn net.Conn) {
 		if len(authResult) >= 3 { // ERR = 0xff + 2-byte code; guard a truncated packet
 			code = uint16(authResult[1]) | uint16(authResult[2])<<8
 		}
-		log.Warn("backend auth failed", "user", username, "code", code)
+		log.Warn("backend auth failed", "user", hello.username, "code", code)
 		return
 	}
-	log.Info("authenticated, piping", "user", username)
+	log.Info("authenticated, piping", "user", hello.username)
 
 	// 10. Login done. Clear the deadline (sessions are long-lived) and become a dumb tube.
 	_ = clientConn.SetDeadline(time.Time{})
 	_ = backend.conn.SetDeadline(time.Time{})
 	pipe(clientConn, backend.conn)
-	log.Info("connection closed", "user", username)
+	log.Info("connection closed", "user", hello.username)
 }
 
 // recoverConn swallows a panic from a connection handler so one bad connection can't crash the

--- a/backend/cmd/mysql-proxy/proxy_test.go
+++ b/backend/cmd/mysql-proxy/proxy_test.go
@@ -24,13 +24,87 @@ func testHandshake(capLow, capHigh uint16, charset byte) []byte {
 	return h
 }
 
-func Test_extractUsername_ReadsNullTerminatedNameAfterHeader(t *testing.T) {
-	resp := append(make([]byte, 32), []byte("alice\x00trailing-junk")...)
-	assert.Equal(t, "alice", extractUsername(resp))
+// testClientHello builds a HandshakeResponse41 payload: caps + max_packet + charset + 23
+// reserved bytes, username NUL, 1-byte-length auth response, then optional database NUL.
+func testClientHello(caps uint32, charset byte, username string, auth []byte, database string) []byte {
+	b := binary.LittleEndian.AppendUint32(nil, caps)
+	b = binary.LittleEndian.AppendUint32(b, maxPacket)
+	b = append(b, charset)
+	b = append(b, make([]byte, 23)...)
+	b = append(b, username...)
+	b = append(b, 0)
+	b = append(b, byte(len(auth)))
+	b = append(b, auth...)
+	if caps&clientConnectWithDB != 0 {
+		b = append(b, database...)
+		b = append(b, 0)
+	}
+	return b
 }
 
-func Test_extractUsername_ShortPacketYieldsEmpty(t *testing.T) {
-	assert.Equal(t, "", extractUsername(make([]byte, 10)))
+func Test_parseClientHello_ReadsCapsCharsetAndUsername(t *testing.T) {
+	resp := testClientHello(clientProtocol41|clientSecureConn, 0x2d, "alice", []byte{1, 2, 3}, "")
+
+	h, err := parseClientHello(resp)
+
+	require.NoError(t, err)
+	assert.Equal(t, clientProtocol41|clientSecureConn, h.caps)
+	assert.Equal(t, byte(0x2d), h.charset)
+	assert.Equal(t, "alice", h.username)
+	assert.Empty(t, h.database)
+}
+
+func Test_parseClientHello_ReadsDatabaseWhenConnectWithDB(t *testing.T) {
+	resp := testClientHello(clientSecureConn|clientConnectWithDB, 0x21, "alice", nil, "radiant")
+
+	h, err := parseClientHello(resp)
+
+	require.NoError(t, err)
+	assert.Equal(t, "radiant", h.database)
+}
+
+func Test_parseClientHello_SkipsLenEncAuthResponse(t *testing.T) {
+	// go-sql-driver switches to a length-encoded auth response for long auth data.
+	caps := clientSecureConn | clientPluginAuthLenEnc | clientConnectWithDB
+	b := binary.LittleEndian.AppendUint32(nil, caps)
+	b = binary.LittleEndian.AppendUint32(b, maxPacket)
+	b = append(b, 0x21)
+	b = append(b, make([]byte, 23)...)
+	b = append(b, "alice"...)
+	b = append(b, 0)
+	b = appendLenEncInt(b, 300)
+	b = append(b, bytes.Repeat([]byte{0xaa}, 300)...)
+	b = append(b, "radiant\x00"...)
+
+	h, err := parseClientHello(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, "alice", h.username)
+	assert.Equal(t, "radiant", h.database)
+}
+
+func Test_parseClientHello_ShortPacketErrors(t *testing.T) {
+	_, err := parseClientHello(make([]byte, 10))
+	assert.Error(t, err)
+}
+
+func Test_parseClientHello_TruncatedAuthResponseErrors(t *testing.T) {
+	resp := testClientHello(clientSecureConn, 0x21, "alice", nil, "")
+	resp[len(resp)-1] = 200 // auth-response length points past the packet end
+
+	_, err := parseClientHello(resp)
+
+	assert.Error(t, err)
+}
+
+func Test_readLenEncInt_DecodesEachLengthClass(t *testing.T) {
+	for _, want := range []int{10, 300, 70000} {
+		got, consumed := readLenEncInt(appendLenEncInt(nil, want))
+		assert.Equal(t, want, got)
+		assert.NotZero(t, consumed)
+	}
+	_, consumed := readLenEncInt([]byte{0xfc}) // truncated 2-byte length
+	assert.Zero(t, consumed)
 }
 
 func Test_removeCapability_ClearsSSLBitAndPreservesOthers(t *testing.T) {
@@ -53,7 +127,7 @@ func Test_charsetFromHandshake_ShortPacketDefaultsToUtf8(t *testing.T) {
 }
 
 func Test_buildSSLRequest_SetsSSLCapabilityAndCharset(t *testing.T) {
-	req := buildSSLRequest(0x21)
+	req := buildSSLRequest(clientProtocol41|clientSecureConn|clientPluginAuth, 0x21)
 
 	require.Len(t, req, 32)
 	assert.NotZero(t, binary.LittleEndian.Uint32(req[0:4])&clientSSL, "CLIENT_SSL advertised")
@@ -61,11 +135,58 @@ func Test_buildSSLRequest_SetsSSLCapabilityAndCharset(t *testing.T) {
 }
 
 func Test_buildNativeHandshakeResponse_CarriesUsernameNativePluginAndNoSSL(t *testing.T) {
-	resp := buildNativeHandshakeResponse("alice", 0x21)
+	caps := backendCaps(clientProtocol41, "")
+
+	resp := buildNativeHandshakeResponse(caps, 0x21, "alice", "")
 
 	assert.Zero(t, binary.LittleEndian.Uint32(resp[0:4])&clientSSL, "client stays cleartext (no SSL)")
 	assert.True(t, bytes.Contains(resp, []byte("alice\x00")), "username present and terminated")
 	assert.True(t, bytes.HasSuffix(resp, []byte(nativePlugin+"\x00")), "declares native_password plugin")
+}
+
+func Test_buildNativeHandshakeResponse_ForwardsDatabase(t *testing.T) {
+	caps := backendCaps(clientProtocol41|clientConnectWithDB, "radiant")
+
+	resp := buildNativeHandshakeResponse(caps, 0x21, "alice", "radiant")
+
+	assert.NotZero(t, binary.LittleEndian.Uint32(resp[0:4])&clientConnectWithDB)
+	assert.True(t, bytes.Contains(resp, []byte("alice\x00\x00radiant\x00")),
+		"database follows the empty auth response, before the plugin name")
+}
+
+func Test_backendCaps_MirrorsClientAndStripsProxyHandledBits(t *testing.T) {
+	clientAsked := clientProtocol41 | clientSSL | clientPluginAuthLenEnc | clientConnectAttrs |
+		clientConnectWithDB | 0x00010000 // arbitrary extra bit (e.g. MULTI_STATEMENTS) must survive
+
+	caps := backendCaps(clientAsked, "radiant")
+
+	assert.Zero(t, caps&(clientSSL|clientPluginAuthLenEnc|clientConnectAttrs), "proxy-handled bits stripped")
+	assert.NotZero(t, caps&0x00010000, "client's other capability bits forwarded")
+	assert.NotZero(t, caps&clientConnectWithDB, "CONNECT_WITH_DB kept when a database is present")
+	assert.NotZero(t, caps&(clientProtocol41|clientSecureConn|clientPluginAuth), "proxy minimum always set")
+}
+
+func Test_backendCaps_DropsConnectWithDBWhenNoDatabase(t *testing.T) {
+	assert.Zero(t, backendCaps(clientConnectWithDB, "")&clientConnectWithDB)
+}
+
+func Test_serverCapabilities_ReassemblesLowAndHighWords(t *testing.T) {
+	hs := testHandshake(uint16(clientSSL|clientProtocol41), uint16(clientPluginAuth>>16), 0x21)
+
+	caps := serverCapabilities(hs)
+
+	assert.NotZero(t, caps&clientSSL)
+	assert.NotZero(t, caps&clientProtocol41)
+	assert.NotZero(t, caps&clientPluginAuth, "high word reassembled into bits 16-31")
+}
+
+func Test_serverCapabilities_TruncatedPacketYieldsZero(t *testing.T) {
+	assert.Zero(t, serverCapabilities([]byte{0x0a, 0x00}))
+}
+
+func Test_authSwitchPluginName_ExtractsNulTerminatedName(t *testing.T) {
+	pkt := append([]byte{0xfe}, oidcPlugin+"\x00plugin-data"...)
+	assert.Equal(t, oidcPlugin, authSwitchPluginName(pkt))
 }
 
 func Test_buildOIDCAuthResponse_SmallToken(t *testing.T) {

--- a/backend/cmd/mysql-proxy/proxy_test.go
+++ b/backend/cmd/mysql-proxy/proxy_test.go
@@ -107,6 +107,14 @@ func Test_readLenEncInt_DecodesEachLengthClass(t *testing.T) {
 	assert.Zero(t, consumed)
 }
 
+func Test_readLenEncInt_RejectsOversizedEightByteLength(t *testing.T) {
+	oversized := binary.LittleEndian.AppendUint64([]byte{0xfe}, uint64(maxPacket)+1)
+
+	_, consumed := readLenEncInt(oversized)
+
+	assert.Zero(t, consumed, "length beyond max packet size is malformed, not a valid int")
+}
+
 func Test_removeCapability_ClearsSSLBitAndPreservesOthers(t *testing.T) {
 	hs := testHandshake(uint16(clientSSL|clientProtocol41), 0x00f0, 0x21)
 

--- a/backend/cmd/mysql-proxy/proxy_test.go
+++ b/backend/cmd/mysql-proxy/proxy_test.go
@@ -97,6 +97,15 @@ func Test_authSwitchPacket_RequestsClearPassword(t *testing.T) {
 	assert.Equal(t, append([]byte{0xfe}, append([]byte(clearPlugin), 0)...), authSwitchPacket())
 }
 
+func Test_recoverConn_ContainsPanicSoTheProxySurvives(t *testing.T) {
+	// A panic in a connection handler must be swallowed (each runs in its own goroutine, so an
+	// unrecovered panic would crash the whole process). Deferring recoverConn contains it.
+	assert.NotPanics(t, func() {
+		defer recoverConn("test-remote")
+		panic("boom in handler")
+	})
+}
+
 func Test_errPacket_EncodesCodeStateAndMessage(t *testing.T) {
 	out := errPacket(1045, "28000", "nope")
 

--- a/backend/cmd/mysql-proxy/proxy_test.go
+++ b/backend/cmd/mysql-proxy/proxy_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testHandshake builds a minimal HandshakeV10 packet with the given capability words and
+// charset, matching the field layout removeCapability/charsetFromHandshake walk.
+func testHandshake(capLow, capHigh uint16, charset byte) []byte {
+	h := make([]byte, 27)
+	h[0] = 0x0a          // protocol_version
+	copy(h[1:], "8.0.0") // server_version (bytes 1..5)
+	h[6] = 0             // NUL terminator
+	// bytes 7..10 conn_id, 11..18 salt, 19 filler (left zero)
+	binary.LittleEndian.PutUint16(h[20:], capLow) // capability_flags_low
+	h[22] = charset
+	// bytes 23..24 status
+	binary.LittleEndian.PutUint16(h[25:], capHigh) // capability_flags_high
+	return h
+}
+
+func Test_extractUsername_ReadsNullTerminatedNameAfterHeader(t *testing.T) {
+	resp := append(make([]byte, 32), []byte("alice\x00trailing-junk")...)
+	assert.Equal(t, "alice", extractUsername(resp))
+}
+
+func Test_extractUsername_ShortPacketYieldsEmpty(t *testing.T) {
+	assert.Equal(t, "", extractUsername(make([]byte, 10)))
+}
+
+func Test_removeCapability_ClearsSSLBitAndPreservesOthers(t *testing.T) {
+	hs := testHandshake(uint16(clientSSL|clientProtocol41), 0x00f0, 0x21)
+
+	out := removeCapability(hs, clientSSL)
+
+	capLow := binary.LittleEndian.Uint16(out[20:])
+	assert.Zero(t, capLow&uint16(clientSSL), "SSL bit cleared")
+	assert.NotZero(t, capLow&uint16(clientProtocol41), "PROTOCOL41 bit preserved")
+	assert.Equal(t, uint16(0x00f0), binary.LittleEndian.Uint16(out[25:]), "high word untouched (SSL is low-only)")
+}
+
+func Test_charsetFromHandshake_ReadsCharsetByte(t *testing.T) {
+	assert.Equal(t, byte(0x21), charsetFromHandshake(testHandshake(0, 0, 0x21)))
+}
+
+func Test_charsetFromHandshake_ShortPacketDefaultsToUtf8(t *testing.T) {
+	assert.Equal(t, byte(0x21), charsetFromHandshake([]byte{0x0a, 0x00}))
+}
+
+func Test_buildSSLRequest_SetsSSLCapabilityAndCharset(t *testing.T) {
+	req := buildSSLRequest(0x21)
+
+	require.Len(t, req, 32)
+	assert.NotZero(t, binary.LittleEndian.Uint32(req[0:4])&clientSSL, "CLIENT_SSL advertised")
+	assert.Equal(t, byte(0x21), req[8], "charset follows the 8-byte caps+maxpacket prefix")
+}
+
+func Test_buildNativeHandshakeResponse_CarriesUsernameNativePluginAndNoSSL(t *testing.T) {
+	resp := buildNativeHandshakeResponse("alice", 0x21)
+
+	assert.Zero(t, binary.LittleEndian.Uint32(resp[0:4])&clientSSL, "client stays cleartext (no SSL)")
+	assert.True(t, bytes.Contains(resp, []byte("alice\x00")), "username present and terminated")
+	assert.True(t, bytes.HasSuffix(resp, []byte(nativePlugin+"\x00")), "declares native_password plugin")
+}
+
+func Test_buildOIDCAuthResponse_SmallToken(t *testing.T) {
+	out := buildOIDCAuthResponse([]byte("ey.abc"))
+
+	require.Equal(t, byte(0x01), out[0], "required OIDC capability flag")
+	assert.Equal(t, byte(6), out[1], "length-encoded length for a <251-byte token")
+	assert.Equal(t, "ey.abc", string(out[2:]))
+}
+
+func Test_buildOIDCAuthResponse_RealisticTokenUsesTwoByteLength(t *testing.T) {
+	jwt := bytes.Repeat([]byte("a"), 300) // real JWTs exceed the 1-byte length limit
+
+	out := buildOIDCAuthResponse(jwt)
+
+	require.Equal(t, byte(0x01), out[0])
+	require.Equal(t, byte(0xfc), out[1], "0xfc marks a 2-byte length")
+	assert.Equal(t, uint16(300), binary.LittleEndian.Uint16(out[2:4]))
+	assert.True(t, bytes.Equal(out[4:], jwt))
+}
+
+func Test_appendLenEncInt_EncodesByLengthClass(t *testing.T) {
+	assert.Equal(t, []byte{10}, appendLenEncInt(nil, 10))
+	assert.Equal(t, []byte{0xfc, 0x2c, 0x01}, appendLenEncInt(nil, 300))
+	assert.Equal(t, []byte{0xfd, 0x70, 0x11, 0x01}, appendLenEncInt(nil, 70000))
+}
+
+func Test_authSwitchPacket_RequestsClearPassword(t *testing.T) {
+	assert.Equal(t, append([]byte{0xfe}, append([]byte(clearPlugin), 0)...), authSwitchPacket())
+}
+
+func Test_errPacket_EncodesCodeStateAndMessage(t *testing.T) {
+	out := errPacket(1045, "28000", "nope")
+
+	assert.Equal(t, byte(0xff), out[0])
+	assert.Equal(t, uint16(1045), binary.LittleEndian.Uint16(out[1:3]))
+	assert.Equal(t, byte('#'), out[3])
+	assert.Equal(t, "28000nope", string(out[4:]))
+}

--- a/backend/mysql-proxy.Dockerfile
+++ b/backend/mysql-proxy.Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.25 AS builder
+ARG CGO_ENABLED=0
+WORKDIR /app
+
+COPY .. .
+RUN go mod download && go mod tidy
+RUN CGO_ENABLED=0 GOOS=linux go build -o bin/main ./cmd/mysql-proxy/
+
+# alpine (not scratch) so the image ships curl for the Fargate in-container health check
+# (CMD-SHELL curl http://localhost:9998/status). ca-certificates covers a TLS fallback to
+# system roots when STARROCKS_SSL_CA is unset.
+FROM alpine:latest
+RUN apk add --no-cache ca-certificates curl
+COPY --from=builder /app/bin/main /main
+# Unprivileged: the proxy binds 9031 (cleartext client, loopback/sidecar only — never expose
+# beyond the pod/task) and 9998 (HTTP health probe), both > 1024, so no root needed. A mounted
+# STARROCKS_SSL_CA must be readable by this user.
+USER nobody
+EXPOSE 9031 9998
+ENTRYPOINT ["/main"]

--- a/backend/mysql-proxy.Dockerfile
+++ b/backend/mysql-proxy.Dockerfile
@@ -7,8 +7,9 @@ RUN go mod download && go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -o bin/main ./cmd/mysql-proxy/
 
 # alpine (not scratch) so the image ships curl for the Fargate in-container health check
-# (CMD-SHELL curl http://localhost:9998/status). ca-certificates covers a TLS fallback to
-# system roots when STARROCKS_SSL_CA is unset.
+# (CMD-SHELL curl http://localhost:9998/status). NOTE: unset STARROCKS_SSL_CA means the proxy
+# SKIPS certificate verification entirely (dev only) — system roots are never consulted, so
+# always set STARROCKS_SSL_CA in QA/prod.
 FROM alpine:latest
 RUN apk add --no-cache ca-certificates curl
 COPY --from=builder /app/bin/main /main


### PR DESCRIPTION
# feat: SJRA-1468 add mysql-proxy for JWT auth to StarRocks

## 📌 Context

Ranger enforces per-user PII masking / row-filter / tenant access at the StarRocks layer, but only when a query runs as the authenticated user. Direct clients (Jupyter, BI, Python ≥9.2) speak StarRocks' `authentication_openid_connect_client` (JWT) plugin natively. But **Go's `go-sql-driver/mysql` implements a fixed set of auth plugins with no extension point**, so GORM (the API/worker) can't log in as a JWT user without forking the driver.

This adds a small TCP proxy that bridges the gap during the login handshake:
Go client ──cleartext (mysql_clear_password: JWT as the "password")──▶ proxy
proxy     ──TLS + authentication_openid_connect_client (JWT as auth data)──▶ StarRocks

After login it's a transparent byte pipe. This is the enabler for running the API's own queries
as the end user (wired in a follow-up) so masking needs no reimplementation in the app.

## 📝 Changes

- **`backend/cmd/mysql-proxy/`** — the proxy: MySQL packet framing, the login-handshake translation (strip `CLIENT_SSL` from the client so it stays cleartext; do TLS + the OIDC auth-switch toward StarRocks), and a transparent pipe. Ported from the POC (`docs/adr/ranger-poc/proxy/`) and hardened: verify StarRocks' cert against `STARROCKS_SSL_CA` (skip-verify fallback for dev), structured `slog`, auth-phase deadlines, graceful shutdown on
  SIGINT/SIGTERM, and an HTTP health probe (`GET /status`).
- **`backend/mysql-proxy.Dockerfile`** — `alpine` runtime (ships `curl` for the Fargate in-container health check), runs as `nobody`, mirrors `api.Dockerfile`'s build.
- **`.github/workflows/build_and_push.yml`** — builds/pushes `radiant-mysql-proxy` (metadata + build-push + provenance attestation) alongside the api/worker images.
- **`backend/.gitignore`** — ignore the root `mysql-proxy` build artifact (anchored so it doesn't ignore the `cmd/mysql-proxy/` source).

## ☑️ TO-DOs

- [ ] Deploy as a **sidecar** in the two QA envs (QLIN/CHOP) — loopback-only, with `STARROCKS_SSL_CA` set to verify StarRocks' cert.
- [ ] Wire the API read path to open per-user proxy connections (separate PR).

## 🧪 Tests

- **Unit** — `proxy_test.go` covers the fiddly byte-math helpers: username extraction, capability stripping, charset parsing, SSL/handshake/OIDC packet builders (incl. the length-encoded path real JWTs hit), auth-switch and error packets.
- **Validated end-to-end against the QLIN Starrocks** — a `go-sql-driver` client (and the API) authenticating through the proxy with a real Keycloak JWT: a member user sees PII masked (`***` / year-only DOB), a geneticist sees it clear; the proxy logs `authenticated, piping`.
- `go build ./...`, `go test ./cmd/mysql-proxy`, `make fmt`, `go vet` all clean.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1468](https://d3b.atlassian.net/browse/SJRA-1468)<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Security — cleartext JWT on the client↔proxy hop.** The proxy asks the Go client for `mysql_clear_password`, so the JWT is cleartext to the proxy. It must run **co-located with the API** (same pod/task) and its port **must never be exposed** beyond loopback. Documented in the package doc + README.
- **Why hand-rolled protocol code?** `go-sql-driver` has no pluggable auth (would require a driver fork — more maintenance than this ~370-LOC proxy); StarRocks JWT users have no documented cleartext-direct path. The proxy only parses the *login* handshake (stable); after auth it's a dumb pipe. The tricky byte offsets are commented and unit-tested.
- **Backend TLS**: verified against `STARROCKS_SSL_CA` when set; unset falls back to skip-verify with a WARN (dev only — QA/prod should set it). The expected server name is the host from `STARROCKS_ADDR`.
- **Additive / low-risk to merge**: nothing consumes the proxy yet — the API only uses it where `STARROCKS_PROXY_ADDR` is set, which no shipped path does. Deploying the sidecar and flipping that env is a separate, reversible step.

[SJRA-1468]: https://d3b.atlassian.net/browse/SJRA-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ