### PR TITLE
feat: SJRA-1695 Add Saved Filters Cypress tests for CNV and SNV somatic

### DIFF
--- a/cypress/e2e/CaseEntity/Variants/Germline/CNV/SavedFilters/Manager.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/Germline/CNV/SavedFilters/Manager.cy.ts
@@ -1,0 +1,51 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { CaseEntity_Variants_SavedFilters } from 'pom/pages/CaseEntity_Variants_SavedFilters';
+import { ManagerFilterModal } from 'pom/pages/ManagerFilterModal';
+
+describe('Case Entity - Variants - Germline - CNV - Saved filters - Manager', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV');
+    CaseEntity_Variants_SavedFilters.cnv.actions.selectFilterInDropdown('Cypress_All_Variants'); // Clean Query Builder
+    CaseEntity_Variants_SavedFilters.cnv.actions.clickNewFilterButton(); // Clean Query Builder
+  };
+
+  it('Rename', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_F1 COPY');
+    CaseEntity_Variants_SavedFilters.cnv.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.cnv.actions.openManager();
+    ManagerFilterModal.actions.editFilterName('Cypress_F1', 'Cypress_FA');
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayInDropdown(/^Cypress_F1$/, false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayInDropdown('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.cnv.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F1', false /*shouldExist*/);
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_FA');
+    ManagerFilterModal.actions.closeManager();
+  });
+
+  it('Delete', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_F2');
+    CaseEntity_Variants_SavedFilters.cnv.actions.createFilter('Cypress_F2');
+    CaseEntity_Variants_SavedFilters.cnv.actions.openManager();
+    ManagerFilterModal.actions.deleteFilter('Cypress_F2');
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayFilterName('Cypress_F2', false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayInDropdown('Cypress_F2', false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.cnv.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F2', false /*shouldExist*/);
+    ManagerFilterModal.actions.closeManager();
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('plus', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('duplicate', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('delete', true /*isDisable*/, false /*isDirty*/);
+  });
+});

--- a/cypress/e2e/CaseEntity/Variants/Germline/CNV/SavedFilters/QueryBuilder.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/Germline/CNV/SavedFilters/QueryBuilder.cy.ts
@@ -1,0 +1,111 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { CaseEntity_Variants_SavedFilters } from 'pom/pages/CaseEntity_Variants_SavedFilters';
+import { ManagerFilterModal } from 'pom/pages/ManagerFilterModal';
+
+describe('Case Entity - Variants - Germline - CNV - Saved filters - Query builder', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitCaseVariantsPage(data.case.case, data.case.seq.seq_id, 'CNV');
+    CaseEntity_Variants_SavedFilters.cnv.actions.selectFilterInDropdown('Cypress_All_Variants'); // Apply a filter for a cleaner query builder
+    CaseEntity_Variants_SavedFilters.cnv.actions.clickNewFilterButton(); // Clean Query Builder
+  };
+
+  it('Create', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_F0');
+    CaseEntity_Variants_SavedFilters.cnv.actions.createFilter('Cypress_F0');
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayFilterName('Cypress_F0');
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldBeSelectedInDropdown('Cypress_F0');
+    CaseEntity_Variants_SavedFilters.cnv.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F0');
+    ManagerFilterModal.actions.closeManager();
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('plus', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('duplicate', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('delete', false /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Rename', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_F1 COPY');
+    CaseEntity_Variants_SavedFilters.cnv.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.cnv.actions.selectFilterInDropdown(/^Cypress_F1$/);
+    CaseEntity_Variants_SavedFilters.cnv.actions.createFilter('Cypress_FA');
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayFilterName('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayInDropdown(/^Cypress_F1$/, false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldBeSelectedInDropdown('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.cnv.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F1', false /*shouldExist*/);
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_FA');
+    ManagerFilterModal.actions.closeManager();
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('plus', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('duplicate', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('delete', false /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Select from dropdown', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_F1 COPY');
+    CaseEntity_Variants_SavedFilters.cnv.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.cnv.actions.selectFilterInDropdown('Cypress_F1');
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayFilterName('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldBeSelectedInDropdown('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('plus', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('duplicate', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('delete', false /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Duplicate', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_F1 COPY');
+    CaseEntity_Variants_SavedFilters.cnv.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.cnv.actions.selectFilterInDropdown('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.cnv.actions.clickDuplicateButton();
+    CaseEntity_Variants_SavedFilters.cnv.actions.clickSaveButton();
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayFilterName(/^Cypress_F1 COPY$/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayInDropdown('Cypress_F1 COPY', true /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.cnv.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F1 COPY', true /*shouldExist*/);
+    ManagerFilterModal.actions.closeManager();
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('plus', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('duplicate', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('delete', false /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Delete', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_F2');
+    CaseEntity_Variants_SavedFilters.cnv.actions.createFilter('Cypress_F2');
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_F2');
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayFilterName(/(Filtre sans titre|Untitled filter)/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldDisplayInDropdown('Cypress_F2', false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.cnv.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F2', false /*shouldExist*/);
+    ManagerFilterModal.actions.closeManager();
+
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('plus', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('duplicate', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('delete', true /*isDisable*/, false /*isDirty*/);
+  });
+});

--- a/cypress/e2e/CaseEntity/Variants/Somatic/SNV/SavedFilters/Manager.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/Somatic/SNV/SavedFilters/Manager.cy.ts
@@ -1,0 +1,51 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { CaseEntity_Variants_SavedFilters } from 'pom/pages/CaseEntity_Variants_SavedFilters';
+import { ManagerFilterModal } from 'pom/pages/ManagerFilterModal';
+
+describe('Case Entity - Variants - Somatic - SNV - Saved filters - Manager', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitCaseVariantsPage(data.caseSomatic.case, data.caseSomatic.seq.seq_id, 'SNV');
+    CaseEntity_Variants_SavedFilters.somatic.actions.selectFilterInDropdown('Cypress_All_Variants'); // Clean Query Builder
+    CaseEntity_Variants_SavedFilters.somatic.actions.clickNewFilterButton(); // Clean Query Builder
+  };
+
+  it('Rename', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_F1 COPY');
+    CaseEntity_Variants_SavedFilters.somatic.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.somatic.actions.openManager();
+    ManagerFilterModal.actions.editFilterName('Cypress_F1', 'Cypress_FA');
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayInDropdown(/^Cypress_F1$/, false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayInDropdown('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.somatic.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F1', false /*shouldExist*/);
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_FA');
+    ManagerFilterModal.actions.closeManager();
+  });
+
+  it('Delete', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_F2');
+    CaseEntity_Variants_SavedFilters.somatic.actions.createFilter('Cypress_F2');
+    CaseEntity_Variants_SavedFilters.somatic.actions.openManager();
+    ManagerFilterModal.actions.deleteFilter('Cypress_F2');
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayFilterName('Cypress_F2', false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayInDropdown('Cypress_F2', false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.somatic.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F2', false /*shouldExist*/);
+    ManagerFilterModal.actions.closeManager();
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('plus', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('duplicate', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('delete', true /*isDisable*/, false /*isDirty*/);
+  });
+});

--- a/cypress/e2e/CaseEntity/Variants/Somatic/SNV/SavedFilters/QueryBuilder.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/Somatic/SNV/SavedFilters/QueryBuilder.cy.ts
@@ -1,0 +1,111 @@
+/// <reference types="cypress"/>
+import 'support/commands';
+import { data } from 'pom/shared/Data';
+import { CaseEntity_Variants_SavedFilters } from 'pom/pages/CaseEntity_Variants_SavedFilters';
+import { ManagerFilterModal } from 'pom/pages/ManagerFilterModal';
+
+describe('Case Entity - Variants - Somatic - SNV - Saved filters - Query builder', () => {
+  const setupTest = () => {
+    cy.login();
+    cy.visitCaseVariantsPage(data.caseSomatic.case, data.caseSomatic.seq.seq_id, 'SNV');
+    CaseEntity_Variants_SavedFilters.somatic.actions.selectFilterInDropdown('Cypress_All_Variants'); // Apply a filter for a cleaner query builder
+    CaseEntity_Variants_SavedFilters.somatic.actions.clickNewFilterButton(); // Clean Query Builder
+  };
+
+  it('Create', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_F0');
+    CaseEntity_Variants_SavedFilters.somatic.actions.createFilter('Cypress_F0');
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayFilterName('Cypress_F0');
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldBeSelectedInDropdown('Cypress_F0');
+    CaseEntity_Variants_SavedFilters.somatic.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F0');
+    ManagerFilterModal.actions.closeManager();
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('plus', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('duplicate', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('delete', false /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Rename', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_F1 COPY');
+    CaseEntity_Variants_SavedFilters.somatic.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.somatic.actions.selectFilterInDropdown(/^Cypress_F1$/);
+    CaseEntity_Variants_SavedFilters.somatic.actions.createFilter('Cypress_FA');
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayFilterName('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayInDropdown(/^Cypress_F1$/, false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldBeSelectedInDropdown('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.somatic.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F1', false /*shouldExist*/);
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_FA');
+    ManagerFilterModal.actions.closeManager();
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('plus', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('duplicate', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('delete', false /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Select from dropdown', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_F1 COPY');
+    CaseEntity_Variants_SavedFilters.somatic.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.somatic.actions.selectFilterInDropdown('Cypress_F1');
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayFilterName('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldBeSelectedInDropdown('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('plus', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('duplicate', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('delete', false /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Duplicate', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_FA');
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_F1 COPY');
+    CaseEntity_Variants_SavedFilters.somatic.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.somatic.actions.selectFilterInDropdown('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.somatic.actions.clickDuplicateButton();
+    CaseEntity_Variants_SavedFilters.somatic.actions.clickSaveButton();
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayFilterName(/^Cypress_F1 COPY$/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayInDropdown('Cypress_F1 COPY', true /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.somatic.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F1 COPY', true /*shouldExist*/);
+    ManagerFilterModal.actions.closeManager();
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('plus', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('duplicate', false /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('delete', false /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Delete', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_F2');
+    CaseEntity_Variants_SavedFilters.somatic.actions.createFilter('Cypress_F2');
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_F2');
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayFilterName(/(Filtre sans titre|Untitled filter)/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldDisplayInDropdown('Cypress_F2', false /*shouldExist*/);
+    CaseEntity_Variants_SavedFilters.somatic.actions.openManager();
+
+    ManagerFilterModal.validations.shouldDisplayInManager('Cypress_F2', false /*shouldExist*/);
+    ManagerFilterModal.actions.closeManager();
+
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('plus', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('duplicate', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('delete', true /*isDisable*/, false /*isDirty*/);
+  });
+});

--- a/cypress/pom/pages/CaseEntity_Variants_SavedFilters.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SavedFilters.ts
@@ -175,4 +175,5 @@ const generateSavedFiltersFunctions = () => {
 export const CaseEntity_Variants_SavedFilters = {
   snv: generateSavedFiltersFunctions(),
   cnv: generateSavedFiltersFunctions(),
+  somatic: generateSavedFiltersFunctions(),
 };


### PR DESCRIPTION
# feat: SJRA-1695 Add Saved Filters Cypress tests for CNV and SNV somatic

## 📌 Context

La fonctionnalité de filtres sauvegardés (Saved Filters) de la page Case Entity - Variants était déjà couverte par des tests Cypress, mais pas pour le **CNV germinal** ni pour le **SNV somatique**. Ce PR étend la couverture E2E à ces deux contextes afin de valider le comportement complet du gestionnaire de filtres et du query builder.

## 📝 Changes

- Ajout du contexte `somatic` au factory `CaseEntity_Variants_SavedFilters`, qui réutilise les fonctions existantes (actions/validations) déjà partagées par `snv` et `cnv`.
- Nouveaux tests Cypress pour le **CNV germinal** :
  - `Manager.cy.ts` : renommage et suppression d'un filtre via le gestionnaire.
  - `QueryBuilder.cy.ts` : création, renommage, sélection dans le dropdown, duplication et suppression d'un filtre.
- Nouveaux tests Cypress pour le **SNV somatique** :
  - `Manager.cy.ts` : renommage et suppression d'un filtre via le gestionnaire.
  - `QueryBuilder.cy.ts` : création, renommage, sélection dans le dropdown, duplication et suppression d'un filtre.
- Chaque cas valide aussi les états (activé/désactivé, dirty) des boutons `plus`, `save`, `duplicate` et `delete`.

## 🧪 Tests

- 4 nouveaux specs Cypress (2 pour CNV germinal, 2 pour SNV somatique), soit 12 nouveaux cas de test au total.
- Les tests s'appuient sur les jeux de données `data.case` (germinal) et `data.caseSomatic` (somatique), ainsi que sur les POM existants `CaseEntity_Variants_SavedFilters` et `ManagerFilterModal`.
- Exécution locale : les specs impactés passent avec succès.

Pour exécuter les nouveaux tests :

```bash
npx cypress run --spec "cypress/e2e/CaseEntity/Variants/Germline/CNV/SavedFilters/*.cy.ts,cypress/e2e/CaseEntity/Variants/Somatic/SNV/SavedFilters/*.cy.ts"
```

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1695](https://d3b.atlassian.net/browse/SJRA-1695)<!-- End JIRA Issues -->

[SJRA-1695]: https://d3b.atlassian.net/browse/SJRA-1695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ