### PR TITLE
feat: SJRA-1701 Add discard and update Query Builder Cypress tests

### DIFF
--- a/cypress/e2e/CaseEntity/Variants/Germline/CNV/SavedFilters/QueryBuilder.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/Germline/CNV/SavedFilters/QueryBuilder.cy.ts
@@ -108,4 +108,34 @@ describe('Case Entity - Variants - Germline - CNV - Saved filters - Query builde
     CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('duplicate', true /*isDisable*/, false /*isDirty*/);
     CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('delete', true /*isDisable*/, false /*isDirty*/);
   });
+
+  it('Modify and update', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.cnv.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('discard', true /*isDisable*/, false /*isDirty*/);
+
+    CaseEntity_Variants_SavedFilters.cnv.actions.modifyFilter();
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', false /*isDisable*/, true /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('discard', false /*isDisable*/, false /*isDirty*/);
+
+    CaseEntity_Variants_SavedFilters.cnv.actions.updateFilter();
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('discard', true /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Modify and discard', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.cnv.actions.deleteFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.cnv.actions.createFilter('Cypress_F1');
+
+    CaseEntity_Variants_SavedFilters.cnv.actions.modifyFilter();
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', false /*isDisable*/, true /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('discard', false /*isDisable*/, false /*isDirty*/);
+
+    CaseEntity_Variants_SavedFilters.cnv.actions.clickDiscardButton();
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.cnv.validations.shouldIconHaveExpectedStates('discard', true /*isDisable*/, false /*isDirty*/);
+  });
 });

--- a/cypress/e2e/CaseEntity/Variants/Germline/SNV/SavedFilters/QueryBuilder.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/Germline/SNV/SavedFilters/QueryBuilder.cy.ts
@@ -107,4 +107,34 @@ describe('Case Entity - Variants - Germline - SNV - Saved filters - Query builde
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('duplicate', true /*isDisable*/, false /*isDirty*/);
     CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('delete', true /*isDisable*/, false /*isDirty*/);
   });
+
+  it('Modify and update', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.snv.actions.deleteFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.snv.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('discard', true /*isDisable*/, false /*isDirty*/);
+
+    CaseEntity_Variants_SavedFilters.snv.actions.modifyFilter();
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('save', false /*isDisable*/, true /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('discard', false /*isDisable*/, false /*isDirty*/);
+
+    CaseEntity_Variants_SavedFilters.snv.actions.updateFilter();
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('discard', true /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Modify and discard', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.snv.actions.deleteFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.snv.actions.createFilter('Cypress_F1');
+
+    CaseEntity_Variants_SavedFilters.snv.actions.modifyFilter();
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('save', false /*isDisable*/, true /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('discard', false /*isDisable*/, false /*isDirty*/);
+
+    CaseEntity_Variants_SavedFilters.snv.actions.clickDiscardButton();
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.snv.validations.shouldIconHaveExpectedStates('discard', true /*isDisable*/, false /*isDirty*/);
+  });
 });

--- a/cypress/e2e/CaseEntity/Variants/Somatic/SNV/SavedFilters/QueryBuilder.cy.ts
+++ b/cypress/e2e/CaseEntity/Variants/Somatic/SNV/SavedFilters/QueryBuilder.cy.ts
@@ -108,4 +108,34 @@ describe('Case Entity - Variants - Somatic - SNV - Saved filters - Query builder
     CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('duplicate', true /*isDisable*/, false /*isDirty*/);
     CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('delete', true /*isDisable*/, false /*isDirty*/);
   });
+
+  it('Modify and update', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.somatic.actions.createFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('discard', true /*isDisable*/, false /*isDirty*/);
+
+    CaseEntity_Variants_SavedFilters.somatic.actions.modifyFilter();
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', false /*isDisable*/, true /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('discard', false /*isDisable*/, false /*isDirty*/);
+
+    CaseEntity_Variants_SavedFilters.somatic.actions.updateFilter();
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('discard', true /*isDisable*/, false /*isDirty*/);
+  });
+
+  it('Modify and discard', () => {
+    setupTest();
+    CaseEntity_Variants_SavedFilters.somatic.actions.deleteFilter('Cypress_F1');
+    CaseEntity_Variants_SavedFilters.somatic.actions.createFilter('Cypress_F1');
+
+    CaseEntity_Variants_SavedFilters.somatic.actions.modifyFilter();
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', false /*isDisable*/, true /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('discard', false /*isDisable*/, false /*isDirty*/);
+
+    CaseEntity_Variants_SavedFilters.somatic.actions.clickDiscardButton();
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('save', true /*isDisable*/, false /*isDirty*/);
+    CaseEntity_Variants_SavedFilters.somatic.validations.shouldIconHaveExpectedStates('discard', true /*isDisable*/, false /*isDirty*/);
+  });
 });

--- a/cypress/pom/pages/CaseEntity_Variants_SavedFilters.ts
+++ b/cypress/pom/pages/CaseEntity_Variants_SavedFilters.ts
@@ -3,13 +3,22 @@ import { CommonSelectors } from 'pom/shared/Selectors';
 import { CommonTexts } from 'pom/shared/Texts';
 import { CaseEntity_Variants_Facets } from './CaseEntity_Variants_Facets';
 
-const generateSavedFiltersFunctions = () => {
+const generateSavedFiltersFunctions = (
+  facetsActions: typeof CaseEntity_Variants_Facets.snv.actions,
+  numericalFacet: { section: string; field: string },
+) => {
   const actions = {
     /**
      * Clicks the delete filter button.
      */
     clickDeleteButton() {
       cy.get(`${CommonSelectors.querybuilderHeader} ${CommonSelectors.deleteIcon}`).clickAndWait({ force: true });
+    },
+    /**
+     * Clicks the discard filter button.
+     */
+    clickDiscardButton() {
+      cy.get(`${CommonSelectors.querybuilderHeader} ${CommonSelectors.discardIcon}`).clickAndWait({ force: true });
     },
     /**
      * Clicks the duplicate filter button.
@@ -48,7 +57,7 @@ const generateSavedFiltersFunctions = () => {
     createFilter(name: string) {
       actions.deleteFilter(name);
 
-      CaseEntity_Variants_Facets.snv.actions.clickSidebarSection('Variant'); // Also works for CNV
+      facetsActions.clickSidebarSection('Variant');
       cy.get(CommonSelectors.facetHeader('chromosome')).clickAndWait({ force: true });
       cy.get(CommonSelectors.facetCheckbox('chromosome', '1')).click({ force: true });
       cy.get(CommonSelectors.facetApplyButton('chromosome')).click({ force: true });
@@ -103,6 +112,12 @@ const generateSavedFiltersFunctions = () => {
       cy.wait('@postSavedFilters');
     },
     /**
+     * Modifies the current filter by applying a numerical facet.
+     */
+    modifyFilter() {
+      facetsActions.applyNumericalFacetFilter(numericalFacet.section, numericalFacet.field);
+    },
+    /**
      * Opens the manager filter modal.
      */
     openManager() {
@@ -123,6 +138,14 @@ const generateSavedFiltersFunctions = () => {
     selectFilterInDropdown(name: string | RegExp) {
       actions.openMyFiltersDropdown();
       cy.get(CommonSelectors.savedListDropdown).contains(name).clickAndWait({ force: true });
+    },
+    /**
+     * Updates the selected filter by saving its unsaved changes.
+     */
+    updateFilter() {
+      cy.intercept('**/saved_filters{,/**}').as('putSavedFilters');
+      actions.clickSaveButton();
+      cy.wait('@putSavedFilters');
     },
   };
 
@@ -173,7 +196,7 @@ const generateSavedFiltersFunctions = () => {
 };
 
 export const CaseEntity_Variants_SavedFilters = {
-  snv: generateSavedFiltersFunctions(),
-  cnv: generateSavedFiltersFunctions(),
-  somatic: generateSavedFiltersFunctions(),
+  snv: generateSavedFiltersFunctions(CaseEntity_Variants_Facets.snv.actions, { section: 'Variant', field: 'position' }),
+  cnv: generateSavedFiltersFunctions(CaseEntity_Variants_Facets.cnv.actions, { section: 'Variant', field: 'start' }),
+  somatic: generateSavedFiltersFunctions(CaseEntity_Variants_Facets.somatic.actions, { section: 'Variant', field: 'position' }),
 };

--- a/cypress/pom/shared/Selectors.ts
+++ b/cypress/pom/shared/Selectors.ts
@@ -16,6 +16,7 @@ export const CommonSelectors = {
   deleteIcon: '[class*="lucide-trash"]',
   detailsButton: '[data-cy="details-button"]',
   dirtyClass: 'text-yellow-500',
+  discardIcon: '[class*="lucide-rotate-ccw"]',
   duplicateIcon: '[class*="lucide-copy"]',
   editIcon: '[class*="lucide-pen"]',
   editLineIcon: '[class*="lucide-pencil-line"]',


### PR DESCRIPTION
# feat: SJRA-1701 Add discard and update Query Builder Cypress tests

## 📌 Context

Les tests Cypress du Query Builder (filtres sauvegardés) couvraient la création, la duplication et la suppression, mais pas les scénarios de **modification** d'un filtre existant. Ce PR ajoute la couverture des actions **update** (sauvegarde des changements) et **discard** (annulation des changements) pour les trois contextes de variants : Germline SNV, Germline CNV et Somatic SNV.

## 📝 Changes

- Ajout de deux tests par contexte (SNV germinal, CNV germinal, SNV somatique) :
  - **Modify and update** : crée un filtre, le modifie, le sauvegarde, puis vérifie que les icônes `save`/`discard` reviennent à l'état non modifié (désactivées, non « dirty »).
  - **Modify and discard** : crée un filtre, le modifie, annule via le bouton discard, puis vérifie le retour à l'état initial.
- POM `CaseEntity_Variants_SavedFilters` :
  - `generateSavedFiltersFunctions` prend désormais en paramètre les `actions` de facettes du contexte et une facette numérique (`section`/`field`). Cela supprime le couplage codé en dur à `snv` et permet d'adapter le comportement par contexte (CNV utilise `start`, SNV/Somatic utilisent `position`).
  - Nouvelles actions : `clickDiscardButton`, `modifyFilter` (applique une facette numérique) et `updateFilter` (sauvegarde via l'intercept `putSavedFilters`).
- `Selectors.ts` : ajout du sélecteur `discardIcon` (`lucide-rotate-ccw`).

## 🧪 Tests

- Nouveaux cas E2E Cypress ajoutés dans :
  - `cypress/e2e/CaseEntity/Variants/Germline/SNV/SavedFilters/QueryBuilder.cy.ts`
  - `cypress/e2e/CaseEntity/Variants/Germline/CNV/SavedFilters/QueryBuilder.cy.ts`
  - `cypress/e2e/CaseEntity/Variants/Somatic/SNV/SavedFilters/QueryBuilder.cy.ts`
- Exécutés localement avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1701](https://d3b.atlassian.net/browse/SJRA-1701)<!-- End JIRA Issues -->

[SJRA-1701]: https://d3b.atlassian.net/browse/SJRA-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ