### PR TITLE
feat: SJRA-1468 - review and local tests

### DIFF
--- a/backend/cmd/mysql-proxy/main.go
+++ b/backend/cmd/mysql-proxy/main.go
@@ -26,11 +26,18 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 )
 
-const authTimeout = 15 * time.Second
+const (
+	authTimeout = 15 * time.Second
+	// drainTimeout bounds how long shutdown waits for in-flight connections. Piped sessions
+	// are long-lived, so this is a grace period for short queries, not a guarantee — after it
+	// elapses remaining connections die with the process.
+	drainTimeout = 10 * time.Second
+)
 
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
@@ -65,17 +72,38 @@ func main() {
 		_ = ln.Close()
 	}()
 
+	var handlers sync.WaitGroup
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
 			if ctx.Err() != nil {
-				slog.Info("shutting down")
+				slog.Info("shutting down, draining connections", "timeout", drainTimeout)
+				waitWithTimeout(&handlers, drainTimeout)
 				return
 			}
 			slog.Error("accept error", "error", err)
 			continue
 		}
-		go p.handle(conn)
+		handlers.Add(1)
+		go func() {
+			defer handlers.Done()
+			p.handle(conn)
+		}()
+	}
+}
+
+// waitWithTimeout waits for wg up to d, then gives up (long-lived piped sessions would
+// otherwise block shutdown forever).
+func waitWithTimeout(wg *sync.WaitGroup, d time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		slog.Warn("drain timeout reached, exiting with active connections")
 	}
 }
 

--- a/backend/cmd/mysql-proxy/proxy.go
+++ b/backend/cmd/mysql-proxy/proxy.go
@@ -180,7 +180,11 @@ func readLenEncInt(b []byte) (n, consumed int) {
 	case b[0] == 0xfd && len(b) >= 4:
 		return int(uint32(b[1]) | uint32(b[2])<<8 | uint32(b[3])<<16), 4
 	case b[0] == 0xfe && len(b) >= 9:
-		return int(binary.LittleEndian.Uint64(b[1:9])), 9
+		v := binary.LittleEndian.Uint64(b[1:9])
+		if v > maxPacket { // longer than any legal MySQL packet payload — malformed
+			return 0, 0
+		}
+		return int(v), 9
 	}
 	return 0, 0
 }

--- a/backend/cmd/mysql-proxy/proxy.go
+++ b/backend/cmd/mysql-proxy/proxy.go
@@ -33,16 +33,20 @@ import (
 // MySQL capability flags — a bitfield where each bit advertises one feature. We only need
 // to set/clear a handful.
 const (
-	clientSSL        uint32 = 0x00000800 // connection will upgrade to TLS
-	clientProtocol41 uint32 = 0x00000200 // 4.1+ protocol (always on for us)
-	clientSecureConn uint32 = 0x00008000 // secure-auth handshake layout
-	clientPluginAuth uint32 = 0x00080000 // pluggable authentication
+	clientConnectWithDB    uint32 = 0x00000008 // handshake response carries a default database
+	clientSSL              uint32 = 0x00000800 // connection will upgrade to TLS
+	clientProtocol41       uint32 = 0x00000200 // 4.1+ protocol (always on for us)
+	clientSecureConn       uint32 = 0x00008000 // secure-auth handshake layout
+	clientPluginAuth       uint32 = 0x00080000 // pluggable authentication
+	clientConnectAttrs     uint32 = 0x00100000 // handshake response carries key/value attributes
+	clientPluginAuthLenEnc uint32 = 0x00200000 // auth response is length-encoded (vs 1-byte length)
 )
 
 const (
 	maxPacket    = 16 * 1024 * 1024        // max packet size we advertise (standard)
 	nativePlugin = "mysql_native_password" // classic password plugin
 	clearPlugin  = "mysql_clear_password"  // send-password-in-clear (what we ask the Go client for)
+	oidcPlugin   = "authentication_openid_connect_client"
 )
 
 // HandshakeV10 fixed-field byte sizes, in wire order after the NUL-terminated server_version
@@ -98,18 +102,87 @@ func (p *packetConn) write(seq byte, payload []byte) error {
 // Pure protocol helpers (unit-tested in proxy_test.go).
 // ---------------------------------------------------------------------------
 
-// extractUsername reads the null-terminated username from a client HandshakeResponse41.
-// That packet starts with a fixed 32-byte header (capabilities 4 + max_packet 4 +
-// charset 1 + 23 reserved zero bytes); the username follows immediately after.
-func extractUsername(handshakeResponse []byte) string {
-	if len(handshakeResponse) < 33 {
-		return ""
+// clientHello is what we keep from the client's HandshakeResponse41: its capability flags and
+// charset (mirrored toward StarRocks so both hops agree on the post-auth wire format), the
+// username, and the default database when the DSN carries one (CLIENT_CONNECT_WITH_DB).
+type clientHello struct {
+	caps     uint32
+	charset  byte
+	username string
+	database string
+}
+
+// parseClientHello decodes a HandshakeResponse41: a fixed 32-byte header (capabilities 4 +
+// max_packet 4 + charset 1 + 23 reserved zero bytes), then the NUL-terminated username, then
+// the auth response (whose length prefix depends on the capability bits), then the database
+// (NUL-terminated) if CLIENT_CONNECT_WITH_DB is set.
+func parseClientHello(resp []byte) (clientHello, error) {
+	var h clientHello
+	if len(resp) < 33 {
+		return h, errors.New("handshake response too short")
 	}
-	rest := handshakeResponse[32:]
-	if end := bytes.IndexByte(rest, 0); end >= 0 {
-		return string(rest[:end])
+	h.caps = binary.LittleEndian.Uint32(resp[0:4])
+	h.charset = resp[8]
+
+	i := 32
+	end := bytes.IndexByte(resp[i:], 0)
+	if end < 0 {
+		return h, errors.New("unterminated username")
 	}
-	return string(rest)
+	h.username = string(resp[i : i+end])
+	i += end + 1
+
+	// Skip the auth response — we replace it anyway; we only parse past it to reach the database.
+	switch {
+	case h.caps&clientPluginAuthLenEnc != 0:
+		n, consumed := readLenEncInt(resp[i:])
+		if consumed == 0 {
+			return h, errors.New("malformed auth-response length")
+		}
+		i += consumed + n
+	case h.caps&clientSecureConn != 0:
+		if i >= len(resp) {
+			return h, errors.New("missing auth-response length")
+		}
+		i += 1 + int(resp[i])
+	default:
+		nul := bytes.IndexByte(resp[i:], 0)
+		if nul < 0 {
+			return h, errors.New("unterminated auth response")
+		}
+		i += nul + 1
+	}
+	if i > len(resp) {
+		return h, errors.New("auth response overruns packet")
+	}
+
+	if h.caps&clientConnectWithDB != 0 && i < len(resp) {
+		if nul := bytes.IndexByte(resp[i:], 0); nul >= 0 {
+			h.database = string(resp[i : i+nul])
+		} else {
+			h.database = string(resp[i:])
+		}
+	}
+	return h, nil
+}
+
+// readLenEncInt decodes a MySQL length-encoded integer, returning the value and the number of
+// bytes consumed (consumed == 0 means malformed/truncated).
+func readLenEncInt(b []byte) (n, consumed int) {
+	if len(b) == 0 {
+		return 0, 0
+	}
+	switch {
+	case b[0] < 0xfb:
+		return int(b[0]), 1
+	case b[0] == 0xfc && len(b) >= 3:
+		return int(binary.LittleEndian.Uint16(b[1:3])), 3
+	case b[0] == 0xfd && len(b) >= 4:
+		return int(uint32(b[1]) | uint32(b[2])<<8 | uint32(b[3])<<16), 4
+	case b[0] == 0xfe && len(b) >= 9:
+		return int(binary.LittleEndian.Uint64(b[1:9])), 9
+	}
+	return 0, 0
 }
 
 // serverVersionEnd returns the index just past the NUL that terminates the server-version
@@ -160,13 +233,43 @@ func charsetFromHandshake(handshake []byte) byte {
 	return 0x21
 }
 
+// serverCapabilities reassembles the split low/high capability words of a HandshakeV10 packet
+// (same layout removeCapability walks). Returns 0 on a truncated packet.
+func serverCapabilities(handshake []byte) uint32 {
+	low := serverVersionEnd(handshake) + hsConnIDLen + hsSaltLen + hsFillerLen
+	if low+hsCapLowLen > len(handshake) {
+		return 0
+	}
+	caps := uint32(binary.LittleEndian.Uint16(handshake[low:]))
+	high := low + hsCapLowLen + hsCharsetLen + hsStatusLen
+	if high+hsCapHighLen <= len(handshake) {
+		caps |= uint32(binary.LittleEndian.Uint16(handshake[high:])) << 16
+	}
+	return caps
+}
+
+// backendCaps derives the capability flags the proxy presents to StarRocks from what the
+// client negotiated with us. After login the pipe is a dumb byte copier, so a capability
+// active on one hop but not the other (COMPRESS, DEPRECATE_EOF, MULTI_STATEMENTS, ...)
+// corrupts the framing — mirroring the client's flags keeps both hops in agreement. We strip:
+// CLIENT_SSL (the proxy does its own TLS), lenenc-auth (our auth data is empty, 1-byte
+// length), and connect-attrs (we don't forward the client's attributes).
+func backendCaps(clientCaps uint32, database string) uint32 {
+	caps := clientCaps &^ (clientSSL | clientPluginAuthLenEnc | clientConnectAttrs)
+	caps |= clientProtocol41 | clientSecureConn | clientPluginAuth
+	if database == "" {
+		caps &^= clientConnectWithDB
+	}
+	return caps
+}
+
 // buildSSLRequest is the short packet we send to StarRocks to say "upgrade this connection
-// to TLS." It carries only capability flags (with CLIENT_SSL set) + max_packet + charset +
-// 23 reserved zero bytes; right after sending it we start the TLS handshake.
-func buildSSLRequest(charset byte) []byte {
-	caps := clientSSL | clientProtocol41 | clientSecureConn | clientPluginAuth
+// to TLS." It carries only capability flags (caps must be the same set later sent in the
+// handshake response, plus CLIENT_SSL) + max_packet + charset + 23 reserved zero bytes; right
+// after sending it we start the TLS handshake.
+func buildSSLRequest(caps uint32, charset byte) []byte {
 	b := make([]byte, 0, 32)
-	b = binary.LittleEndian.AppendUint32(b, caps)
+	b = binary.LittleEndian.AppendUint32(b, caps|clientSSL)
 	b = binary.LittleEndian.AppendUint32(b, maxPacket)
 	b = append(b, charset)
 	return append(b, make([]byte, 23)...)
@@ -175,10 +278,10 @@ func buildSSLRequest(charset byte) []byte {
 // buildNativeHandshakeResponse is the login packet we send to StarRocks: it claims
 // mysql_native_password with EMPTY auth data. This is deliberate — StarRocks looks the user
 // up, sees it's a JWT user, and answers with an AuthSwitchRequest to the OIDC plugin, which
-// is the hook we use to hand over the JWT.
-func buildNativeHandshakeResponse(username string, charset byte) []byte {
-	caps := clientProtocol41 | clientSecureConn | clientPluginAuth
-	b := make([]byte, 0, 64+len(username))
+// is the hook we use to hand over the JWT. caps/charset/database mirror the client's own
+// handshake response (see backendCaps) so the DSN's default database survives the proxy.
+func buildNativeHandshakeResponse(caps uint32, charset byte, username, database string) []byte {
+	b := make([]byte, 0, 64+len(username)+len(database))
 	b = binary.LittleEndian.AppendUint32(b, caps)
 	b = binary.LittleEndian.AppendUint32(b, maxPacket)
 	b = append(b, charset)
@@ -186,6 +289,10 @@ func buildNativeHandshakeResponse(username string, charset byte) []byte {
 	b = append(b, username...)
 	b = append(b, 0) // username terminator
 	b = append(b, 0) // empty auth data (length 0)
+	if caps&clientConnectWithDB != 0 {
+		b = append(b, database...)
+		b = append(b, 0) // database terminator
+	}
 	b = append(b, nativePlugin...)
 	return append(b, 0) // plugin-name terminator
 }
@@ -220,6 +327,16 @@ func authSwitchPacket() []byte {
 	b := []byte{0xfe}
 	b = append(b, clearPlugin...)
 	return append(b, 0)
+}
+
+// authSwitchPluginName extracts the plugin name from an AuthSwitchRequest
+// (0xfe + NUL-terminated name + plugin data).
+func authSwitchPluginName(pkt []byte) string {
+	rest := pkt[1:]
+	if nul := bytes.IndexByte(rest, 0); nul >= 0 {
+		return string(rest[:nul])
+	}
+	return string(rest)
 }
 
 // errPacket builds an ERR packet (0xff = error): code + '#' + SQLSTATE + message.
@@ -267,16 +384,65 @@ func (p *proxy) handle(clientConn net.Conn) {
 	backend := &packetConn{conn: backendTCP}
 	client := &packetConn{conn: clientConn}
 
-	// 1. Read StarRocks' opening handshake.
+	// 1. Read StarRocks' opening handshake; it must offer TLS or the OIDC hop can't happen.
 	_, hs, err := backend.read()
 	if err != nil {
 		log.Error("read backend handshake failed", "error", err)
 		return
 	}
-	charset := charsetFromHandshake(hs)
+	if serverCapabilities(hs)&clientSSL == 0 {
+		log.Error("backend does not advertise CLIENT_SSL — enable TLS on the StarRocks FE")
+		return
+	}
 
-	// 2. Tell StarRocks we want TLS, then upgrade the proxy→backend socket.
-	if err := backend.write(1, buildSSLRequest(charset)); err != nil {
+	// 2. Forward the handshake to the Go client, but with CLIENT_SSL stripped so it stays
+	//    cleartext and hands us the raw JWT. Copy first — removeCapability mutates in place.
+	if err := client.write(0, removeCapability(append([]byte(nil), hs...), clientSSL)); err != nil {
+		log.Error("send handshake to client failed", "error", err)
+		return
+	}
+
+	// 3. Read the client's response: its capabilities, charset, username and — when the DSN
+	//    carries one — the default database, all mirrored toward StarRocks below.
+	_, clientResp, err := client.read()
+	if err != nil {
+		log.Error("read client response failed", "error", err)
+		return
+	}
+	hello, err := parseClientHello(clientResp)
+	if err != nil {
+		log.Warn("malformed client handshake response", "error", err)
+		_ = client.write(2, errPacket(1045, "28000", "malformed handshake response"))
+		return
+	}
+
+	// 4. Ask the client to switch to cleartext so it resends the "password" (the JWT) raw.
+	if err := client.write(2, authSwitchPacket()); err != nil {
+		log.Error("auth switch to client failed", "error", err)
+		return
+	}
+
+	// 5. Read the JWT (a cleartext-plugin payload is the password + a trailing NUL).
+	_, jwtPayload, err := client.read()
+	if err != nil {
+		log.Error("read JWT failed", "error", err)
+		return
+	}
+	jwt := strings.TrimRight(string(jwtPayload), "\x00")
+	if !strings.HasPrefix(jwt, "ey") { // every JWT starts with base64url({"alg"... → "ey"
+		log.Warn("client did not send a JWT", "user", hello.username)
+		_ = client.write(4, errPacket(1045, "28000", "expected JWT as password"))
+		return
+	}
+
+	// 6. Tell StarRocks we want TLS (mirroring the client's capabilities so both hops agree on
+	//    the post-auth wire format), then upgrade the proxy→backend socket.
+	caps := backendCaps(hello.caps, hello.database)
+	charset := hello.charset
+	if charset == 0 {
+		charset = charsetFromHandshake(hs)
+	}
+	if err := backend.write(1, buildSSLRequest(caps, charset)); err != nil {
 		log.Error("send SSL request failed", "error", err)
 		return
 	}
@@ -287,42 +453,8 @@ func (p *proxy) handle(clientConn net.Conn) {
 	}
 	backend.conn = tlsConn
 
-	// 3. Forward the handshake to the Go client, but with CLIENT_SSL stripped so it stays
-	//    cleartext and hands us the raw JWT. Copy first — removeCapability mutates in place.
-	if err := client.write(0, removeCapability(append([]byte(nil), hs...), clientSSL)); err != nil {
-		log.Error("send handshake to client failed", "error", err)
-		return
-	}
-
-	// 4. Read the client's first response — we only need the username from it.
-	_, clientResp, err := client.read()
-	if err != nil {
-		log.Error("read client response failed", "error", err)
-		return
-	}
-	username := extractUsername(clientResp)
-
-	// 5. Ask the client to switch to cleartext so it resends the "password" (the JWT) raw.
-	if err := client.write(2, authSwitchPacket()); err != nil {
-		log.Error("auth switch to client failed", "error", err)
-		return
-	}
-
-	// 6. Read the JWT (a cleartext-plugin payload is the password + a trailing NUL).
-	_, jwtPayload, err := client.read()
-	if err != nil {
-		log.Error("read JWT failed", "error", err)
-		return
-	}
-	jwt := strings.TrimRight(string(jwtPayload), "\x00")
-	if !strings.HasPrefix(jwt, "ey") { // every JWT starts with base64url({"alg"... → "ey"
-		log.Warn("client did not send a JWT", "user", username)
-		_ = client.write(4, errPacket(1045, "28000", "expected JWT as password"))
-		return
-	}
-
 	// 7. Log in to StarRocks with native_password + empty auth; it will ask us to switch.
-	if err := backend.write(2, buildNativeHandshakeResponse(username, charset)); err != nil {
+	if err := backend.write(2, buildNativeHandshakeResponse(caps, charset, hello.username, hello.database)); err != nil {
 		log.Error("send auth to backend failed", "error", err)
 		return
 	}
@@ -334,6 +466,13 @@ func (p *proxy) handle(clientConn net.Conn) {
 
 	// 8. On the AuthSwitchRequest (0xfe), send the JWT in OIDC format and read the verdict.
 	if len(authResult) > 0 && authResult[0] == 0xfe {
+		if plugin := authSwitchPluginName(authResult); plugin != oidcPlugin {
+			// Non-JWT user (or misconfigured FE): our OIDC-formatted reply would only produce a
+			// confusing backend error, so fail fast with a clear one.
+			log.Error("backend requested unsupported auth plugin", "plugin", plugin, "user", hello.username)
+			_ = client.write(4, errPacket(1045, "28000", "backend requested unsupported auth plugin: "+plugin))
+			return
+		}
 		if err := backend.write(seq+1, buildOIDCAuthResponse([]byte(jwt))); err != nil {
 			log.Error("send OIDC auth response failed", "error", err)
 			return
@@ -354,16 +493,16 @@ func (p *proxy) handle(clientConn net.Conn) {
 		if len(authResult) >= 3 { // ERR = 0xff + 2-byte code; guard a truncated packet
 			code = uint16(authResult[1]) | uint16(authResult[2])<<8
 		}
-		log.Warn("backend auth failed", "user", username, "code", code)
+		log.Warn("backend auth failed", "user", hello.username, "code", code)
 		return
 	}
-	log.Info("authenticated, piping", "user", username)
+	log.Info("authenticated, piping", "user", hello.username)
 
 	// 10. Login done. Clear the deadline (sessions are long-lived) and become a dumb tube.
 	_ = clientConn.SetDeadline(time.Time{})
 	_ = backend.conn.SetDeadline(time.Time{})
 	pipe(clientConn, backend.conn)
-	log.Info("connection closed", "user", username)
+	log.Info("connection closed", "user", hello.username)
 }
 
 // recoverConn swallows a panic from a connection handler so one bad connection can't crash the

--- a/backend/cmd/mysql-proxy/proxy_test.go
+++ b/backend/cmd/mysql-proxy/proxy_test.go
@@ -24,13 +24,87 @@ func testHandshake(capLow, capHigh uint16, charset byte) []byte {
 	return h
 }
 
-func Test_extractUsername_ReadsNullTerminatedNameAfterHeader(t *testing.T) {
-	resp := append(make([]byte, 32), []byte("alice\x00trailing-junk")...)
-	assert.Equal(t, "alice", extractUsername(resp))
+// testClientHello builds a HandshakeResponse41 payload: caps + max_packet + charset + 23
+// reserved bytes, username NUL, 1-byte-length auth response, then optional database NUL.
+func testClientHello(caps uint32, charset byte, username string, auth []byte, database string) []byte {
+	b := binary.LittleEndian.AppendUint32(nil, caps)
+	b = binary.LittleEndian.AppendUint32(b, maxPacket)
+	b = append(b, charset)
+	b = append(b, make([]byte, 23)...)
+	b = append(b, username...)
+	b = append(b, 0)
+	b = append(b, byte(len(auth)))
+	b = append(b, auth...)
+	if caps&clientConnectWithDB != 0 {
+		b = append(b, database...)
+		b = append(b, 0)
+	}
+	return b
 }
 
-func Test_extractUsername_ShortPacketYieldsEmpty(t *testing.T) {
-	assert.Equal(t, "", extractUsername(make([]byte, 10)))
+func Test_parseClientHello_ReadsCapsCharsetAndUsername(t *testing.T) {
+	resp := testClientHello(clientProtocol41|clientSecureConn, 0x2d, "alice", []byte{1, 2, 3}, "")
+
+	h, err := parseClientHello(resp)
+
+	require.NoError(t, err)
+	assert.Equal(t, clientProtocol41|clientSecureConn, h.caps)
+	assert.Equal(t, byte(0x2d), h.charset)
+	assert.Equal(t, "alice", h.username)
+	assert.Empty(t, h.database)
+}
+
+func Test_parseClientHello_ReadsDatabaseWhenConnectWithDB(t *testing.T) {
+	resp := testClientHello(clientSecureConn|clientConnectWithDB, 0x21, "alice", nil, "radiant")
+
+	h, err := parseClientHello(resp)
+
+	require.NoError(t, err)
+	assert.Equal(t, "radiant", h.database)
+}
+
+func Test_parseClientHello_SkipsLenEncAuthResponse(t *testing.T) {
+	// go-sql-driver switches to a length-encoded auth response for long auth data.
+	caps := clientSecureConn | clientPluginAuthLenEnc | clientConnectWithDB
+	b := binary.LittleEndian.AppendUint32(nil, caps)
+	b = binary.LittleEndian.AppendUint32(b, maxPacket)
+	b = append(b, 0x21)
+	b = append(b, make([]byte, 23)...)
+	b = append(b, "alice"...)
+	b = append(b, 0)
+	b = appendLenEncInt(b, 300)
+	b = append(b, bytes.Repeat([]byte{0xaa}, 300)...)
+	b = append(b, "radiant\x00"...)
+
+	h, err := parseClientHello(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, "alice", h.username)
+	assert.Equal(t, "radiant", h.database)
+}
+
+func Test_parseClientHello_ShortPacketErrors(t *testing.T) {
+	_, err := parseClientHello(make([]byte, 10))
+	assert.Error(t, err)
+}
+
+func Test_parseClientHello_TruncatedAuthResponseErrors(t *testing.T) {
+	resp := testClientHello(clientSecureConn, 0x21, "alice", nil, "")
+	resp[len(resp)-1] = 200 // auth-response length points past the packet end
+
+	_, err := parseClientHello(resp)
+
+	assert.Error(t, err)
+}
+
+func Test_readLenEncInt_DecodesEachLengthClass(t *testing.T) {
+	for _, want := range []int{10, 300, 70000} {
+		got, consumed := readLenEncInt(appendLenEncInt(nil, want))
+		assert.Equal(t, want, got)
+		assert.NotZero(t, consumed)
+	}
+	_, consumed := readLenEncInt([]byte{0xfc}) // truncated 2-byte length
+	assert.Zero(t, consumed)
 }
 
 func Test_removeCapability_ClearsSSLBitAndPreservesOthers(t *testing.T) {
@@ -53,7 +127,7 @@ func Test_charsetFromHandshake_ShortPacketDefaultsToUtf8(t *testing.T) {
 }
 
 func Test_buildSSLRequest_SetsSSLCapabilityAndCharset(t *testing.T) {
-	req := buildSSLRequest(0x21)
+	req := buildSSLRequest(clientProtocol41|clientSecureConn|clientPluginAuth, 0x21)
 
 	require.Len(t, req, 32)
 	assert.NotZero(t, binary.LittleEndian.Uint32(req[0:4])&clientSSL, "CLIENT_SSL advertised")
@@ -61,11 +135,58 @@ func Test_buildSSLRequest_SetsSSLCapabilityAndCharset(t *testing.T) {
 }
 
 func Test_buildNativeHandshakeResponse_CarriesUsernameNativePluginAndNoSSL(t *testing.T) {
-	resp := buildNativeHandshakeResponse("alice", 0x21)
+	caps := backendCaps(clientProtocol41, "")
+
+	resp := buildNativeHandshakeResponse(caps, 0x21, "alice", "")
 
 	assert.Zero(t, binary.LittleEndian.Uint32(resp[0:4])&clientSSL, "client stays cleartext (no SSL)")
 	assert.True(t, bytes.Contains(resp, []byte("alice\x00")), "username present and terminated")
 	assert.True(t, bytes.HasSuffix(resp, []byte(nativePlugin+"\x00")), "declares native_password plugin")
+}
+
+func Test_buildNativeHandshakeResponse_ForwardsDatabase(t *testing.T) {
+	caps := backendCaps(clientProtocol41|clientConnectWithDB, "radiant")
+
+	resp := buildNativeHandshakeResponse(caps, 0x21, "alice", "radiant")
+
+	assert.NotZero(t, binary.LittleEndian.Uint32(resp[0:4])&clientConnectWithDB)
+	assert.True(t, bytes.Contains(resp, []byte("alice\x00\x00radiant\x00")),
+		"database follows the empty auth response, before the plugin name")
+}
+
+func Test_backendCaps_MirrorsClientAndStripsProxyHandledBits(t *testing.T) {
+	clientAsked := clientProtocol41 | clientSSL | clientPluginAuthLenEnc | clientConnectAttrs |
+		clientConnectWithDB | 0x00010000 // arbitrary extra bit (e.g. MULTI_STATEMENTS) must survive
+
+	caps := backendCaps(clientAsked, "radiant")
+
+	assert.Zero(t, caps&(clientSSL|clientPluginAuthLenEnc|clientConnectAttrs), "proxy-handled bits stripped")
+	assert.NotZero(t, caps&0x00010000, "client's other capability bits forwarded")
+	assert.NotZero(t, caps&clientConnectWithDB, "CONNECT_WITH_DB kept when a database is present")
+	assert.NotZero(t, caps&(clientProtocol41|clientSecureConn|clientPluginAuth), "proxy minimum always set")
+}
+
+func Test_backendCaps_DropsConnectWithDBWhenNoDatabase(t *testing.T) {
+	assert.Zero(t, backendCaps(clientConnectWithDB, "")&clientConnectWithDB)
+}
+
+func Test_serverCapabilities_ReassemblesLowAndHighWords(t *testing.T) {
+	hs := testHandshake(uint16(clientSSL|clientProtocol41), uint16(clientPluginAuth>>16), 0x21)
+
+	caps := serverCapabilities(hs)
+
+	assert.NotZero(t, caps&clientSSL)
+	assert.NotZero(t, caps&clientProtocol41)
+	assert.NotZero(t, caps&clientPluginAuth, "high word reassembled into bits 16-31")
+}
+
+func Test_serverCapabilities_TruncatedPacketYieldsZero(t *testing.T) {
+	assert.Zero(t, serverCapabilities([]byte{0x0a, 0x00}))
+}
+
+func Test_authSwitchPluginName_ExtractsNulTerminatedName(t *testing.T) {
+	pkt := append([]byte{0xfe}, oidcPlugin+"\x00plugin-data"...)
+	assert.Equal(t, oidcPlugin, authSwitchPluginName(pkt))
 }
 
 func Test_buildOIDCAuthResponse_SmallToken(t *testing.T) {

--- a/backend/cmd/mysql-proxy/proxy_test.go
+++ b/backend/cmd/mysql-proxy/proxy_test.go
@@ -107,6 +107,14 @@ func Test_readLenEncInt_DecodesEachLengthClass(t *testing.T) {
 	assert.Zero(t, consumed)
 }
 
+func Test_readLenEncInt_RejectsOversizedEightByteLength(t *testing.T) {
+	oversized := binary.LittleEndian.AppendUint64([]byte{0xfe}, uint64(maxPacket)+1)
+
+	_, consumed := readLenEncInt(oversized)
+
+	assert.Zero(t, consumed, "length beyond max packet size is malformed, not a valid int")
+}
+
 func Test_removeCapability_ClearsSSLBitAndPreservesOthers(t *testing.T) {
 	hs := testHandshake(uint16(clientSSL|clientProtocol41), 0x00f0, 0x21)
 

--- a/backend/mysql-proxy.Dockerfile
+++ b/backend/mysql-proxy.Dockerfile
@@ -7,8 +7,9 @@ RUN go mod download && go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -o bin/main ./cmd/mysql-proxy/
 
 # alpine (not scratch) so the image ships curl for the Fargate in-container health check
-# (CMD-SHELL curl http://localhost:9998/status). ca-certificates covers a TLS fallback to
-# system roots when STARROCKS_SSL_CA is unset.
+# (CMD-SHELL curl http://localhost:9998/status). NOTE: unset STARROCKS_SSL_CA means the proxy
+# SKIPS certificate verification entirely (dev only) — system roots are never consulted, so
+# always set STARROCKS_SSL_CA in QA/prod.
 FROM alpine:latest
 RUN apk add --no-cache ca-certificates curl
 COPY --from=builder /app/bin/main /main


### PR DESCRIPTION
# Revue + correctifs (testés localement)

  **Correctifs appliqués :**
  - `proxy.go` : le HandshakeResponse du client n'est plus jeté — les capability flags, le charset et la base par défaut (`CLIENT_CONNECT_WITH_DB`, cas d'un DSN GORM avec `/dbname`) sont maintenant relayés vers
  StarRocks. Avant : session sans base par défaut (échec silencieux des requêtes non qualifiées) et risque de désynchronisation du pipe post-auth (COMPRESS, MULTI_STATEMENTS, DEPRECATE_EOF) pour les clients
  non-Go.
  - `proxy.go` : handshake réordonné (dialogue client avant le SSLRequest backend) pour que les deux hops portent les mêmes flags.
  - `proxy.go` : deux gardes ajoutées — erreur claire si StarRocks n'annonce pas `CLIENT_SSL` (TLS désactivé sur le FE), et vérification du nom du plugin dans l'AuthSwitchRequest (utilisateur non-JWT → erreur
  explicite au lieu d'un échec opaque).
  - `main.go` : arrêt gracieux réel — drain des connexions en cours avec timeout de 10 s sur SIGTERM.
  - `mysql-proxy.Dockerfile` : commentaire corrigé — `STARROCKS_SSL_CA` non défini = vérification du certificat désactivée (les roots système ne sont jamais utilisés) ; à définir en QA/prod.
  - Tests unitaires mis à jour et étendus (24 tests verts) : parsing complet du HandshakeResponse, forwarding des caps/base, helpers.

  **Validation E2E locale** (stack compose : StarRocks TLS + Ranger + Keycloak) :
  - Proxy lancé en mode vérification CA (pas skip-verify).
  - Matrice de masquage conforme via le proxy (mysql CLI, JWT en mot de passe cleartext) : alice masquée sur ORG_A2, bob tout masqué, wendy tout en clair — identique à une connexion OIDC native.
  - Client Go (`go-sql-driver`) avec `/tenant_a` dans le DSN : `SELECT DATABASE()` retourne `tenant_a` et les requêtes non qualifiées fonctionnent (cassé avant le correctif).
  - Chemin d'erreur : mot de passe non-JWT → `ERROR 1045` propre, proxy stable.

  **À noter (hors scope PR)** : `cmd/createuser` laisse l'action `UPDATE_PASSWORD` sur les utilisateurs Keycloak (ROPC échoue après le seed) et `starrocks-connect.sh` passe le handle au lieu de l'email — à
  corriger séparément.